### PR TITLE
[Agent] fix socket sync listen addr overlook

### DIFF
--- a/agent/src/platform/platform_synchronizer/linux_socket.rs
+++ b/agent/src/platform/platform_synchronizer/linux_socket.rs
@@ -351,9 +351,6 @@ fn record_tcp_listening_ip_port(
                     };
                     spec_addr_listen_sock.insert(local_address);
                 }
-            } else {
-                // the listen socket info in /proc/pid/net/tcp always in the top
-                break;
             }
         }
     };


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes socket sync overlook listen addr
#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
 

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->

=========================================================
由于错误地认为 /proc/pid/net/tcp listening 的链接永远在最上面，遇到非listening的地址就跳出，导致有遗漏 tcp listenning 的记录。record_tcp_listening_ip_port 修改为扫描整个 /proc/pid/net/tcp listening
