### PR TITLE
[eBPF] Fix linux 5.2+ verify fail

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -1468,14 +1468,6 @@ infer_protocol(struct ctx_info_s *ctx,
 				return inferred_message;
 			}
 			break;
-		case PROTO_HTTP2:
-			if ((inferred_message.type =
-			     infer_http2_message(http2_infer_buf, http2_infer_len,
-						 conn_info)) != MSG_UNKNOWN) {
-				inferred_message.protocol = PROTO_HTTP2;
-				return inferred_message;
-			}
-			break;
 		case PROTO_POSTGRESQL:
 			if ((inferred_message.type =
 			     infer_postgre_message(infer_buf, count,
@@ -1587,11 +1579,7 @@ infer_protocol(struct ctx_info_s *ctx,
 		    infer_sofarpc_message(infer_buf, count,
 					  conn_info)) != MSG_UNKNOWN){
 		inferred_message.protocol = PROTO_SOFARPC;
-#ifdef LINUX_VER_5_2_PLUS
-	} else if (skip_proto != PROTO_HTTP2 && (inferred_message.type =
-#else
 	} else if ((inferred_message.type =
-#endif
 		    infer_http2_message(http2_infer_buf, http2_infer_len, 
 					conn_info)) != MSG_UNKNOWN) {
 		inferred_message.protocol = PROTO_HTTP2;


### PR DESCRIPTION
The following error occurs in the Linux5.2+ kernel:

```
last_idx 1554 first_idx 532
regs=2 stack=0 before 1553: (79) r1 = *(u64 *)(r10 -376)
regs=0 stack=400000000000 before 533: (05) goto pc+1019
regs=0 stack=400000000000 before 532: (55) if r0 != 0x0 goto pc+77
 R0_rw=map_value_or_null(id=51,off=0,ks=4,vs=4,imm=0) R6=invP(id=0,umax_value=65535,var_off=(0x0; 0xffff)) R7_r=map_value(id=0,off=0,ks=4,vs=65536,imm=0) R8=inv0 R9=map_value(id=0,off=0,ks=4,vs=168,imm=0) R10=fp0 fp-8=mmmmmmmm fp-72=mmmmmmmm fp-80=mmmmmmmm fp-96=mmmmmmmm fp-104=mmmmmmmm fp-112=map_value fp-120=00000000 fp-128=mmmmmmmm fp-136=inv4 fp-144=00000000 fp-152=00000000 fp-160=mmmmmmmm fp-168=0000mmmm fp-176=00000mmm fp-184=mmmmmmm0 fp-192=00000000 fp-200=00000000 fp-208=00000000 fp-216=00000000 fp-224=mmmmmmmm fp-232=????mmmm fp-240=mmmmmmmm fp-248=mmmmmmmm fp-256=mmmmmmmm fp-264=mmmmmmmm fp-272=mmmmmmmm fp-280=mmmmmmmm fp-288=mmmmmmmm fp-296=????0000 fp-304=00000000 fp-312=00000000 fp-320=mmmmmmmm fp-328=mmmmmmmm fp-336=map_value fp-344=ctx fp-352=map_value fp-360=map_value fp-368=mmmmmmmm fp-376_r=mmmmmmmm
parent already had regs=0 stack=0 marks
math between map_value pointer and register with unbounded min value is not allowed
processed 5491 insns (limit 1000000) max_states_per_insn 7 total_states 380 peak_states 355 mark_read 37
```
Solution: Skip the http2 inferred fast path.



### This PR is for:

- Agent


#### Affected branches
- main
