### PR TITLE
[Agent] change packet-sequence-block-size default value from 64 to 256

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -471,7 +471,7 @@ impl YamlConfig {
 
         // Enterprise Edition Feature: packet-sequence
         if c.packet_sequence_block_size <= 0 || c.packet_sequence_block_size >= 1024 {
-            c.packet_sequence_block_size = 64;
+            c.packet_sequence_block_size = 256;
         }
 
         // Enterprise Edition Feature: packet-sequence
@@ -622,10 +622,10 @@ impl Default for YamlConfig {
             external_metrics_sender_queue_size: 1 << 12,
             l7_protocol_inference_max_fail_count: L7_PROTOCOL_INFERENCE_MAX_FAIL_COUNT,
             l7_protocol_inference_ttl: L7_PROTOCOL_INFERENCE_TTL,
-            packet_sequence_block_size: 64, // Enterprise Edition Feature: packet-sequence
+            packet_sequence_block_size: 256, // Enterprise Edition Feature: packet-sequence
             packet_sequence_queue_size: 1 << 16, // Enterprise Edition Feature: packet-sequence
-            packet_sequence_queue_count: 1, // Enterprise Edition Feature: packet-sequence
-            packet_sequence_flag: 0,        // Enterprise Edition Feature: packet-sequence
+            packet_sequence_queue_count: 1,  // Enterprise Edition Feature: packet-sequence
+            packet_sequence_flag: 0,         // Enterprise Edition Feature: packet-sequence
             feature_flags: vec![],
             l7_protocol_enabled: {
                 let mut protos = vec![];

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -823,10 +823,10 @@ vtap_group_id: g-xxxxxx
   ## L4 Packet Sequence ##
   ########################
   ## Block Size
-  ## Default: 64. Unit: Byte.
+  ## Default: 256. Unit: Byte.
   ## Note: When generating TCP header data, each flow uses one block to compress and
   ##   store multiple TCP headers, and the block size can be set here.
-  #packet-sequence-block-size: 64
+  #packet-sequence-block-size: 256
 
   ## Queue Size of PacketSequence Output
   ## Default: 65536. Range: [65536, +oo)


### PR DESCRIPTION
### This PR is for:

- Agent
- Server

### change packet-sequence-block-size default value from 64 to 256
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
     