### PR TITLE
[eBPF] Adjust socket/trace map statistics #20579

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,9 @@ One or more of:
 - main
 #### Checklist
 - [ ] Added unit test to verify the fix.
+- [ ] Verified eBPF program runs successfully on linux 4.14.x.
+- [ ] Verified eBPF program runs successfully on linux 4.19.x.
+- [ ] Verified eBPF program runs successfully on Linux 5.2+.
      ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->
 
 <!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -470,7 +470,7 @@ impl YamlConfig {
         if c.ebpf.thread_num == 0 {
             c.ebpf.thread_num = 1;
         }
-        if c.ebpf.perf_pages_count < 32 || c.ebpf.perf_pages_count > 512 {
+        if c.ebpf.perf_pages_count < 32 || c.ebpf.perf_pages_count > 8192 {
             c.ebpf.perf_pages_count = 128
         }
         if c.ebpf.ring_size < 8192 || c.ebpf.ring_size > 131072 {

--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -314,11 +314,13 @@ static __inline void http2_fill_common_socket(struct http2_header_data *data,
 		struct socket_info_t sk_info = {
 			.uid = send_buffer->socket_id,
 		};
-		socket_info_map__update(&conn_key, &sk_info);
 		struct trace_stats *trace_stats = trace_stats_map__lookup(&k0);
 		if (trace_stats == NULL)
 			return;
-		trace_stats->socket_map_count++;
+		if (!socket_info_map__update(&conn_key, &sk_info)) {
+			__sync_fetch_and_add(&trace_stats->
+					     socket_map_count, 1);
+		}
 	}
 
 	send_buffer->tgid = tgid;

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -96,6 +96,18 @@ pub const TRACER_WAIT_STOP: u8 = 5;
 #[allow(dead_code)]
 pub const TRACER_STOP_ERR: u8 = 6;
 
+// Identifying data source
+#[allow(dead_code)]
+pub const DATA_SOURCE_SYSCALL: u8 = 0;
+#[allow(dead_code)]
+pub const DATA_SOURCE_GO_TLS_UPROBE: u8 = 1;
+#[allow(dead_code)]
+pub const DATA_SOURCE_GO_HTTP2_UPROBE: u8 = 2;
+#[allow(dead_code)]
+pub const DATA_SOURCE_OPENSSL_UPROBE: u8 = 3;
+#[allow(dead_code)]
+pub const DATA_SOURCE_IO_EVENT: u8 = 4;
+
 // 消息类型
 // 目前除了 source=EBPF_TYPE_GO_HTTP2_UPROBE 以外,都不能保证这个方向的正确性.
 // go http2 uprobe 目前 只用了MSG_RESPONSE_END, 用于判断流结束.
@@ -141,7 +153,7 @@ pub struct SK_BPF_DATA {
     pub process_id: u32,   // tgid in kernel struct task_struct
     pub thread_id: u32,    // pid in kernel struct task_struct, main thread iff pid==tgid
     pub coroutine_id: u64, // CoroutineID, i.e., golang goroutine id
-    pub source: u8,        // SYSCALL,GO_TLS_UPROBE,GO_HTTP2_UPROBE
+    pub source: u8,        // Value is DATA_SOURCE_*
 
     pub process_kname: [u8; PACKET_KNAME_MAX_PADDING + 1], //进程或线程名字，占用16bytes
 

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -35,9 +35,6 @@
 #include "socket_trace_bpf_5_2.c"
 #include "socket_trace_bpf_kylin.c"
 
-static uint64_t socket_map_reclaim_count;	// socket map回收数量统计
-static uint64_t trace_map_reclaim_count;	// trace map回收数量统计
-
 static struct list_head events_list;	// Use for extra register events
 static pthread_t proc_events_pthread;	// Process exec/exit thread
 
@@ -99,7 +96,9 @@ static int socket_tracer_start(void);
 static int update_offsets_table(struct bpf_tracer *t,
 				struct bpf_offset_param *offset);
 static void datadump_process(void *data);
-
+static bool bpf_stats_map_update(struct bpf_tracer *tracer,
+				 int socket_num,
+				 int trace_num);
 static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 {
 	int index = 0, curr_idx;
@@ -348,9 +347,6 @@ static int socktrace_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
 	if (bpf_stats_map_collect(t, &stats_total)) {
 		params->kern_socket_map_used = stats_total.socket_map_count;
 		params->kern_trace_map_used = stats_total.trace_map_count;
-		// Calibrate map statistics
-		params->kern_socket_map_used -= socket_map_reclaim_count;
-		params->kern_trace_map_used -= trace_map_reclaim_count;
 	}
 
 	if (!bpf_offset_map_collect(t, array)) {
@@ -722,6 +718,37 @@ static void reader_lost_cb(void *t, uint64_t lost)
 	atomic64_add(&tracer->lost, lost);
 }
 
+static bool inline insert_list(void *elt,
+			       uint32_t len,
+			       struct list_head *h)
+{
+	struct clear_list_elem *cle;
+	cle = calloc(sizeof(*cle) + len, 1);
+	if (cle == NULL) {
+		ebpf_warning("calloc() failed.\n");
+		return false;
+	}
+	memcpy((void *)cle->p, (void *)elt, len);
+	list_add_tail(&cle->list, h);
+	return true;
+}
+
+static int inline __reclaim_map(int map_fd, struct list_head *h)
+{
+	int count = 0;
+	struct list_head *p, *n;
+	struct clear_list_elem *cle;
+	list_for_each_safe(p, n, h) {
+		cle = container_of(p, struct clear_list_elem, list);
+		if (!bpf_delete_elem(map_fd, (void *)cle->p))
+			count++;
+		list_head_del(&cle->list);
+		free(cle);
+	}
+
+	return count;
+}
+
 static void reclaim_trace_map(struct bpf_tracer *tracer, uint32_t timeout)
 {
 	struct ebpf_map *map =
@@ -737,15 +764,20 @@ static void reclaim_trace_map(struct bpf_tracer *tracer, uint32_t timeout)
 	uint32_t reclaim_count = 0;
 	struct trace_info_t value;
 	uint32_t uptime = get_sys_uptime();
+	uint32_t curr_trace_count = 0, limit;
+	limit = conf_max_trace_entries * RECLAIM_TRACE_MAP_SCALE;
+	struct list_head clear_elem_head;
+	init_list_head(&clear_elem_head);
 
 	while (bpf_get_next_key(map_fd, &trace_key, &next_trace_key) == 0) {
 		if (bpf_lookup_elem(map_fd, &next_trace_key, &value) == 0) {
-			if (uptime - value.update_time > timeout) {
-				bpf_delete_elem(map_fd, &next_trace_key);
-				reclaim_count++;
-				if (reclaim_count >= 
-				    (conf_max_trace_entries * RECLAIM_TRACE_MAP_SCALE)) {
-					break;
+			curr_trace_count++;
+			if (uptime - value.update_time > timeout &&
+			    reclaim_count < limit) {
+				if (insert_list(&next_trace_key,
+						sizeof(next_trace_key),
+						&clear_elem_head)) {
+					reclaim_count++;
 				}
 			}
 		}
@@ -753,9 +785,15 @@ static void reclaim_trace_map(struct bpf_tracer *tracer, uint32_t timeout)
 		trace_key = next_trace_key;
 	}
 
-	trace_map_reclaim_count += reclaim_count;
-	ebpf_info("[%s] trace map reclaim_count :%u\n", __func__,
-		  reclaim_count);
+	reclaim_count = __reclaim_map(map_fd, &clear_elem_head);
+	// The trace statistics map needs to be updated to reflect the count.	
+	curr_trace_count -= reclaim_count;
+	if (!bpf_stats_map_update(tracer, -1, curr_trace_count)) {
+		ebpf_warning("Update trace statistics failed.\n");
+	}
+
+	ebpf_info("[%s] curr_trace_count %u trace map reclaim_count :%u\n",
+		  __func__, curr_trace_count, reclaim_count);
 }
 
 static void reclaim_socket_map(struct bpf_tracer *tracer, uint32_t timeout)
@@ -773,24 +811,34 @@ static void reclaim_socket_map(struct bpf_tracer *tracer, uint32_t timeout)
 	struct socket_info_t value;
 	conn_key = 0;
 	uint32_t uptime = get_sys_uptime();
+	uint32_t curr_socket_count = 0;
+	struct list_head clear_elem_head;
+	init_list_head(&clear_elem_head);
 
 	while (bpf_get_next_key(map_fd, &conn_key, &next_conn_key) == 0) {
 		if (bpf_lookup_elem(map_fd, &next_conn_key, &value) == 0) {
-			if (uptime - value.update_time > timeout) {
-				bpf_delete_elem(map_fd, &next_conn_key);
-				sockets_reclaim_count++;
-				if (sockets_reclaim_count >=
-				    conf_socket_map_max_reclaim) {
-					break;
+			curr_socket_count++;
+			if ((uptime - value.update_time > timeout) &&
+			    (sockets_reclaim_count <
+				conf_socket_map_max_reclaim)) {
+				if (insert_list(&next_conn_key,
+						sizeof(next_conn_key),
+						&clear_elem_head)) {
+					sockets_reclaim_count++;
 				}
 			}
 		}
 		conn_key = next_conn_key;
 	}
 
-	socket_map_reclaim_count += sockets_reclaim_count;
-	ebpf_info("[%s] sockets_reclaim_count :%u\n", __func__,
-		  sockets_reclaim_count);
+	sockets_reclaim_count = __reclaim_map(map_fd, &clear_elem_head);
+	curr_socket_count -= sockets_reclaim_count;
+	if (!bpf_stats_map_update(tracer, curr_socket_count, -1)) {
+		ebpf_warning("Update trace statistics failed.\n");
+	}
+
+	ebpf_info("[%s] curr_socket_count %u sockets_reclaim_count :%u\n",
+		  __func__, curr_socket_count, sockets_reclaim_count);
 }
 
 static int check_map_exceeded(void)
@@ -806,9 +854,6 @@ static int check_map_exceeded(void)
 	if (bpf_stats_map_collect(t, &stats_total)) {
 		kern_socket_map_used = stats_total.socket_map_count;
 		kern_trace_map_used = stats_total.trace_map_count;
-		// Calibrate map statistics
-		kern_socket_map_used -= socket_map_reclaim_count;
-		kern_trace_map_used -= trace_map_reclaim_count;
 	}
 
 	if (kern_socket_map_used >= conf_socket_map_max_reclaim) {
@@ -1444,19 +1489,39 @@ static int socket_tracer_start(void)
 static bool bpf_stats_map_collect(struct bpf_tracer *tracer,
 				  struct trace_stats *stats_total)
 {
-	int nr_cpus = get_num_possible_cpus();
-	struct trace_stats values[nr_cpus];
-	memset(values, 0, sizeof(values));
-
-	if (!bpf_table_get_value(tracer, MAP_TRACE_STATS_NAME, 0, values))
+	struct trace_stats value = { 0 };
+	if (!bpf_table_get_value(tracer, MAP_TRACE_STATS_NAME,
+				 0, &value))
 		return false;
 
 	memset(stats_total, 0, sizeof(*stats_total));
+	stats_total->socket_map_count += value.socket_map_count;
+	stats_total->trace_map_count += value.trace_map_count;
 
-	int i;
-	for (i = 0; i < nr_cpus; i++) {
-		stats_total->socket_map_count += values[i].socket_map_count;
-		stats_total->trace_map_count += values[i].trace_map_count;
+	return true;
+}
+
+static bool bpf_stats_map_update(struct bpf_tracer *tracer,
+				 int socket_num,
+				 int trace_num)
+{
+	struct trace_stats value = { 0 };
+	if (!bpf_table_get_value(tracer, MAP_TRACE_STATS_NAME,
+				 0, &value))
+		return false;
+
+	if (socket_num != -1) {
+		value.socket_map_count = socket_num;
+	}
+
+	if (trace_num != -1) {
+		value.trace_map_count = trace_num;
+	}
+
+	if (!bpf_table_set_value(tracer,
+				 MAP_TRACE_STATS_NAME,
+				 0, (void *)&value)) {
+		return false;
 	}
 
 	return true;
@@ -1548,9 +1613,6 @@ struct socket_trace_stats socket_tracer_stats(void)
 	if (bpf_stats_map_collect(t, &stats_total)) {
 		stats.kern_socket_map_used = stats_total.socket_map_count;
 		stats.kern_trace_map_used = stats_total.trace_map_count;
-		// Calibrate map statistics
-		stats.kern_socket_map_used -= socket_map_reclaim_count;
-		stats.kern_trace_map_used -= trace_map_reclaim_count;
 	}
 
 	int i;

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -158,6 +158,11 @@ struct bpf_socktrace_params {
 	struct bpf_offset_param_array offset_array;
 };
 
+struct clear_list_elem {
+	struct list_head list;
+	const char p[0];
+};
+
 /*
  * This structure is used for registration of additional events. 
  */

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -887,8 +887,8 @@ vtap_group_id: g-xxxxxx
     #thread-num: 1
 
     ## eBPF perf pages count
-    ## Default: 128. Range: [32, 512]
-    ## Note: The number of page occupied by the shared memory of the kernel. The value is 2^n ( n range [5, 9] ). Used for perf data transfer.
+    ## Default: 128. Range: [32, 8192]
+    ## Note: The number of page occupied by the shared memory of the kernel. The value is 2^n ( n range [5, 13] ). Used for perf data transfer.
     ##   If the value is between 2^n and 2^(n+1), it will be automatically adjusted by the ebpf configurator to the minimum value (2^n).
     #perf-pages-count: 128
 


### PR DESCRIPTION
Adjust socket/trace map statistics
[[eBPF] Adjust eBPF configuration item 'perf_pages_count'](https://github.com/deepflowio/deepflow/pull/2705/commits/947f4baf2c9a1b3ccb43f034319c8f5ee569507c) 

The following reasons require adjusting the upper limit of perf-pages-count:

1. To prevent data loss at the kernel level (producer) due to a sudden surge in the number of perf events.

2. When Golang HTTP2 uprobe is enabled, a single request is divided into multiple events, leading to an increase in the number of events and a risk of kernel data loss.

3. Our program framework currently distributes data through a single thread, with the option to configure multiple worker threads for data processing. If there are too many events and the CPU is under pressure, more memory is needed to alleviate the risk of eBPF kernel-level data loss.

### This PR is for:


- Agent


#### Affected branches
- main
- v6.1

#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on Linux 5.2+.





