### PR TITLE
[server] LRU128 reduce the use of pointers

### DIFF
--- a/server/libs/hmap/lru/u128_lru.go
+++ b/server/libs/hmap/lru/u128_lru.go
@@ -32,13 +32,12 @@ type u128LRUNode struct {
 	key1  uint64
 	value interface{}
 
-	hashListNext *u128LRUNode // 表示节点所在冲突链的下一个节点的 buffer 数组下标，-1 表示不存在
-	hashListPrev *u128LRUNode // 表示节点所在冲突链的上一个节点的 buffer 数组下标，-1 表示不存在
-	timeListNext *u128LRUNode // 时间链表，含义与冲突链类似
-	timeListPrev *u128LRUNode // 时间链表，含义与冲突链类似
+	hashListNext int32 // 表示节点所在冲突链的下一个节点的 buffer 数组下标，-1 表示不存在
+	hashListPrev int32 // 表示节点所在冲突链的上一个节点的 buffer 数组下标，-1 表示不存在
+	timeListNext int32 // 时间链表，含义与冲突链类似
+	timeListPrev int32 // 时间链表，含义与冲突链类似
 
-	hash  int32
-	index int32
+	hash int32
 }
 
 var blankU128LRUNodeForInit u128LRUNode
@@ -62,9 +61,9 @@ type U128LRU struct {
 	hashSlots    int32  // 上取整至2^N，哈希桶个数
 	hashSlotBits uint32 // hashSlots中低位连续0比特个数
 
-	hashSlotHead []*u128LRUNode // 哈希桶，hashSlotHead[i] 表示哈希值为 i 的冲突链的第一个节点为 buffer[[ hashSlotHead[i] ]]
-	timeListHead *u128LRUNode
-	timeListTail *u128LRUNode
+	hashSlotHead []int32 // 哈希桶，hashSlotHead[i] 表示哈希值为 i 的冲突链的第一个节点为 buffer[[ hashSlotHead[i] ]]
+	timeListHead int32
+	timeListTail int32
 
 	capacity int // 最大容纳的Flow个数
 	size     int // 当前容纳的Flow个数
@@ -117,68 +116,70 @@ func (m *U128LRU) getNode(index int32) *u128LRUNode {
 	return &m.ringBuffer[index>>_BLOCK_SIZE_BITS][index&_BLOCK_SIZE_MASK]
 }
 
-func (m *U128LRU) pushNodeToHashList(node *u128LRUNode, hash int32) {
+func (m *U128LRU) pushNodeToHashList(node *u128LRUNode, nodeIndex, hash int32) {
 	node.hashListNext = m.hashSlotHead[hash]
-	node.hashListPrev = nil
-	if node.hashListNext != nil {
-		node.hashListNext.hashListPrev = node
+	node.hashListPrev = -1
+	if node.hashListNext != -1 {
+		m.getNode(node.hashListNext).hashListPrev = nodeIndex
 	}
-	m.hashSlotHead[hash] = node
+	m.hashSlotHead[hash] = nodeIndex
 }
 
 func (m *U128LRU) pushNodeToTimeList(node *u128LRUNode, nodeIndex int32) {
 	node.timeListNext = m.timeListHead
-	node.timeListPrev = nil
-	if node.timeListNext != nil {
-		node.timeListNext.timeListPrev = node
+	node.timeListPrev = -1
+	if node.timeListNext != -1 {
+		m.getNode(node.timeListNext).timeListPrev = nodeIndex
 	}
-	m.timeListHead = node
-	if m.timeListTail == nil {
-		m.timeListTail = node
+	m.timeListHead = nodeIndex
+	if m.timeListTail == -1 {
+		m.timeListTail = nodeIndex
 	}
 }
 
-func (m *U128LRU) removeNodeFromHashList(node, newNext, newPrev *u128LRUNode) {
-	if node.hashListPrev != nil {
-		node.hashListPrev.hashListNext = newNext
+func (m *U128LRU) removeNodeFromHashList(node *u128LRUNode, newNext, newPrev int32) {
+	if node.hashListPrev != -1 {
+		prevNode := m.getNode(node.hashListPrev)
+		prevNode.hashListNext = newNext
 	} else {
 		m.hashSlotHead[node.hash] = newNext
 	}
 
-	if node.hashListNext != nil {
-		node.hashListNext.hashListPrev = newPrev
+	if node.hashListNext != -1 {
+		nextNode := m.getNode(node.hashListNext)
+		nextNode.hashListPrev = newPrev
 	}
 }
 
-func (m *U128LRU) removeNodeFromTimeList(node, newNext, newPrev *u128LRUNode) {
-	prevNode := node.timeListPrev
-	if prevNode != nil {
+func (m *U128LRU) removeNodeFromTimeList(node *u128LRUNode, newNext, newPrev int32) {
+	if node.timeListPrev != -1 {
+		prevNode := m.getNode(node.timeListPrev)
 		prevNode.timeListNext = newNext
 	} else {
 		m.timeListHead = newNext
 	}
 
-	nextNode := node.timeListNext
-	if nextNode != nil {
+	if node.timeListNext != -1 {
+		nextNode := m.getNode(node.timeListNext)
 		nextNode.timeListPrev = newPrev
 	} else {
 		m.timeListTail = newPrev
 	}
 }
 
-func (m *U128LRU) removeNode(node *u128LRUNode) {
+func (m *U128LRU) removeNode(node *u128LRUNode, nodeIndex int32) {
 	// 从哈希链表、时间链表中删除
 	m.removeNodeFromHashList(node, node.hashListNext, node.hashListPrev)
 	m.removeNodeFromTimeList(node, node.timeListNext, node.timeListPrev)
 
 	// 将节点交换至buffer头部
-	if node.index != m.bufferStartIndex {
+	if nodeIndex != m.bufferStartIndex {
 		firstNode := m.getNode(m.bufferStartIndex)
 		// 将firstNode内容拷贝至node
 		*node = *firstNode
 		// 修改firstNode在哈希链、时间链的上下游指向node
-		m.removeNodeFromHashList(firstNode, node, node)
-		m.removeNodeFromTimeList(firstNode, node, node)
+		m.removeNodeFromHashList(firstNode, nodeIndex, nodeIndex)
+		m.removeNodeFromTimeList(firstNode, nodeIndex, nodeIndex)
 		// 将firstNode初始化
 		*firstNode = blankU128LRUNodeForInit
 	} else {
@@ -195,18 +196,19 @@ func (m *U128LRU) removeNode(node *u128LRUNode) {
 	m.size--
 }
 
-func (m *U128LRU) updateNode(node *u128LRUNode, value interface{}) {
-	if node != m.timeListHead {
+func (m *U128LRU) updateNode(node *u128LRUNode, nodeIndex int32, value interface{}) {
+	if nodeIndex != m.timeListHead {
 		// 从时间链表中删除
 		m.removeNodeFromTimeList(node, node.timeListNext, node.timeListPrev)
 		// 插入时间链表头部
-		m.pushNodeToTimeList(node, node.index)
+		m.pushNodeToTimeList(node, nodeIndex)
 	}
-	if node != m.hashSlotHead[node.hash] {
+	// move the hit node to the head of the hash list, so that it can be hit quickly in the next query.
+	if nodeIndex != m.hashSlotHead[node.hash] {
 		// 从hash链表中删除
 		m.removeNodeFromHashList(node, node.hashListNext, node.hashListPrev)
 		// 插入到hash链表头部
-		m.pushNodeToHashList(node, node.hash)
+		m.pushNodeToHashList(node, nodeIndex, node.hash)
 	}
 
 	node.value = value
@@ -215,7 +217,8 @@ func (m *U128LRU) updateNode(node *u128LRUNode, value interface{}) {
 func (m *U128LRU) newNode(key0, key1 uint64, value interface{}, hash int32) {
 	// buffer空间检查
 	if m.size >= m.capacity {
-		m.removeNode(m.timeListTail)
+		node := m.getNode(m.timeListTail)
+		m.removeNode(node, m.timeListTail)
 	}
 	row := m.bufferEndIndex >> _BLOCK_SIZE_BITS
 	col := m.bufferEndIndex & _BLOCK_SIZE_MASK
@@ -226,7 +229,7 @@ func (m *U128LRU) newNode(key0, key1 uint64, value interface{}, hash int32) {
 	m.size++
 
 	// 新节点加入哈希链
-	m.pushNodeToHashList(node, hash)
+	m.pushNodeToHashList(node, m.bufferEndIndex, hash)
 	// 新节点加入时间链
 	m.pushNodeToTimeList(node, m.bufferEndIndex)
 	// 更新key、value
@@ -234,7 +237,6 @@ func (m *U128LRU) newNode(key0, key1 uint64, value interface{}, hash int32) {
 	node.key1 = key1
 	node.value = value
 	node.hash = hash
-	node.index = m.bufferEndIndex
 
 	// 更新buffer信息
 	m.bufferEndIndex = m.incIndex(m.bufferEndIndex)
@@ -251,20 +253,35 @@ func (m *U128LRU) GetCounter() interface{} {
 }
 
 func (m *U128LRU) Add(key0, key1 uint64, value interface{}) {
-	node, slot := m.find(key0, key1, true)
+	node, nodeIndex := m.find(key0, key1, true)
 	if node != nil {
-		m.updateNode(node, value)
+		m.updateNode(node, nodeIndex, value)
 		return
 	}
+
+	hash := m.compressHash(key0, key1)
+	m.newNode(key0, key1, value, hash)
+}
+
+func (m *U128LRU) AddOrGet(key0, key1 uint64, value interface{}) *interface{} {
+	node, nodeIndex := m.find(key0, key1, true)
+	if node != nil {
+		m.updateNode(node, nodeIndex, node.value) // do not change value
+		return &node.value
+	}
+	slot := m.compressHash(key0, key1)
 	m.newNode(key0, key1, value, slot)
+	return nil
 }
 
 func (m *U128LRU) Remove(key0, key1 uint64) {
-	for node := m.hashSlotHead[m.compressHash(key0, key1)]; node != nil; node = node.hashListNext {
+	for hashListNext := m.hashSlotHead[m.compressHash(key0, key1)]; hashListNext != -1; {
+		node := m.getNode(hashListNext)
 		if node.key0 == key0 && node.key1 == key1 {
-			m.removeNode(node)
+			m.removeNode(node, hashListNext)
 			return
 		}
+		hashListNext = node.hashListNext
 	}
 }
 
@@ -272,7 +289,8 @@ func (m *U128LRU) find(key0, key1 uint64, isAdd bool) (*u128LRUNode, int32) {
 	m.counter.scanTimes++
 	width := 0
 	slot := m.compressHash(key0, key1)
-	for node := m.hashSlotHead[slot]; node != nil; node = node.hashListNext {
+	for hashListNext := m.hashSlotHead[slot]; hashListNext != -1; {
+		node := m.getNode(hashListNext)
 		width++
 		if node.key0 == key0 && node.key1 == key1 {
 			m.counter.totalScan += width
@@ -289,8 +307,9 @@ func (m *U128LRU) find(key0, key1 uint64, isAdd bool) (*u128LRUNode, int32) {
 				}
 			}
 			m.counter.Hit++
-			return node, slot
+			return node, hashListNext
 		}
+		hashListNext = node.hashListNext
 	}
 	m.counter.Miss++
 	m.counter.totalScan += width
@@ -315,17 +334,19 @@ func (m *U128LRU) find(key0, key1 uint64, isAdd bool) (*u128LRUNode, int32) {
 			atomic.StoreUint32(&m.debugChainRead, 0)
 		}
 	}
-	return nil, slot
+	return nil, -1
 }
 
 func (m *U128LRU) generateCollisionChainIn(bs []byte, index int32) {
 	offset := 0
 	bsLen := len(bs)
 
-	for node := m.hashSlotHead[index]; node != nil && offset < bsLen; node = node.hashListNext {
+	for hashListNext := m.hashSlotHead[index]; hashListNext != -1 && offset < bsLen; {
+		node := m.getNode(hashListNext)
 		binary.BigEndian.PutUint64(bs[offset:], node.key0)
 		binary.BigEndian.PutUint64(bs[offset+8:], node.key1)
 		offset += m.KeySize()
+		hashListNext = node.hashListNext
 	}
 }
 
@@ -350,10 +371,10 @@ func (m *U128LRU) SetCollisionChainDebugThreshold(t int) {
 }
 
 func (m *U128LRU) Get(key0, key1 uint64, peek bool) (interface{}, bool) {
-	node, _ := m.find(key0, key1, false)
+	node, nodeIndex := m.find(key0, key1, false)
 	if node != nil {
 		if !peek {
-			m.updateNode(node, node.value)
+			m.updateNode(node, nodeIndex, node.value)
 		}
 		return node.value, true
 	}
@@ -374,10 +395,10 @@ func (m *U128LRU) Clear() {
 	m.bufferEndIndex = 0
 
 	for i := range m.hashSlotHead {
-		m.hashSlotHead[i] = nil
+		m.hashSlotHead[i] = -1
 	}
-	m.timeListHead = nil
-	m.timeListTail = nil
+	m.timeListHead = -1
+	m.timeListTail = -1
 
 	m.size = 0
 
@@ -391,8 +412,10 @@ func (m *U128LRU) compressHash(key0, key1 uint64) int32 {
 type walkCallback func(key0, key1 uint64, value interface{})
 
 func (m *U128LRU) Walk(callback walkCallback) {
-	for node := m.timeListHead; node != nil; node = node.timeListNext {
+	for i := m.timeListHead; i != -1; {
+		node := m.getNode(i)
 		callback(node.key0, node.key1, node.value)
+		i = node.timeListNext
 	}
 }
 
@@ -417,16 +440,16 @@ func NewU128LRUNoStats(module string, hashSlots, capacity int) *U128LRU {
 		ringBuffer:   make([]u128LRUNodeBlock, (capacity+_BLOCK_SIZE)/_BLOCK_SIZE+1),
 		hashSlots:    int32(hashSlots),
 		hashSlotBits: uint32(hashSlotBits),
-		hashSlotHead: make([]*u128LRUNode, hashSlots),
-		timeListHead: nil,
-		timeListTail: nil,
+		hashSlotHead: make([]int32, hashSlots),
+		timeListHead: -1,
+		timeListTail: -1,
 		capacity:     capacity,
 		counter:      &Counter{},
 		id:           "lru128-" + module,
 	}
 
 	for i := range m.hashSlotHead {
-		m.hashSlotHead[i] = nil
+		m.hashSlotHead[i] = -1
 	}
 
 	return m


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- libs

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

### Improves the performance of libs/hmap/lru

The increase of pointers will lead to an increase in GC pressure. If a structure contains too many pointers, it will cause a particularly serious CPU burst phenomenon. After observing this behavior, we rolled back an optimization from three years ago (internal link):

https://gitlab.yunshan.net/yunshan/droplet-libs/-/merge_requests/1230

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


