### PR TITLE
[Agent] Modify the default of afpacket-blocks to 128

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -576,7 +576,7 @@ impl Default for YamlConfig {
             log_level: log::Level::Info,
             profiler: false,
             af_packet_blocks_enabled: false,
-            af_packet_blocks: 0,
+            af_packet_blocks: 128,
             enable_debug_stats: false,
             analyzer_dedup_disabled: false,
             default_tap_type: 3,

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -460,10 +460,11 @@ vtap_group_id: g-xxxxxx
   #afpacket-blocks-enabled: false
 
   ## AF_PACKET Blocks
+  ## Default: 128, Range: [8, +oo)
   ## Note: deepflow-agent will automatically calculate the number of blocks
   ##   used by AF_PACKET according to max_memory, which can also be specified
   ##   using this configuration item. The size of each block is fixed at 1MB.
-  #afpacket-blocks: 0
+  #afpacket-blocks: 128
 
   ###################
   ## Analyzer Mode ##


### PR DESCRIPTION
### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

### Modify the default of afpacket-blocks to 128
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main
- 6.1

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


