### PR TITLE
[server] ignore the error of drop index in the distributed table

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -1281,7 +1281,7 @@ func (i *Issu) renameColumn(connect *sql.DB, cr *ColumnRename) error {
 		if err != nil {
 			if strings.Contains(err.Error(), "Cannot find index") {
 				log.Infof("db: %s, table: %s error: %s", cr.Db, cr.Table, err)
-			} else if strings.Contains(err.Error(), "'DROP_INDEX' is not supported by storage Distributed") {
+			} else if strings.Contains(err.Error(), "is not supported by storage Distributed") {
 				log.Infof("db: %s, table: %s info: %s", cr.Db, cr.Table, err)
 			} else if strings.Contains(err.Error(), "doesn't exist") {
 				log.Infof("db: %s, table: %s info: %s", cr.Db, cr.Table, err)


### PR DESCRIPTION
in clickhouse v21.8 error info is: 'DROP INDEX' is not supported by storage Distributed

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


