### PR TITLE
[Agent] Fixes the inconsistency between the rrt_max of metrics of otel data and the rrt_max of l7_flow_log #20752

### DIFF
--- a/agent/src/collector/acc_flow.rs
+++ b/agent/src/collector/acc_flow.rs
@@ -85,14 +85,14 @@ impl AccumulatedFlow {
         // 1. unknown协议可以被任何协议覆盖
         // 2. other可以被其他非unknown协议覆盖
         if let Some(other_stats) = tagged_flow.flow.flow_perf_stats.as_ref() {
-            if self.l7_protocol == L7Protocol::Unknown
+            if other_stats.l7_protocol == self.l7_protocol {
+                self.app_meter.sequential_merge(app_meter);
+            } else if self.l7_protocol == L7Protocol::Unknown
                 || (self.l7_protocol == L7Protocol::Other
                     && other_stats.l7_protocol != L7Protocol::Unknown)
             {
                 self.l7_protocol = other_stats.l7_protocol;
                 self.app_meter = *app_meter;
-            } else if other_stats.l7_protocol == self.l7_protocol {
-                self.app_meter.sequential_merge(app_meter);
             }
         }
     }

--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -438,9 +438,9 @@ fn fill_tagged_flow(
     let start_time = span.start_time_unix_nano;
     let end_time = span.end_time_unix_nano;
     if time_diff >= 0 {
-        tagged_flow.flow.flow_stat_time = Timestamp::from_nanos(start_time + time_diff as u64);
+        tagged_flow.flow.flow_stat_time = Timestamp::from_nanos(end_time + time_diff as u64);
     } else {
-        tagged_flow.flow.flow_stat_time = Timestamp::from_nanos(start_time - -time_diff as u64);
+        tagged_flow.flow.flow_stat_time = Timestamp::from_nanos(end_time - -time_diff as u64);
     }
     let rrt = if end_time > start_time {
         (end_time - start_time) / 1000 // unit: μs


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the inconsistency between the rrt_max of metrics of otel data and the rrt_max of l7_flow_log
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
