### PR TITLE
[ingester] update profile judge nil

### DIFF
--- a/server/ingester/profile/dbwriter/profile.go
+++ b/server/ingester/profile/dbwriter/profile.go
@@ -289,9 +289,11 @@ func genID(time uint32, counter *uint32, vtapID uint16) uint64 {
 
 func (p *InProcessProfile) fillResource(vtapID uint32, platformData *grpc.PlatformInfoTable) {
 	vtapInfo := platformData.QueryVtapInfo(vtapID)
-	p.L3EpcID = vtapInfo.EpcId
-	var info *grpc.Info
+	if vtapInfo != nil {
+		p.L3EpcID = vtapInfo.EpcId
+	}
 
+	var info *grpc.Info
 	if p.IsIPv4 {
 		info = platformData.QueryIPV4Infos(p.L3EpcID, p.IP4)
 	} else {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes when upload server profile panic
#### Steps to reproduce the bug
- start server when vtap is not registet success, and enable server profile
#### Changes to fix the bug
- update profile fillResource judge vtapinfo is not nil
#### Affected branches
- main

