### PR TITLE
[server] fix flag.Bool redefined due to reference conflict

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -48,8 +48,9 @@ func execName() string {
 
 var log = logging.MustGetLogger(execName())
 
-var configPath = flag.String("f", "/etc/server.yaml", "Specify config file location")
-var version = flag.Bool("v", false, "Display the version")
+var flagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+var configPath = flagSet.String("f", "/etc/server.yaml", "Specify config file location")
+var version = flagSet.Bool("v", false, "Display the version")
 
 var Branch, RevCount, Revision, CommitDate, goVersion, CompileTime string
 
@@ -74,7 +75,7 @@ func loadConfig(path string) *Config {
 }
 
 func main() {
-	flag.Parse()
+	flagSet.Parse(os.Args[1:])
 	if *version {
 		fmt.Printf(
 			"%s\n%s\n%s\n%s\n%s\n%s\n",


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server 
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes flagParseError
#### Steps to reproduce the bug
- use image tag: deepflow-server:latest-7824

#### Changes to fix the bug
- add new flagSet when server initialize.

#### Affected branches
- main

#### Bug Description
- [This Commit](https://github.com/deepflowio/deepflow/commit/d43a074d734781da3418dc0ea207cecfbb1d13f0) add a new reference to [glog](https://github.com/golang/glog), which defines the same flag in https://github.com/golang/glog/blob/master/glog.go#L401, it causes panic :
```
panic: /bin/deepflow-server flag redefined: v
```

- So I add a new flagSet to parse flags, it do the same `Parse()` like `flag` package in golang 
- ref: flag.Parse() is implement in https://github.com/golang/go/blob/master/src/flag/flag.go#L1139
