### PR TITLE
[eBPF] remove -mcpu=probe

### DIFF
--- a/agent/src/ebpf/kernel/Makefile
+++ b/agent/src/ebpf/kernel/Makefile
@@ -40,7 +40,7 @@ ifeq ($(LINUX_VER_KYLIN),1)
 	EXTRA_EBPF_CLAGS = -DLINUX_VER_KYLIN
 endif
 
-FINAL_TARGET = -emit-llvm -D__TARGET_ARCH_$(ARCH) -o ${@:.elf=.ll} -c $^ && $(LLC) -march=bpf -filetype=obj -mcpu=probe -o $@ ${@:.elf=.ll}
+FINAL_TARGET = -emit-llvm -D__TARGET_ARCH_$(ARCH) -o ${@:.elf=.ll} -c $^ && $(LLC) -march=bpf -filetype=obj -o $@ ${@:.elf=.ll}
 
 all: $(TAEGET_KERN_ELF)
 


### PR DESCRIPTION
### This PR is for:

- Agent

### remove -mcpu=probe

The eBPF binary generated by enabling mcpu=probe is related to the kernel of the system at compile time, and it will appear that the binary compiled by the high-version kernel cannot run on the low-version kernel, so remove this configuration

#### Checklist

- [ ] Added unit test.

#### Backport to branches

- <branch name here>

