### PR TITLE
[eBPF] Let the plus operation of capture-sequence is atomic

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -95,8 +95,14 @@ struct trace_stats {
 };
 
 struct socket_info_t {
-	__u64 l7_proto: 8;
-	__u64 seq: 56; // socket 读写数据的序列号，用于排序
+	__u64 l7_proto;
+	/*
+	 * The serial number of the socket read and write data, used to
+	 * correct out-of-sequence.
+	 *
+	 * socket读写数据的序列号，用于纠正数据乱序。
+	 */
+	volatile __u64 seq;
 
 	/*
 	 * mysql, kafka这种类型在读取数据时，先读取4字节


### PR DESCRIPTION
Ensure that the accumulation operation of capturing the data sequence number is an atomic operation when multiple threads read/write to the socket simultaneously.



### This PR is for:


- Agent


#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.

