### PR TITLE
[eBPF] Remove duplicate data caused by MSG_PEEK

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -216,6 +216,7 @@ struct syscall_comm_enter_ctx {
 		};
 	};
 	size_t count;		/*    32     8 */
+	unsigned int flags;
 };
 
 struct sched_comm_exit_ctx {

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1298,15 +1298,19 @@ TPPROG(sys_exit_sendto) (struct syscall_comm_exit_ctx *ctx) {
 	if (write_args != NULL) {
 		write_args->bytes_count = bytes_count;
 		process_syscall_data((struct pt_regs*)ctx, id, T_EGRESS, write_args, bytes_count);
+		active_write_args_map__delete(&id);
 	}
 
-	active_write_args_map__delete(&id);
 	return 0;
 }
 
 // ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
 //		  struct sockaddr *src_addr, socklen_t *addrlen);
 TPPROG(sys_enter_recvfrom) (struct syscall_comm_enter_ctx *ctx) {
+	// If flags contains MSG_PEEK, it is returned directly.
+	// ref : https://linux.die.net/man/2/recvfrom
+	if (ctx->flags & MSG_PEEK)
+		return 0;
 	__u64 id = bpf_get_current_pid_tgid();
 	int sockfd = (int)ctx->fd;
 	char *buf = (char *)ctx->buf;
@@ -1332,8 +1336,9 @@ TPPROG(sys_exit_recvfrom) (struct syscall_comm_exit_ctx *ctx) {
 	if (read_args != NULL) {
 		read_args->bytes_count = bytes_count;
 		process_syscall_data((struct pt_regs *)ctx, id, T_INGRESS, read_args, bytes_count);
+		active_read_args_map__delete(&id);
 	}
-	active_read_args_map__delete(&id);
+
 	return 0;
 }
 
@@ -1370,12 +1375,14 @@ TPPROG(sys_exit_sendmsg) (struct syscall_comm_exit_ctx *ctx) {
 	if (write_args != NULL) {
 		write_args->bytes_count = bytes_count;
 		process_syscall_data_vecs((struct pt_regs *)ctx, id, T_EGRESS, write_args, bytes_count);
+		active_write_args_map__delete(&id);
 	}
 
-	active_write_args_map__delete(&id);
 	return 0;
 }
 
+// int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+//              int flags);
 KPROG(__sys_sendmmsg)(struct pt_regs* ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int sockfd = (int)PT_REGS_PARM1(ctx);
@@ -1423,6 +1430,10 @@ TPPROG(sys_exit_sendmmsg) (struct syscall_comm_exit_ctx *ctx) {
 //		   bool forbid_cmsg_compat)
 // ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags);
 KPROG(__sys_recvmsg) (struct pt_regs* ctx) {
+	int flags = (int) PT_REGS_PARM3(ctx);
+	if (flags & MSG_PEEK)
+		return 0;
+
 	__u64 id = bpf_get_current_pid_tgid();
 	struct user_msghdr __msg, *msghdr = (struct user_msghdr *)PT_REGS_PARM2(ctx);
 	int sockfd = (int) PT_REGS_PARM1(ctx);
@@ -1453,15 +1464,19 @@ TPPROG(sys_exit_recvmsg) (struct syscall_comm_exit_ctx *ctx) {
 	if (read_args != NULL) {
 		read_args->bytes_count = bytes_count;
 		process_syscall_data_vecs((struct pt_regs *)ctx, id, T_INGRESS, read_args, bytes_count);
+		active_read_args_map__delete(&id);
 	}
 
-	active_read_args_map__delete(&id);
 	return 0;
 }
 
 // int __sys_recvmmsg(int fd, struct mmsghdr __user *mmsg, unsigned int vlen,
 //		   unsigned int flags, struct timespec *timeout)
 KPROG(__sys_recvmmsg) (struct pt_regs* ctx) {
+	int flags = (int) PT_REGS_PARM4(ctx);
+	if (flags & MSG_PEEK)
+		return 0;
+
 	__u64 id = bpf_get_current_pid_tgid();
 	int sockfd = (int)PT_REGS_PARM1(ctx);
 	struct mmsghdr *msgvec = (struct mmsghdr *)PT_REGS_PARM2(ctx);

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1024,7 +1024,9 @@ impl FlowMap {
             self.update_endpoint_and_policy_data(node, meta_packet);
         } else {
             // copy endpoint and policy data
-            meta_packet.policy_data.replace(node.policy_data_cache[meta_packet.lookup_key.direction as usize].clone());
+            meta_packet
+                .policy_data
+                .replace(node.policy_data_cache[meta_packet.lookup_key.direction as usize].clone());
             match meta_packet.lookup_key.direction {
                 PacketDirection::ClientToServer => {
                     meta_packet
@@ -1745,16 +1747,17 @@ impl FlowMap {
 
         // update policy data
         if meta_packet.policy_data.is_some() {
-            node.policy_data_cache[meta_packet.lookup_key.direction as usize] = Arc::new(PolicyData {
-                acl_id: meta_packet.policy_data.as_ref().unwrap().acl_id,
-                npb_actions: meta_packet
-                    .policy_data
-                    .as_ref()
-                    .unwrap()
-                    .npb_actions
-                    .clone(),
-                action_flags: meta_packet.policy_data.as_ref().unwrap().action_flags,
-            });
+            node.policy_data_cache[meta_packet.lookup_key.direction as usize] =
+                Arc::new(PolicyData {
+                    acl_id: meta_packet.policy_data.as_ref().unwrap().acl_id,
+                    npb_actions: meta_packet
+                        .policy_data
+                        .as_ref()
+                        .unwrap()
+                        .npb_actions
+                        .clone(),
+                    action_flags: meta_packet.policy_data.as_ref().unwrap().action_flags,
+                });
         }
         node.tagged_flow.tag.policy_data = node.policy_data_cache.clone();
     }


### PR DESCRIPTION
The recv() function usually takes a last argument of 0, which means fetch from the buffer, whereas MSG_PEEK means just look at the data, not fetch the data. As a result, the ebpf gets a lot of duplicate data.

We made a judgment at sys_enter_recvfrom/sys_recvmmsg/sys_recvmsg, not to collect data with MSG_PEEK.

### This PR is for:


- Agent



#### Affected branches
- main
- 6.1

#### Checklist
- [ ] Added unit test.
