### PR TITLE
[eBPF] Fixed a memory leak during uprobes processing

### DIFF
--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -772,6 +772,16 @@ static struct proc_info *find_proc_info(int pid)
 	return NULL;
 }
 
+static void free_proc_info(struct proc_info *p_info)
+{
+	// Free memory occupied by structure members.
+	if (p_info->path != NULL) {
+		free(p_info->path);
+	}
+
+	free(p_info);
+}
+
 /*
  * Clear all probes, if probe->pid == pid
  */
@@ -786,7 +796,7 @@ static void clear_probes_by_pid(struct bpf_tracer *tracer, int pid,
 	struct proc_info *p_info = find_proc_info(pid);
 	if (p_info) {
 		list_head_del(&p_info->list);
-		free(p_info);
+		free_proc_info(p_info);
 	}
 
 	list_for_each_safe(p, n, &tracer->probes_head) {


### PR DESCRIPTION
A stable running Golang program (which has been running for at least 60 seconds) was probed and tracked by an agent using eBPF. If this Golang program exits, it will cause a memory leak. The reason for the memory leak is that when releasing the memory of the 'proc_info' (process information) structure during program exit, the memory occupied by the 'path' member (uprobe file path) inside the structure is not released, resulting in an average of about 60 bytes of memory leak. This patch fixes this bug.



### This PR is for:


- Agent



#### Affected branches
- main
- 6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
 

