### PR TITLE
[server] fix perf_event table name wrong in flow tag

### DIFF
--- a/server/ingester/event/dbwriter/event.go
+++ b/server/ingester/event/dbwriter/event.go
@@ -137,6 +137,13 @@ func (e *EventStore) WriteBlock(block *ckdb.Block) {
 	}
 }
 
+func (e *EventStore) Table() string {
+	if e.HasMetrics {
+		return PERF_EVENT_TABLE
+	}
+	return EVENT_TABLE
+}
+
 func (e *EventStore) Release() {
 	ReleaseEventStore(e)
 }
@@ -223,7 +230,7 @@ func (e *EventStore) GenerateNewFlowTags(cache *flow_tag.FlowTagCache) {
 	// reset temporary buffers
 	flowTagInfo := &cache.FlowTagInfoBuffer
 	*flowTagInfo = flow_tag.FlowTagInfo{
-		Table:   EVENT_TABLE,
+		Table:   e.Table(),
 		VpcId:   e.L3EpcID,
 		PodNsId: e.PodNSID,
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on Linux 5.2+.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


