### PR TITLE
[Agent] Fixes empty server_port in vtap_app_port #20828

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -604,8 +604,8 @@ impl Stash {
             tap_side: TapSide::from(direction),
             tap_port: flow_key.tap_port,
             tap_type: flow_key.tap_type,
-            // 资源位于客户端时，忽略服务端口
-            server_port: if ep == 0
+            // If the resource is located on the client, the service port is ignored, except flow, which belongs to LocalToLocal
+            server_port: if (ep == 0 && direction != Direction::LocalToLocal)
                 || Self::ignore_server_port(
                     flow,
                     self.context.config.load().inactive_server_port_enabled,


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes empty server_port in vtap_app_port #20828
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
