### PR TITLE
[Server] fix vtap group config 'ntp enabled'

### DIFF
--- a/server/controller/common/vtap_config.go
+++ b/server/controller/common/vtap_config.go
@@ -126,7 +126,7 @@ var (
 	DefaultTapMode                       = TAPMODE_LOCAL
 	DefaultThreadThreshold               = 500
 	DefaultProcessThreshold              = 10
-	DefaultNtpEnabled                    = 1
+	DefaultNtpEnabled                    = 0
 	DefaultL4PerformanceEnabled          = 1
 	DefaultPodClusterInternalIP          = 0
 	DefaultDomains                       = "0"


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

