### PR TITLE
[eBPF] Convert 'data_submit' to tail call programe

### DIFF
--- a/agent/src/ebpf/kernel/config.h
+++ b/agent/src/ebpf/kernel/config.h
@@ -1,0 +1,1 @@
+../user/config.h

--- a/agent/src/ebpf/kernel/go_tls_bpf.c
+++ b/agent/src/ebpf/kernel/go_tls_bpf.c
@@ -124,7 +124,8 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 	active_write_args_map__update(&id, &write_args);
 	if (!process_data((struct pt_regs *)ctx, id, T_EGRESS, &write_args,
 			  bytes_count, &extra)) {
-		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map), 0);
+		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
+			      PROG_DATA_SUBMIT_KP_IDX);
 	}
 	active_write_args_map__delete(&id);
 	return 0;
@@ -239,7 +240,8 @@ int uprobe_go_tls_read_exit(struct pt_regs *ctx)
 	active_read_args_map__update(&id, &read_args);
 	if (!process_data((struct pt_regs *)ctx, id, T_INGRESS, &read_args,
 			  bytes_count, &extra)) {
-		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map), 0);
+		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
+			      PROG_DATA_SUBMIT_KP_IDX);
 	}
 	active_read_args_map__delete(&id);
 	return 0;

--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -196,7 +196,8 @@ _Pragma("GCC error \"PT_GO_REGS_PARM\"");
 
 #define NAME(N)  __##N
 
-#define PROG(F) SEC("prog/"__stringify(F)) int bpf_prog__##F
+#define PROGTP(F) SEC("prog/tp/"__stringify(F)) int bpf_prog_tp__##F
+#define PROGKP(F) SEC("prog/kp/"__stringify(F)) int bpf_prog_kp__##F
 #define KRETPROG(F) SEC("kretprobe/"__stringify(F)) int kretprobe__##F
 #define KPROG(F) SEC("kprobe/"__stringify(F)) int kprobe__##F
 #define TPPROG(F) SEC("tracepoint/syscalls/"__stringify(F)) int bpf_func_##F

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -149,6 +149,19 @@ struct process_data_extra {
 	enum message_type message_type;
 } __attribute__ ((packed));
 
+/*
+ * BPF Tail Calls context
+ */
+struct tail_calls_context {
+	int max_size_limit;             // The maximum size of the socket data that can be transferred.
+	enum traffic_direction dir;     // Data flow direction.
+	bool vecs;                      // Whether a memory vector is used ? (for specific syscall)
+	struct conn_info_t conn_info;
+	struct process_data_extra extra;
+	__u32 bytes_count;
+	struct member_fields_offset *offset;
+};
+
 enum syscall_src_func {
 	SYSCALL_FUNC_UNKNOWN,
 	SYSCALL_FUNC_WRITE,
@@ -164,15 +177,6 @@ enum syscall_src_func {
 	SYSCALL_FUNC_WRITEV,
 	SYSCALL_FUNC_READV,
 	SYSCALL_FUNC_SENDFILE
-};
-
-/*
- * BPF Tail Calls context
- */
-struct tail_calls_context {
-	int max_size_limit;             // The maximum size of the socket data that can be transferred.
-	enum traffic_direction dir;     // Data flow direction.
-	bool vecs;                      // Whether a memory vector is used ? (for specific syscall)
 };
 
 struct data_args_t {

--- a/agent/src/ebpf/kernel/openssl_bpf.c
+++ b/agent/src/ebpf/kernel/openssl_bpf.c
@@ -82,7 +82,8 @@ int uprobe_openssl_write_exit(struct pt_regs *ctx)
         active_write_args_map__update(&id, &write_args);
 	if (!process_data((struct pt_regs *)ctx, id, T_EGRESS, &write_args,
 			  size, &extra)) {
-		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map), 0);
+		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
+			      PROG_DATA_SUBMIT_KP_IDX);
 	}
 	active_write_args_map__delete(&id);
 	return 0;
@@ -136,7 +137,8 @@ int uprobe_openssl_read_exit(struct pt_regs *ctx)
         active_read_args_map__update(&id, &read_args);
 	if (!process_data((struct pt_regs *)ctx, id, T_INGRESS, &read_args,
 			  size, &extra)) {
-		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map), 0);
+		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
+			      PROG_DATA_SUBMIT_KP_IDX);
 	}
 	active_read_args_map__delete(&id);
 	return 0;

--- a/agent/src/ebpf/samples/rust/src/main.rs
+++ b/agent/src/ebpf/samples/rust/src/main.rs
@@ -276,10 +276,10 @@ fn main() {
             CString::new(".*".as_bytes()).unwrap().as_c_str().as_ptr(),
         );
 
-        let allow_port = 443;
-        let mut allow_port_bitmap:[u8;65536/8] = [0;65536/8];
-        allow_port_bitmap[allow_port/8] |= 1<<(allow_port%8);
-        set_allow_port_bitmap(allow_port_bitmap.as_ptr());
+        //let allow_port = 443;
+        //let mut allow_port_bitmap:[u8;65536/8] = [0;65536/8];
+        //allow_port_bitmap[allow_port/8] |= 1<<(allow_port%8);
+        //set_allow_port_bitmap(allow_port_bitmap.as_ptr());
 
         // The first parameter passed by a null pointer can be
         // filled with std::ptr::null()

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -37,8 +37,22 @@
 #define MAP_PROGS_JMP_TP_NAME		"__progs_jmp_tp_map"
 
 // This prog is designed to handle data transfer
-#define PROG_OUTPUT_DATA_NAME_FOR_KP	"bpf_prog__output_data_kp"
-#define PROG_OUTPUT_DATA_NAME_FOR_TP	"bpf_prog__output_data_tp"
+#define PROG_DATA_SUBMIT_NAME_FOR_KP	"bpf_prog_kp__data_submit"
+#define PROG_DATA_SUBMIT_NAME_FOR_TP	"bpf_prog_tp__data_submit"
+#define PROG_OUTPUT_DATA_NAME_FOR_KP	"bpf_prog_kp__output_data"
+#define PROG_OUTPUT_DATA_NAME_FOR_TP	"bpf_prog_tp__output_data"
+
+enum {
+	PROG_DATA_SUBMIT_TP_IDX,
+	PROG_OUTPUT_DATA_TP_IDX,
+	PROG_TP_NUM
+};
+
+enum {
+	PROG_DATA_SUBMIT_KP_IDX,
+	PROG_OUTPUT_DATA_KP_IDX,
+	PROG_KP_NUM
+};
 
 /*
  * When the socket map is recycled, each socket message is recycled without sending

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1136,14 +1136,25 @@ static void __insert_output_prog_to_map(struct bpf_tracer *tracer,
  */
 static void insert_output_prog_to_map(struct bpf_tracer *tracer)
 {
+	// jmp for tracepoints
+	__insert_output_prog_to_map(tracer,
+				    MAP_PROGS_JMP_TP_NAME,
+				    PROG_DATA_SUBMIT_NAME_FOR_TP,
+				    PROG_DATA_SUBMIT_TP_IDX);
 	__insert_output_prog_to_map(tracer,
 				    MAP_PROGS_JMP_TP_NAME,
 				    PROG_OUTPUT_DATA_NAME_FOR_TP,
-				    0);
+				    PROG_OUTPUT_DATA_TP_IDX);
+
+	// jmp for kprobe/uprobe
+	__insert_output_prog_to_map(tracer,
+				    MAP_PROGS_JMP_KP_NAME,
+				    PROG_DATA_SUBMIT_NAME_FOR_KP,
+				    PROG_DATA_SUBMIT_KP_IDX);
 	__insert_output_prog_to_map(tracer,
 				    MAP_PROGS_JMP_KP_NAME,
 				    PROG_OUTPUT_DATA_NAME_FOR_KP,
-				    0);
+				    PROG_OUTPUT_DATA_KP_IDX);
 }
 
 /**


### PR DESCRIPTION
The eBPF program is getting larger and larger, and the instruction is easy to exceed the limit, so we need to adjust the program structure to meet the needs of later development. The following adjustments have been made:
- Convert 'data_submit' to tail call programe.

eBPF programs processing flow:
```
(start) -- [1 initial & infer protocol prog]  -- [2 submit/trace process prog]   -- \
                              |                                                       [4 output prog]
                              |----------------- [3 file io event prog] ------------/
```

1 syscall programe, 2/3/4 tail-calls programe.


### This PR is for:


- Agent


#### Affected branches
- main
- v6.1

