### PR TITLE
[Agent] fixes wrong server_port in vtap_app_port #20932

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -612,9 +612,8 @@ impl Stash {
             tap_side: TapSide::from(direction),
             tap_port: flow_key.tap_port,
             tap_type: flow_key.tap_type,
-            // If the resource is located on the client, the service port is ignored,
-            // the flow whose server and client belong to the same mac address is excluded
-            server_port: if (ep == 0 && flow.flow_key.mac_src != flow.flow_key.mac_dst)
+            // If the resource is located on the client, the service port is ignored
+            server_port: if ep == FLOW_METRICS_PEER_SRC
                 || Self::ignore_server_port(
                     flow,
                     self.context.config.load().inactive_server_port_enabled,

--- a/agent/src/common/flow.rs
+++ b/agent/src/common/flow.rs
@@ -1031,7 +1031,7 @@ pub fn get_direction(
     } else if flow.flow_key.mac_src == flow.flow_key.mac_dst
         && (is_tt_pod(trident_type) || is_tt_workload(trident_type))
     {
-        return (Direction::LocalToLocal, Direction::None, false);
+        return (Direction::None, Direction::LocalToLocal, false);
     }
 
     // 返回值分别为统计点对应的zerodoc.DirectionEnum以及及是否添加追踪数据的开关，在微软
@@ -1393,7 +1393,7 @@ pub fn get_direction(
             | TridentType::TtPhysicalMachine
             | TridentType::TtHostPod
             | TridentType::TtVmPod => {
-                return (Direction::LocalToLocal, Direction::None, false);
+                return (Direction::None, Direction::LocalToLocal, false);
             }
             _ => (),
         }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes  wrong server_port in vtap_app_port #20932
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.2
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
