### PR TITLE
[server] when resource_event not match any resource info, fill with o…

### DIFF
--- a/server/ingester/event/decoder/decoder.go
+++ b/server/ingester/event/decoder/decoder.go
@@ -242,7 +242,6 @@ func (d *Decoder) handleResourceEvent(event *eventapi.ResourceEvent) {
 			strings.Join(event.AttributeIPs, SEPARATOR))
 
 	}
-	eventStore.AutoInstanceID, eventStore.AutoInstanceType = getAutoInstance(event.InstanceID, event.InstanceType, event.GProcessID)
 
 	if event.IfNeedTagged {
 		eventStore.Tagged = 1
@@ -280,9 +279,9 @@ func (d *Decoder) handleResourceEvent(event *eventapi.ResourceEvent) {
 
 	}
 	eventStore.SubnetID = uint16(event.SubnetID)
+	eventStore.IsIPv4 = true
 	if ip := net.ParseIP(event.IP); ip != nil {
 		if ip4 := ip.To4(); ip4 != nil {
-			eventStore.IsIPv4 = true
 			eventStore.IP4 = utils.IpToUint32(ip4)
 		} else {
 			eventStore.IsIPv4 = false
@@ -298,6 +297,11 @@ func (d *Decoder) handleResourceEvent(event *eventapi.ResourceEvent) {
 			eventStore.L3DeviceType,
 			eventStore.L3EpcID,
 		)
+	// if resource information is not matched, it will be filled with event(InstanceID, InstanceType, GProcessID) information
+	if eventStore.AutoInstanceID == 0 {
+		eventStore.AutoInstanceID, eventStore.AutoInstanceType = getAutoInstance(event.InstanceID, event.InstanceType, event.GProcessID)
+	}
+
 	if event.InstanceType == uint32(trident.DeviceType_DEVICE_TYPE_POD_SERVICE) {
 		eventStore.ServiceID = event.InstanceID
 	}


### PR DESCRIPTION
…rigin event info #20994

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


### when resource_event not match any resource info, fill with origin event instance info

#### Affected branches
- main
- v6.2


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


