### PR TITLE
[Agent] fix wrong http version for otel data

### DIFF
--- a/agent/crates/public/src/l7_protocol.rs
+++ b/agent/crates/public/src/l7_protocol.rs
@@ -59,7 +59,7 @@ impl From<String> for L7Protocol {
         let l7_protocol_str = l7_protocol_str.to_lowercase();
         match l7_protocol_str.as_str() {
             "http" => Self::Http1,
-            "http2" => Self::Http2,
+            "https" => Self::Http1TLS,
             "dubbo" => Self::Dubbo,
             "grpc" => Self::Grpc,
             "protobufrpc" => Self::ProtobufRPC,

--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -325,6 +325,7 @@ fn fill_tagged_flow(
     let mut l4_protocol = L4Protocol::Tcp;
     let mut l7_protocol = L7Protocol::Unknown;
     let mut status = L7ResponseStatus::NotExist;
+    let mut is_http2 = false;
 
     let mut tagged_flow = TaggedFlow::default();
     tagged_flow.flow.signal_source = SignalSource::OTel;
@@ -397,9 +398,28 @@ fn fill_tagged_flow(
                     }
                 }
             }
+            // Format as above, "http.flavor": "1.1"
+            "http.flavor" => {
+                if let Some(value) = attr.value.clone() {
+                    if let Some(StringValue(val)) = value.value {
+                        if val == "2.0" {
+                            is_http2 = true;
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
+
+    if is_http2 {
+        if l7_protocol == L7Protocol::Http1 {
+            l7_protocol = L7Protocol::Http2;
+        } else if l7_protocol == L7Protocol::Http1TLS {
+            l7_protocol = L7Protocol::Http2TLS;
+        }
+    }
+
     (
         tagged_flow.flow.flow_key.ip_src,
         tagged_flow.flow.flow_key.ip_dst,


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong http version for otel data
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- fix wrong http version
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
