### PR TITLE
[Agent] fix redis direction incorrect

### DIFF
--- a/agent/src/flow_generator/app_table.rs
+++ b/agent/src/flow_generator/app_table.rs
@@ -325,7 +325,14 @@ impl AppTable {
         remote_epc: i32,
     ) -> bool {
         let is_c2s = packet.direction == PacketDirection::ClientToServer;
-        let (ip, _, port) = Self::get_ip_epc_port(packet, is_c2s);
+
+        let (ip, port);
+        // redis can not determine dirction by RESP protocol when pakcet is from ebpf, special treatment
+        if protocol.get_l7_protocol() == L7Protocol::Redis {
+            (ip, port) = packet.get_redis_server_addr();
+        } else {
+            (ip, _, port) = Self::get_ip_epc_port(packet, is_c2s);
+        }
         // due to loopback may be in different protocol in container, add pid as key
         // FIXME: istio (or the similar proxy use DNAT on loopback addr and port to hijack traffic) will have different protocol in same port,
         // save the protocol to apptable use loopback addr and port will lead to get incorrect protocol in those envrioment


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes 20416 relieve redis direction incorrect
#### Steps to reproduce the bug
- send redis req/resp with long rrt
#### Changes to fix the bug
- add process name and default port check
#### Affected branches
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
