### PR TITLE
[eBPF] Remove duplicate data caused by MSG_PEEK #20313

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -212,6 +212,7 @@ struct syscall_comm_enter_ctx {
 		};
 	};
 	size_t count;		/*    32     8 */
+	unsigned int flags;
 };
 
 struct sched_comm_exit_ctx {


### PR DESCRIPTION
The recv() function usually takes a last argument of 0, which means fetch from the buffer, whereas MSG_PEEK means just look at the data, not fetch the data. As a result, the ebpf gets a lot of duplicate data.

We made a judgment at sys_enter_recvfrom/sys_recvmmsg/sys_recvmsg, not to collect data with MSG_PEEK.


### This PR is for:

One or more of:
- Agent



#### Affected branches
- main
- v6.1

#### Checklist
- [ ] Added unit test.

