### PR TITLE
Compatible with the inaccurate timeout of the UDPSocket::recv_from

### DIFF
--- a/agent/src/debug/mod.rs
+++ b/agent/src/debug/mod.rs
@@ -18,7 +18,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 pub const QUEUE_LEN: usize = 1024;
 pub const BEACON_INTERVAL: Duration = Duration::from_secs(60);
 pub const BEACON_PORT: u16 = 20035;
-pub const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
+pub const DEBUG_QUEUE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 pub const METAFLOW_AGENT_BEACON: &str = "metaflow-agent";
 pub const MAX_BUF_SIZE: usize = 9000;
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
     let version = concat!(env!("REV_COUNT"), "-", env!("REVISION"));
     if opts.version {
         println!("{} {}", version, env!("COMMIT_DATE"));
-        println!("metaflow-server community edition");
+        println!("metaflow-agent community edition");
         println!(env!("RUSTC_VERSION"));
         return Ok(());
     }


### PR DESCRIPTION
**Phenomenon and reproduction steps**

Print timeout log every 30s like below

```
WARN [src/debug/debugger.rs:155] receive udp packet error: Resource temporarily unavailable
```

**Root cause and solution**

remove 30s timeout

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)