### PR TITLE
[eBPF] Fix missing data in HTTP2 iovecs mode

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -1365,6 +1365,12 @@ infer_protocol(struct ctx_info_s *ctx,
 						     count, DATA_BUF_MAX,
 						     &http2_infer_buf,
 						     &http2_infer_len);
+		/*
+		 * The http2_infer_len(iov_cpy.iov_len) may be larger than
+		 * syscall length, make adjustments here.
+		 */
+		if (http2_infer_len > count)
+			http2_infer_len = count;
 	} else {
 		bpf_probe_read(__infer_buf->data, sizeof(__infer_buf->data), buf);
 		http2_infer_buf = (char *)buf;

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -190,7 +190,7 @@ static __u32 __inline get_tcp_read_seq_from_fd(int fd)
 }
 
 /*
- * B ; buffer
+ * B : buffer
  * O : buffer offset, e.g.: infer_buf->len
  * I : &args->iov[i]
  * L_T : total_size
@@ -201,7 +201,7 @@ static __u32 __inline get_tcp_read_seq_from_fd(int fd)
 #define COPY_IOV(B, O, I, L_T, L_C, F, F_S) do {				\
 	struct iovec iov_cpy;							\
 	bpf_probe_read(&iov_cpy, sizeof(struct iovec), (I));			\
-	if (iov_cpy.iov_base == NULL) continue;					\
+	if (iov_cpy.iov_base == NULL || iov_cpy.iov_len == 0) continue;		\
 	if (!(F)) {								\
 		F = iov_cpy.iov_base;						\
 		F_S = iov_cpy.iov_len;						\
@@ -213,7 +213,7 @@ static __u32 __inline get_tcp_read_seq_from_fd(int fd)
         __u32 len = (O) + (L_C);						\
         struct copy_data_s *cp = (struct copy_data_s *)((B) + len);		\
 	if (len > (sizeof((B)) - sizeof(*cp)))					\
-		return (L_C);							\
+		break;								\
 	if (iov_size >= sizeof(cp->data)) {					\
 		bpf_probe_read(cp->data, sizeof(cp->data), iov_cpy.iov_base);	\
 		iov_size = sizeof(cp->data);					\
@@ -243,6 +243,10 @@ static __inline int iovecs_copy(struct __socket_data *v,
 		total_size = sizeof(v->data);
 	else
 		total_size = send_len;
+
+	if (total_size > syscall_len)
+		total_size = syscall_len;
+
 	char *first_iov = NULL;
 	__u32 first_iov_size = 0;
 
@@ -267,7 +271,7 @@ static __inline int infer_iovecs_copy(struct infer_data_s *infer_buf,
 				      __u32 *f_iov_len)
 {
 #define INFER_COPY_SZ	 32
-#define INFER_LOOP_LIMIT 3
+#define INFER_LOOP_LIMIT 4
 	struct copy_data_s {
 		char data[INFER_COPY_SZ];
 	};
@@ -280,6 +284,10 @@ static __inline int infer_iovecs_copy(struct infer_data_s *infer_buf,
 		total_size = sizeof(infer_buf->data);
 	else
 		total_size = copy_len;
+
+	if (total_size > syscall_len)
+		total_size = syscall_len;
+
 	char *first_iov = NULL;
 	__u32 first_iov_size = 0;
 


### PR DESCRIPTION
Fix missing data in HTTP2 iovecs mode

### This PR is for:


- Agent



#### Affected branches
- main
- v6.1

#### eBPF linux kernel Checklist
- [X] Linux 4.14.x
- [X] Linux 4.19.x
- [X] Linux 5.2+

