### PR TITLE
[eBPF] Fixed MySQL/Kafka incorrectly judging as HTTP2 #20374

### DIFF
--- a/agent/src/ebpf/kernel/Makefile
+++ b/agent/src/ebpf/kernel/Makefile
@@ -40,7 +40,7 @@ ifeq ($(LINUX_VER_KYLIN),1)
 	EXTRA_EBPF_CLAGS = -DLINUX_VER_KYLIN
 endif
 
-FINAL_TARGET = -emit-llvm -D__TARGET_ARCH_$(ARCH) -o ${@:.elf=.ll} -c $^ && $(LLC) -march=bpf -filetype=obj -mcpu=probe -o $@ ${@:.elf=.ll}
+FINAL_TARGET = -emit-llvm -D__TARGET_ARCH_$(ARCH) -o ${@:.elf=.ll} -c $^ && $(LLC) -march=bpf -filetype=obj -mcpu=v2 -o $@ ${@:.elf=.ll}
 
 all: $(TAEGET_KERN_ELF)
 

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1021,7 +1021,7 @@ data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 		conn_info->prev_count = 0;
 	}
 
-	if (conn_info->prev_count > 0) {
+	if (conn_info->prev_count == 4) {
 		// 注意这里没有调整v->syscall_len和v->len我们会在用户层做。
 		v->extra_data = *(__u32 *)conn_info->prev_buf;
 		v->extra_data_count = conn_info->prev_count;

--- a/agent/src/ebpf/test/Makefile
+++ b/agent/src/ebpf/test/Makefile
@@ -24,7 +24,7 @@ ARCH ?= $(shell uname -m)
 CC ?= gcc
 CFLAGS ?= -std=gnu99 --static -g -O2 -ffunction-sections -fdata-sections -fPIC -fno-omit-frame-pointer -Wall -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
 
-EXECS := test_symbol test_offset
+EXECS := test_symbol test_offset test_insns_cnt
 ifeq ($(ARCH), x86_64)
         LDLIBS += ../libtrace.a -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread
 else ifeq ($(ARCH), aarch64)

--- a/agent/src/ebpf/test/test_insns_cnt.c
+++ b/agent/src/ebpf/test/test_insns_cnt.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include "../user/common.h"
+#include "../user/log.h"
+#include "../user/elf.h"
+#include <bcc/linux/bpf.h>
+#include <bcc/linux/bpf_common.h>
+#include <bcc/libbpf.h>
+#include "../user/load.h"
+#include "../user/socket_trace_bpf_common.c"
+
+static int verify_obj__progs(struct ebpf_object *obj)
+{
+	int i;
+	int progs_cnt = obj->elf_info.prog_sec_cnt;
+	struct sec_desc *desc, *prog_descs = obj->elf_info.prog_secs;
+
+	Elf_Scn *scn_rel;	// SHT_REL type section
+	Elf_Scn *scn_syms;	// SHT_SYMTAB type section
+	Elf_Data *data_rel;	// SHT_REL type section data
+	GElf_Shdr shdr_rel;	// SHT_REL type section header
+	struct bpf_insn *insns;
+	GElf_Sym sym;
+	struct ebpf_prog *new_prog;
+
+	scn_syms = elf_getscn(obj->elf_info.elf, obj->elf_info.syms_sec->shndx);
+	if (scn_syms == NULL) {
+		ebpf_warning("elf_getscn() is failed.\n");
+		return -1;
+	}
+
+	for (i = 0; i < progs_cnt; i++) {
+		desc = &prog_descs[i];
+		insns = (struct bpf_insn *)desc->d_buf;	// SHT_PROGBITS & SHF_EXECINSTR data buffer
+		scn_rel = elf_getscn(obj->elf_info.elf, desc->shndx_rel);
+		if (gelf_getshdr(scn_rel, &shdr_rel) == NULL) {
+			ebpf_warning("gelf_getshdr() is failed.\n");
+			return -1;
+		}
+
+		data_rel = elf_getdata(scn_rel, 0);
+		if (data_rel == NULL) {
+			ebpf_warning("gelf_getshdr() is failed.\n");
+			return -1;
+		}
+
+		if (find_prog_func_sym
+		    (obj->elf_info.elf, scn_syms, desc->shndx,
+		     &sym) != ETR_OK) {
+			ebpf_warning
+			    ("Not find program function symbol, program shndx:%d\n",
+			     desc->shndx);
+			return -1;
+		}
+
+		char *sym_name = elf_strptr(obj->elf_info.elf,
+					    obj->elf_info.syms_sec->strtabidx,
+					    sym.st_name);
+
+		new_prog = NULL;
+		add_new_prog(obj->progs, obj->progs_cnt, new_prog);
+		if (new_prog == NULL) {
+			return -1;
+		}
+
+		new_prog->sec_name = strdup(desc->name);
+		if (new_prog->sec_name == NULL)
+			return -1;
+
+		new_prog->name = strdup(sym_name);
+		if (new_prog->name == NULL) {
+			ebpf_warning("strdup() failed.\n");
+			return -1;
+		}
+
+		new_prog->insns = insns;
+		new_prog->insns_cnt = desc->size / sizeof(struct bpf_insn);
+		new_prog->obj = obj;
+
+		printf
+		    ("sec_name %s\tfunc %s\tinsns_cnt %zd\t"
+		     "license %s\tkern_version %u\n",
+		     new_prog->sec_name, new_prog->name, new_prog->insns_cnt,
+		     obj->license, obj->kern_version);
+		if (new_prog->insns_cnt > 4096) {
+			printf("The number of instructions exceeded the 4096 limit\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int main(void)
+{
+	void *bpf_bin_buffer;
+	int buffer_sz;
+	bpf_bin_buffer = (void *)socket_trace_common_ebpf_data;
+	buffer_sz = sizeof(socket_trace_common_ebpf_data);
+
+	struct ebpf_object *obj;
+	obj = ebpf_open_buffer(bpf_bin_buffer, buffer_sz, "common-elf");
+
+	return verify_obj__progs(obj);
+}


### PR DESCRIPTION
Fixed MySQL/Kafka incorrectly judging as HTTP2

[[eBPF] Adjust the bpf compilation parameter '-mcpu'](https://github.com/deepflowio/deepflow/pull/2593/commits/25776948c506045d5b1de5690aaa2b752153ed3c) 

LLVM by default uses the BPF base instruction set for generating code in order to make sure that the generated object file can also be loaded with older kernels such as long-term stable kernels (e.g. 4.9+).

However, LLVM has a -mcpu selector for the BPF back end in order to select different versions of the BPF instruction set, namely instruction set extensions on top of the BPF base instruction set in order to generate more efficient and smaller code.

Available -mcpu options can be queried through:

```
$ llc -march bpf -mcpu=help
Available CPUs for this target:

  generic - Select the generic processor.
  probe   - Select the probe processor.
  v1      - Select the v1 processor.
  v2      - Select the v2 processor.
[...]
```

The generic processor is the default processor, which is also the base instruction set v1 of BPF. Options v1 and v2 are typically useful in an environment where the BPF program is being cross compiled and the target host where the program is loaded differs from the one where it is compiled (and thus available BPF kernel features might differ as well).

Here is the test comparison: (with probe `bpf_func_sys_enter_close`)

```
version        size
------------------------------
v1(generic)    4128
v2             4063
v3             4128
probe          4128
```

Because it is cross-compilation, the smallest instruction compiled by v2 is the best choice.

[[eBPF] Instruction overrun check](https://github.com/deepflowio/deepflow/pull/2593/commits/37c147c4dc6a26404cc8e778183cb2641f3c175e)
### This PR is for:


- Agent



#### Affected branches
- main
- v6.1

#### Checklist
- [ ] Added unit test.

