### PR TITLE
[queirer] add promql monitoring

### DIFF
--- a/cli/ctl/cli.go
+++ b/cli/ctl/cli.go
@@ -64,6 +64,7 @@ func Execute(version string) {
 	root.AddCommand(RegisterRepoCommand())
 	root.AddCommand(RegisterPluginCommand())
 	root.AddCommand(RegisterPrometheusCacheCommand())
+	root.AddCommand(RegisterPromQLCommand())
 
 	cmd.RegisterIngesterCommand(root)
 

--- a/cli/ctl/promql.go
+++ b/cli/ctl/promql.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ctl
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/deepflowio/deepflow/cli/ctl/common"
+	"github.com/deepflowio/deepflow/cli/ctl/common/table"
+	"github.com/spf13/cobra"
+)
+
+func RegisterPromQLCommand() *cobra.Command {
+	promql := &cobra.Command{
+		Use:   "promql",
+		Short: "promql stats",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("please run with 'stats'.")
+		},
+	}
+	promql.PersistentFlags().String("since", "1h", "analysis promql stats since time duration like [5s,1m,5m,1h], default: 1h")
+	promql.PersistentFlags().String("from", "", "analysis promql stats from a specific time(RFC3339), e.g.: 2000-01-01T00:00:00")
+	promql.PersistentFlags().String("to", "", "analysis promql stats to a specific time(RFC3339), e.g.: 2000-01-01T00:00:00")
+
+	promql.AddCommand(statsSubCommand())
+	promql.ParseFlags(os.Args[1:])
+	return promql
+}
+
+func statsSubCommand() *cobra.Command {
+	var metric string
+	var labelFlag bool
+	stats := &cobra.Command{
+		Use:   "stats",
+		Short: "stats --metric",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, to, err := getQueryTime(cmd)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "parse time error: %v\n", err)
+				return
+			}
+			var targetLabel, appLabel []string
+			if labelFlag {
+				targetLabel = []string{"*"}
+				appLabel = []string{"*"}
+			}
+			err = statsQuery(cmd, from, to, metric, targetLabel, appLabel)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "promql stats query error: %v\n", err)
+			}
+		},
+	}
+	stats.PersistentFlags().StringVarP(&metric, "metric", "m", "", "target metric name for stats analysis")
+	stats.PersistentFlags().BoolVarP(&labelFlag, "all-labels", "A", false, "query metric and all labels stats info")
+
+	var targetLabels []string
+	target := &cobra.Command{
+		Use:   "target",
+		Short: "stats target --target-labels",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, to, err := getQueryTime(cmd)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "parse time error: %v\n", err)
+				return
+			}
+			if len(targetLabels) == 0 {
+				targetLabels = []string{"*"}
+			}
+			err = statsQuery(cmd, from, to, metric, targetLabels, nil)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "promql stats query error: %v\n", err)
+			}
+		},
+	}
+	target.Flags().StringArrayVarP(&targetLabels, "target-labels", "l", nil, "specific target labels for stats analysis, default: [all]")
+	stats.AddCommand(target)
+
+	var appLabels []string
+	app := &cobra.Command{
+		Use:   "app",
+		Short: "stats app --app-labels",
+		Run: func(cmd *cobra.Command, args []string) {
+			from, to, err := getQueryTime(cmd)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "parse time error: %v\n", err)
+				return
+			}
+			if len(appLabels) == 0 {
+				appLabels = []string{"*"}
+			}
+			err = statsQuery(cmd, from, to, metric, nil, appLabels)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "promql stats query error: %v\n", err)
+			}
+		},
+	}
+	app.Flags().StringArrayVarP(&appLabels, "app-lables", "l", nil, "specific app labels for stats analysis, default: [all]")
+	stats.AddCommand(app)
+
+	return stats
+}
+
+func getQueryTime(cmd *cobra.Command) (int64, int64, error) {
+	since, _ := cmd.Flags().GetString("since")
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	var fromTime, toTime time.Time
+	var err error
+	// priority: from&to > since
+	if from != "" {
+		fromTime, err = time.Parse(time.RFC3339, from)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+	if to != "" {
+		toTime, err = time.Parse(time.RFC3339, to)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	// when and only when from&to are null, use --since time
+	if toTime.IsZero() && fromTime.IsZero() {
+		if since == "" {
+			since = "1h"
+		}
+		sinceDuration, err := time.ParseDuration(since)
+		if err != nil {
+			return 0, 0, err
+		}
+		fromTime = time.Now().Add(-sinceDuration)
+		toTime = time.Now()
+	}
+
+	if toTime.IsZero() {
+		toTime = time.Now()
+	}
+
+	if fromTime.IsZero() {
+		fromTime = toTime.Add(-1 * time.Hour)
+	}
+
+	if fromTime.After(toTime) {
+		return 0, 0, fmt.Errorf("query time from: %d should not greater than to: %d", fromTime.Unix(), toTime.Unix())
+	}
+
+	return fromTime.Unix(), toTime.Unix(), nil
+}
+
+func statsQuery(cmd *cobra.Command, from, to int64, metric string, targetLabels, appLabels []string) error {
+	server := common.GetServerInfo(cmd)
+	url := fmt.Sprintf("http://%s:%d/prom/api/v1/analysis?from=%d&to=%d", server.IP, server.Port, from, to)
+	if metric != "" {
+		url += fmt.Sprintf("&metric=%s", metric)
+	}
+	if len(targetLabels) > 0 {
+		url += fmt.Sprintf("&target=%s", strings.Join(targetLabels, ","))
+	}
+	if len(appLabels) > 0 {
+		url += fmt.Sprintf("&app=%s", strings.Join(appLabels, ","))
+	}
+	response, err := common.CURLPerform("GET", url, nil, "")
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	t := table.New()
+	t.SetHeader(response.Get("Columns").MustStringArray())
+	tableItems := make([][]string, 0, len(response.Get("Values").MustArray()))
+	var rowItems []string
+	for i := range response.Get("Values").MustArray() {
+		row := response.Get("Values").GetIndex(i)
+		rowItems = make([]string, 0, len(response.Get("Columns").MustStringArray()))
+		for k, v := range response.Get("Columns").MustStringArray() {
+			col := row.GetIndex(k)
+			var val string
+			switch strings.ToUpper(v) {
+			case "QUERY_COUNT":
+				val = strconv.Itoa(col.MustInt())
+			case "AVG_DURATION(MS)", "MAX_DURATION(MS)":
+				val = fmt.Sprintf("%f", col.MustFloat64())
+			default:
+				val = col.MustString()
+			}
+			rowItems = append(rowItems, val)
+		}
+		tableItems = append(tableItems, rowItems)
+	}
+	t.AppendBulk(tableItems)
+	t.Render()
+	return nil
+}

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -19,6 +19,7 @@ package config
 type Prometheus struct {
 	QPSLimit              int    `default:"100" yaml:"qps-limit"`
 	SeriesLimit           int    `default:"100" yaml:"series-limit"`
+	MaxSamples            int    `default:"50000000" yaml:"max-samples"`
 	AutoTaggingPrefix     string `default:"df_" yaml:"auto-tagging-prefix"`
 	RequestQueryWithDebug bool   `default:"false" yaml:"request-query-with-debug"`
 }

--- a/server/querier/app/prometheus/promql-prom-metrics-tests.yaml
+++ b/server/querier/app/prometheus/promql-prom-metrics-tests.yaml
@@ -98,7 +98,7 @@ test_cases:
     # Check that unary minus sets timestamps correctly.
     # TODO: Check this more systematically for every node type?
   - query: 'timestamp(-node_cpu_seconds_total)'
-  - query: 'node_cpu_seconds_totalnode_cpu_seconds_total{mode="system", cpu="0"} {{.binOp}} on(instance, job, mode) node_cpu_seconds_total{mode="system", cpu="0"}'
+  - query: 'node_cpu_seconds_total{mode="system", cpu="0"} {{.binOp}} on(instance, job, mode) node_cpu_seconds_total{mode="system", cpu="0"}'
     variant_args: ['binOp']
   - query: 'sum by(instance, mode) (node_cpu_seconds_total{mode="system", cpu="0"}) {{.binOp}} on(instance, mode) group_left(job) node_cpu_seconds_total{mode="system", cpu="0"}'
     variant_args: ['binOp']
@@ -222,3 +222,4 @@ test_cases:
   # Subqueries.
   - query: 'max_over_time((time() - max(node_cpu_seconds_total{mode="system", cpu="0"}) < 1000)[5m:10s] offset 5m)'
   - query: 'avg_over_time(rate(node_cpu_seconds_total{mode="system", cpu="0"}[1m])[2m:10s])'
+  

--- a/server/querier/app/prometheus/router/router.go
+++ b/server/querier/app/prometheus/router/router.go
@@ -30,13 +30,18 @@ func PrometheusRouter(e *gin.Engine) {
 	// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
 	service.QPSLeakyBucket.Init(uint64(config.Cfg.Prometheus.QPSLimit * 1000))
 
+	// only one instance during server lifetime
+	prometheusService := service.NewPrometheusService()
+
 	// api router for prometheus
-	e.POST("/api/v1/prom/read", promReader())
-	e.GET("/prom/api/v1/query", promQuery())
-	e.GET("/prom/api/v1/query_range", promQueryRange())
-	e.POST("/prom/api/v1/query", promQuery())
-	e.POST("/prom/api/v1/query_range", promQueryRange())
-	e.GET("/prom/api/v1/label/:labelName/values", promTagValuesReader())
-	e.GET("/prom/api/v1/series", promSeriesReader())
-	e.POST("/prom/api/v1/series", promSeriesReader())
+	e.POST("/api/v1/prom/read", promReader(prometheusService))
+	e.GET("/prom/api/v1/query", promQuery(prometheusService))
+	e.GET("/prom/api/v1/query_range", promQueryRange(prometheusService))
+	e.POST("/prom/api/v1/query", promQuery(prometheusService))
+	e.POST("/prom/api/v1/query_range", promQueryRange(prometheusService))
+	e.GET("/prom/api/v1/series", promSeriesReader(prometheusService))
+	e.POST("/prom/api/v1/series", promSeriesReader(prometheusService))
+	e.GET("/prom/api/v1/label/:labelName/values", promTagValuesReader(prometheusService))
+
+	e.GET("/prom/api/v1/analysis", promQLAnalysis(prometheusService))
 }

--- a/server/querier/app/prometheus/service/prom_logger.go
+++ b/server/querier/app/prometheus/service/prom_logger.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+)
+
+type prometheusLogger struct {
+	pool *sync.Pool
+}
+
+func newPrometheusLogger() *prometheusLogger {
+	return &prometheusLogger{
+		pool: &sync.Pool{
+			New: func() any {
+				return new(bytes.Buffer)
+			},
+		},
+	}
+}
+
+func (l *prometheusLogger) Log(keyvals ...interface{}) error {
+	if len(keyvals)%2 != 0 {
+		keyvals = append(keyvals, "") // to handle when len(keyvals) is odd
+	}
+	buf := l.pool.Get().(*bytes.Buffer)
+	buf.WriteString("prometheus engine runtime log: ")
+
+	for i := 0; i < len(keyvals); i += 2 {
+		fmt.Fprintf(buf, "[%s=%v]", keyvals[i], keyvals[i+1])
+	}
+	// use `debug` level here
+	log.Debug(buf.String())
+	buf.Reset()
+	l.pool.Put(buf)
+
+	return nil
+}

--- a/server/querier/app/prometheus/service/promql_analysis.go
+++ b/server/querier/app/prometheus/service/promql_analysis.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/deepflowio/deepflow/server/querier/common"
+)
+
+func (e *prometheusExecutor) promQLAnalysis(ctx context.Context, metric string, targetLabels []string, appLabels []string, startTime string, endTime string) (*common.Result, error) {
+	startMs, err := strconv.ParseInt(startTime, 10, 64)
+	if err != nil {
+		log.Error(err)
+		startMs = time.Now().Add(-5 * time.Minute).Unix()
+	}
+	endMs, err := strconv.ParseInt(endTime, 10, 64)
+	if err != nil {
+		log.Error(err)
+		endMs = time.Now().Unix()
+	}
+
+	field := []string{
+		"Sum(log_count) as `query_count`",
+		"Avg(response_duration)/1000 as `avg_duration(ms)`",
+		"Max(response_duration)/1000 as `max_duration(ms)`",
+		"`attribute.promql.query.metric.name` as `metric_name`",
+		"`attribute.promql.query.range` as `query_range`",
+	}
+	group := []string{"`metric_name`", "`query_range`"}
+
+	filters := []string{
+		fmt.Sprintf("time >= %d and time <= %d", startMs, endMs),
+		"endpoint like 'Prometheus*Query'",
+		"tap_port_type = 8",
+	}
+	if metric != "" {
+		filters = append(filters, fmt.Sprintf("`metric_name` = '%s'", metric))
+	}
+
+	if len(targetLabels) > 0 {
+		targetFilter := make([]string, 0, len(targetLabels))
+		for _, v := range targetLabels {
+			if v == "" {
+				continue
+			}
+			if v != "*" {
+				targetFilter = append(targetFilter, fmt.Sprintf("`target_labels` like '*%s*'", v))
+			}
+		}
+		if len(targetFilter) > 0 {
+			filters = append(filters, fmt.Sprintf("(%s)", strings.Join(targetFilter, " OR ")))
+		}
+		field = append(field, "`attribute.promql.query.metric.targetLabel` As `target_labels`")
+		group = append(group, "`target_labels`")
+	}
+
+	if len(appLabels) > 0 {
+		appFilter := make([]string, 0, len(appLabels))
+		for _, v := range appLabels {
+			if v == "" {
+				continue
+			}
+			if v != "*" {
+				appFilter = append(appFilter, fmt.Sprintf("`app_labels` like '*%s*'", v))
+			}
+		}
+		if len(appFilter) > 0 {
+			filters = append(filters, fmt.Sprintf("(%s)", strings.Join(appFilter, " OR ")))
+		}
+		field = append(field, "`attribute.promql.query.metric.appLabel` As `app_labels`")
+		group = append(group, "`app_labels`")
+	}
+
+	sql := fmt.Sprintf("select %s from %s where %s group by %s order by `query_count` desc limit %d",
+		strings.Join(field, ","),
+		"l7_flow_log",
+		strings.Join(filters, " AND "),
+		strings.Join(group, ","),
+		10000,
+	)
+	return queryDataExecute(ctx, sql, "flow_log", "")
+}

--- a/server/querier/app/prometheus/service/service.go
+++ b/server/querier/app/prometheus/service/service.go
@@ -18,28 +18,66 @@ package service
 
 import (
 	"context"
+	"time"
 
+	logging "github.com/op/go-logging"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql"
 
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
+	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/deepflowio/deepflow/server/querier/config"
 )
 
-func PromRemoteReadService(req *prompb.ReadRequest, ctx context.Context) (resp *prompb.ReadResponse, err error) {
-	return promReaderExecute(req, ctx)
+var log = logging.MustGetLogger("promethues")
+
+type PrometheusService struct {
+	// keep only 1 instance of prometheus engine during server lifetime
+	engine   *promql.Engine
+	executor *prometheusExecutor
 }
 
-func PromInstantQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return promQueryExecute(args, ctx)
+func NewPrometheusService() *PrometheusService {
+	// query.max-samples set to same default value in prometheus, ref settings: https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go#L407
+	return &PrometheusService{
+		engine: promql.NewEngine(promql.EngineOpts{
+			Logger:                   newPrometheusLogger(),
+			Reg:                      nil,
+			MaxSamples:               config.Cfg.Prometheus.MaxSamples,
+			Timeout:                  100 * time.Second,
+			NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
+			EnableAtModifier:         true,
+			EnableNegativeOffset:     true,
+			EnablePerStepStats:       true,
+		}),
+		executor: NewPrometheusExecutor(),
+	}
 }
 
-func PromRangeQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return promQueryRangeExecute(args, ctx)
+func (s *PrometheusService) PromRemoteReadService(req *prompb.ReadRequest, ctx context.Context) (resp *prompb.ReadResponse, err error) {
+	return s.executor.promRemoteReadExecute(ctx, req)
 }
 
-func PromLabelValuesService(args *model.PromMetaParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return getTagValues(args, ctx)
+func (s *PrometheusService) PromInstantQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
+	return s.executor.promQueryExecute(ctx, args, s.engine)
 }
 
-func PromSeriesQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return series(args, ctx)
+func (s *PrometheusService) PromRangeQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
+	return s.executor.promQueryRangeExecute(ctx, args, s.engine)
+}
+
+func (s *PrometheusService) PromLabelValuesService(args *model.PromMetaParams, ctx context.Context) (*model.PromQueryResponse, error) {
+	return s.executor.getTagValues(ctx, args)
+}
+
+func (s *PrometheusService) PromSeriesQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
+	return s.executor.series(ctx, args)
+}
+
+func (s *PrometheusService) PromQLAnalysis(ctx context.Context, metric string, targetLabels []string, appLabels []string, startTime string, endTime string) (*common.Result, error) {
+	return s.executor.promQLAnalysis(ctx, metric, targetLabels, appLabels, startTime, endTime)
+}
+
+func durationMilliseconds(d time.Duration) int64 {
+	return int64(d / (time.Millisecond / time.Nanosecond))
 }

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -246,6 +246,7 @@ querier:
   prometheus:
     qps-limit: 100 # setting to 0 means no limit
     series-limit: 10000
+    max-samples: 50000000
     auto-tagging-prefix: df_
     request-query-with-debug: true
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Add PromQL Monitoring
#### Checklist
- [X] Added unit test.
- [X] Add `Cli` and `Querier` modify

deepflow-ctl tools add such command to do analysis:
```bash
deepflow-ctl -i deepflow-server.deepflow --api-port 20416 promql stats # stats for all metric 
deepflow-ctl -i deepflow-server.deepflow --api-port 20416 promql stats --since 4h # stats for metric from 4h before to now
deepflow-ctl -i deepflow-server.deepflow --api-port 20416 promql stats -m $metric # stats for specific metric
deepflow-ctl -i deepflow-server.deepflow --api-port 20416 promql stats target -l $lables # stats for target_labels with specific label (default: all)
deepflow-ctl -i deepflow-server.deepflow --api-port 20416 promql stats app -l $lables # stats for target_labels with specific label (default: all)
```

`deepflow-ctl` analysis result like: 
![image](https://github.com/deepflowio/deepflow/assets/45836837/7af0dc13-2ef5-4e4e-9133-bf31dbece146)

