### PR TITLE
[Agent] fix otel data's wrong ip and timestamp, add tap_type

### DIFF
--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -1967,6 +1967,7 @@ impl AgentComponents {
             candidate_config.metric_server.compressed,
             candidate_config.platform.epc_id,
             policy_getter,
+            synchronizer.ntp_diff(),
         );
 
         stats_collector.register_countable(


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes otel data's wrong ip and timestamp, add tap_type
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- fix mismatch ip type like "::ffff:0.0.0.0" it is either an IPv4-compatible address
- correct flow_stat_time with time_diff
- add tap_type
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
