### PR TITLE
[Agent] change otel data default l7_protocol from Unknown to Other

### DIFF
--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -323,7 +323,7 @@ fn fill_tagged_flow(
         )
     };
     let mut l4_protocol = L4Protocol::Tcp;
-    let mut l7_protocol = L7Protocol::Unknown;
+    let mut l7_protocol = L7Protocol::Other;
     let mut status = L7ResponseStatus::NotExist;
     let mut is_http2 = false;
 


### PR DESCRIPTION
### This PR is for:

- Agent

### change otel data default l7_protocol from Unknown to Other
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
