### PR TITLE
[eBPF] Revert go-tracing-timeout configuration to 120 seconds

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -294,7 +294,7 @@ impl Default for EbpfYamlConfig {
             socket_map_max_reclaim: 520000,
             kprobe_whitelist: EbpfKprobeWhitelist::default(),
             uprobe_proc_regexp: UprobeProcRegExp::default(),
-            go_tracing_timeout: 0,
+            go_tracing_timeout: 120,
             io_event_collect_mode: 1,
             io_event_minimal_duration: Duration::from_millis(1),
         }

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -81,7 +81,7 @@ enum {
 #define PROC_EVENT_DELAY_HANDLE_DEF     60
 
 // seconds
-#define GO_TRACING_TIMEOUT_DEFAULT      0
+#define GO_TRACING_TIMEOUT_DEFAULT      120
 
 #define SK_TRACER_NAME			"socket-trace"
 

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -936,10 +936,10 @@ vtap_group_id: g-xxxxxx
     #max-trace-entries: 524288
 
     ## eBPF go trace timeout
-    ## Default: 0 second[s]. Range: [0, +]
+    ## Default: 120 second[s]. Range: [0, +]
     ## Note: The expected maximum time interval between the server receiving the request and returning the response,
     ##   If the value is 0, this feature is disabled. Tracing only considers the thread number.
-    #go-tracing-timeout: 0
+    #go-tracing-timeout: 120
 
     ## eBPF IO event collect mode
     ## Default: 1 . Range: [0, 1, 2]


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes Revert go-tracing-timeout configuration to 120 seconds

#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.