### PR TITLE
[CONTROLLER/DB] add primary key for table db_version

### DIFF
--- a/server/controller/db/mysql/migration/rawsql/init.sql
+++ b/server/controller/db/mysql/migration/rawsql/init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS db_version (
-    version             CHAR(64),
+    version             CHAR(64) PRIMARY KEY,
     created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )ENGINE=innodb DEFAULT CHARSET=utf8;


### PR DESCRIPTION
### This PR is for:
- Server

### Fixes db init error
#### Steps to reproduce the bug
- init db in MySQL Group Replication
#### Changes to fix the bug
- add primary key for table db_version
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.