### PR TITLE
[server] fix parent_span_id field error when flow log to otlp

### DIFF
--- a/server/ingester/flow_log/exporter/otlp.go
+++ b/server/ingester/flow_log/exporter/otlp.go
@@ -117,7 +117,7 @@ func L7FlowLogToExportRequest(l7 *log_data.L7FlowLog, universalTagsManager *Univ
 			if parentSpanId, err := hex.DecodeString(l7.ParentSpanId); err != nil {
 				id := [8]byte{}
 				copy(id[:], parentSpanId)
-				span.SetSpanID(pcommon.SpanID(id))
+				span.SetParentSpanID(pcommon.SpanID(id))
 			}
 			span.SetKind(ptrace.SpanKind(l7.SpanKind))
 		} else {


### PR DESCRIPTION

### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- There are no steps to reproduce, it should be a problem if you see the code

#### Changes to fix the bug
- Fixed a possible spelling issue

#### Affected branches
- main
#### Checklist
- [x] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.

