### PR TITLE
[eBPF] Disable io event update go tracing map

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -207,7 +207,6 @@ http2_fill_common_socket_1(struct http2_header_data *data,
 	__u64 id = bpf_get_current_pid_tgid();
 	// source, coroutine_id, timestamp, comm
 	send_buffer->source = DATA_SOURCE_GO_HTTP2_UPROBE;
-	send_buffer->coroutine_id = get_current_goroutine();
 	send_buffer->timestamp = bpf_ktime_get_ns();
 	bpf_get_current_comm(send_buffer->comm, sizeof(send_buffer->comm));
 
@@ -337,7 +336,7 @@ http2_fill_common_socket_2(struct http2_header_data *data,
 	}
 
 	__u32 timeout = trace_conf->go_tracing_timeout;
-	struct trace_key_t trace_key = get_trace_key(timeout);
+	struct trace_key_t trace_key = get_trace_key(timeout, true);
 	struct trace_info_t *trace_info_ptr = trace_map__lookup(&trace_key);
 
 	struct conn_info_t conn_info = {
@@ -353,6 +352,7 @@ http2_fill_common_socket_2(struct http2_header_data *data,
 			      send_buffer->timestamp, &trace_key);
 	}
 
+	send_buffer->coroutine_id = trace_key.goid;
 	send_buffer->pid = (__u32)id;
 	return true;
 }

--- a/agent/src/ebpf/samples/rust/src/main.rs
+++ b/agent/src/ebpf/samples/rust/src/main.rs
@@ -283,12 +283,10 @@ fn main() {
 
         set_io_event_collect_mode(1);
 
-        // Normal operating systems rarely have file io exceeding 1ms.
-        // Adjust the time to 1000 nanoseconds during the test
-        set_io_event_minimal_duration(1000);
+        set_io_event_minimal_duration(1000000);
 
         // enable go auto traceing,
-        set_go_tracing_timeout(1);
+        set_go_tracing_timeout(120);
 
         /*
             let allow_port = 443;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes IO events break Go trace key
#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.


### Report the Go goroutine number used for tracking, not the real goroutine number
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
