### PR TITLE
[Ingester] add gprocess_id info for ext_metrics

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -769,6 +769,12 @@ var ColumnAdd626 = []*ColumnAdds{
 		ColumnNames: u16ColumnProfileNameAdd626,
 		ColumnType:  ckdb.UInt16,
 	},
+	&ColumnAdds{
+		Dbs:         []string{"ext_metrics"},
+		Tables:      []string{"metrics", "metrics_local"},
+		ColumnNames: []string{"gprocess_id"},
+		ColumnType:  ckdb.UInt32,
+	},
 }
 
 var TableRenames626 = []*TableRename{

--- a/server/ingester/common/const.go
+++ b/server/ingester/common/const.go
@@ -17,6 +17,6 @@
 package common
 
 const (
-	CK_VERSION             = "v6.2.6.1" // 用于表示clickhouse的表版本号
+	CK_VERSION             = "v6.2.6.2" // 用于表示clickhouse的表版本号
 	DEFAULT_PCAP_DATA_PATH = "/var/lib/pcap"
 )

--- a/server/libs/zerodoc/tag_universal.go
+++ b/server/libs/zerodoc/tag_universal.go
@@ -57,7 +57,7 @@ type UniversalTag struct {
 // Currently all fields are sorted lexicographically by name.
 func GenUniversalTagColumns(columns []*ckdb.Column) []*ckdb.Column {
 	columns = append(columns, ckdb.NewColumnWithGroupBy("az_id", ckdb.UInt16).SetComment("可用区ID"))
-	//columns = append(columns, ckdb.NewColumnWithGroupBy("gprocess_id", ckdb.UInt32).SetComment("全局进程ID"))
+	columns = append(columns, ckdb.NewColumnWithGroupBy("gprocess_id", ckdb.UInt32).SetComment("全局进程ID"))
 	columns = append(columns, ckdb.NewColumnWithGroupBy("host_id", ckdb.UInt16).SetComment("宿主机ID"))
 	columns = append(columns, ckdb.NewColumnWithGroupBy("ip4", ckdb.IPv4).SetComment("IPv4地址"))
 	columns = append(columns, ckdb.NewColumnWithGroupBy("ip6", ckdb.IPv6).SetComment("IPV6地址"))
@@ -88,7 +88,7 @@ func GenUniversalTagColumns(columns []*ckdb.Column) []*ckdb.Column {
 func (t *UniversalTag) WriteBlock(block *ckdb.Block) {
 	block.Write(
 		t.AZID,
-		//t.GPID,
+		t.GPID,
 		t.HostID,
 	)
 	block.WriteIPv4(t.IP)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query ext_metrics error
#### Steps to reproduce the bug
- monitoring process, and make `os.app` universal tags available;
- when query any metrics in `ext_metrics`, it returns error from query, because `querier` needs `gprocess_id` to query `os.app` tags.
#### Changes to fix the bug
- add `gprocess_id` for ext_metrics tables
#### Affected branches
- main
#### Checklist
- [x] complete integration write test: after add `gprocess_id`, ext_metrics successfully write data without error.
- [x] complete integration query test: after add `gprocess_id`, query metrics successfully without error ( in `os.app` scene)


