### PR TITLE
[eBPF] Disable DNS AAAA record tracking

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -816,6 +816,18 @@ static __inline enum message_type infer_dns_message(const char *buf,
 		return MSG_UNKNOWN;
 	}
 
+	// FIXME: Remove this code when the call chain can correctly handle the
+	// Go DNS case.
+	__u8 *queries_start = (__u8 *)(dns + 1);
+	conn_info->dns_q_type = 0;
+	for (int idx = 0; idx < 32; ++idx) {
+		if (queries_start[idx] == 0) {
+			conn_info->dns_q_type = __bpf_ntohs(
+				*(__u16 *)(queries_start + idx + 1));
+			break;
+		}
+	}
+
 	return (qr == 0) ? MSG_REQUEST : MSG_RESPONSE;
 }
 

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -149,6 +149,30 @@ struct conn_info_t {
 	__s32 correlation_id; // 目前用于kafka判断
 	enum traffic_direction prev_direction;
 	struct socket_info_t *socket_info_ptr; /* lookup __socket_info_map */
+
+	/*
+	The matching logic is:
+
+	DNS 1 req ---->
+	DNS 1 res <-------
+	DNS 2 req ----> ​
+	DNS 2 res <-------
+
+	and now it is
+
+	DNS 1 req ---->
+	DNS 2 req ---->
+	DNS 1 res <-------
+	DNS 2 res <-------
+
+	Such a scene affects the whole tracking
+
+	DNS 1 req is IPV6, DNS 2 req is IPV4
+	*/
+	// FIXME: Remove this field when the call chain can correctly handle
+	// the Go DNS case. Parse DNS save record type and ignore AAAA records
+	// in call chain trace
+	__u16 dns_q_type;
 };
 
 enum process_data_extra_source {

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1053,9 +1053,17 @@ __data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 		socket_id = socket_info_ptr->uid;
 	}
 
+#define DNS_AAAA_TYPE_ID 0x1c
+	// FIXME: By default, the Go process continuously sends A record and
+	// AAAA record DNS request messages. In the current call chain tracking
+	// implementation, two consecutive request messages before receiving
+	// the response message will cause the link to be broken. Ignore the
+	// AAAA record To ensure that the call chain will not be broken.
 	if (conn_info->message_type != MSG_PRESTORE &&
 	    conn_info->message_type != MSG_RECONFIRM &&
-	    (timeout != 0 || extra->is_go_process == false))
+	    (timeout != 0 || extra->is_go_process == false) &&
+	    !(conn_info->protocol == PROTO_DNS &&
+	      conn_info->dns_q_type == DNS_AAAA_TYPE_ID))
 		trace_process(socket_info_ptr, conn_info, socket_id, pid_tgid,
 			      trace_info_ptr, trace_conf, trace_stats,
 			      &thread_trace_id, time_stamp, &trace_key);


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes When the Go process requests the IPv4 and IPv6 addresses of the domain name at the same time, the call chain is broken
#### Steps to reproduce the bug

#### Changes to fix the bug

- DNS requests for IPv6 are not tracked

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
