### PR TITLE
[Agent] Fixed an issue where cgroup was cleared when systemctl daemon-reload #20327

### DIFF
--- a/agent/pkg/deepflow-agent.service
+++ b/agent/pkg/deepflow-agent.service
@@ -3,6 +3,7 @@ Description=deepflow-agent.service
 After=syslog.target network-online.target
 
 [Service]
+Delegate=true
 Environment=GOTRACEBACK=single
 Environment=RUST_BACKTRACE=1
 LimitCORE=1G

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -489,7 +489,7 @@ impl Trident {
                         libvirt_xml_extractor.stop();
                         if let Some(cg_controller) = cgroups_controller {
                             if let Err(e) = cg_controller.stop() {
-                                warn!("stop cgroup controller failed, {:?}", e);
+                                info!("stop cgroup controller failed, {:?}", e);
                             }
                         }
                     }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixed an issue where cgroup was cleared when systemctl daemon-reload #20327
#### Steps to reproduce the bug
- run  `systemctl daemon-reload`
#### Changes to fix the bug
- add `Delegate=true` to deepflow-agent.service
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
