### PR TITLE
[CONTROLLER/DB] add primary key for table db version #20806

### DIFF
--- a/server/controller/db/mysql/migration/rawsql/init.sql
+++ b/server/controller/db/mysql/migration/rawsql/init.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS db_version (
-    version             CHAR(64),
+    version             CHAR(64) PRIMARY KEY,
     created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          DATETIME NOT NULL ON UPDATE CURRENT_TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 )ENGINE=innodb DEFAULT CHARSET=utf8;

--- a/server/controller/db/mysql/migration/rawsql/issu/6.1.8.16.sql
+++ b/server/controller/db/mysql/migration/rawsql/issu/6.1.8.16.sql
@@ -1,1 +1,3 @@
 ALTER TABLE pod_service ADD COLUMN label TEXT COMMENT 'separated by ,';
+
+UPDATE db_version SET version='6.1.8.16';

--- a/server/controller/db/mysql/migration/rawsql/issu/6.1.8.17.sql
+++ b/server/controller/db/mysql/migration/rawsql/issu/6.1.8.17.sql
@@ -1,0 +1,3 @@
+ALTER TABLE db_version ADD PRIMARY KEY (version);
+
+UPDATE db_version SET version='6.1.8.17';

--- a/server/controller/db/mysql/migration/version.go
+++ b/server/controller/db/mysql/migration/version.go
@@ -18,5 +18,5 @@ package migration
 
 const (
 	DB_VERSION_TABLE    = "db_version"
-	DB_VERSION_EXPECTED = "6.1.8.16"
+	DB_VERSION_EXPECTED = "6.1.8.17"
 )


### PR DESCRIPTION
### This PR is for:
- Server

### Fixes mysql init error
#### Steps to reproduce the bug
- init group replication mysql
#### Changes to fix the bug
- add primary key for table db version
#### Affected branches
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.