### PR TITLE
[server] fix gRPC request case panic

### DIFF
--- a/server/ingester/event/decoder/grpc_resource_info.go
+++ b/server/ingester/event/decoder/grpc_resource_info.go
@@ -91,7 +91,6 @@ func NewResourceInfoTable(ips []net.IP, port, rpcMaxMsgSize int) *ResourceInfoTa
 	info.GrpcSession.Init(ips, uint16(port), grpc.DEFAULT_SYNC_INTERVAL, rpcMaxMsgSize, runOnce)
 	info.Reload()
 	log.Infof("New ResourceInfoTable ips:%v port:%d rpcMaxMsgSize:%d", ips, port, rpcMaxMsgSize)
-	info.GrpcSession.Start()
 	return info
 }
 
@@ -113,7 +112,11 @@ func (p *ResourceInfoTable) Reload() error {
 			CtrlIp:              proto.String(p.ctlIP),
 			ProcessName:         proto.String("resource-info-watcher"),
 		}
-		client := trident.NewSynchronizerClient(p.GrpcSession.GetClient())
+		c := p.GrpcSession.GetClient()
+		if c == nil {
+			return fmt.Errorf("can't get grpc client to %s", remote)
+		}
+		client := trident.NewSynchronizerClient(c)
 		response, err = client.AnalyzerSync(ctx, &request)
 		return err
 	})

--- a/server/libs/grpc/grpc_session.go
+++ b/server/libs/grpc/grpc_session.go
@@ -95,7 +95,9 @@ func (s *GrpcSession) Request(syncFunction SyncFunction) error {
 				s.synchronized = false
 				log.Warningf("Sync from server %s failed, reason: %s", s.ips[s.ipIndex], err.Error())
 			}
-			s.nextServer()
+			if err := s.nextServer(); err != nil {
+				return err
+			}
 			continue
 		}
 		if !s.synchronized {


### PR DESCRIPTION
fix to start 2 rpc request instances, if one connection fails, another connection may cause a null pointer exception

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server
- Libs



### Fixes  to start 2 rpc request instances, if one connection fails, another connection may cause a null pointer exception

#### Affected branches
- main
- v6.1

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


