### PR TITLE
[querier] Fix the bug of swallowing the wrong #21063

### DIFF
--- a/server/querier/engine/clickhouse/client/client.go
+++ b/server/querier/engine/clickhouse/client/client.go
@@ -116,7 +116,6 @@ func (c *Client) DoQuery(params *QueryParams) (result *common.Result, err error)
 		ctx = context.Background()
 	}
 	rows, err := c.connection.Query(ctx, sqlstr)
-
 	c.Debug.Sql = sqlstr
 	if err != nil {
 		log.Errorf("query clickhouse Error: %s, sql: %s, query_uuid: %s", err, sqlstr, c.Debug.QueryUUID)
@@ -164,6 +163,13 @@ func (c *Client) DoQuery(params *QueryParams) (result *common.Result, err error)
 			columnSchemas[i].ValueType = valueType
 		}
 		values = append(values, record)
+	}
+	// Even if the query operation produces an error, it does not necessarily return an error in the'err 'parameter,
+	// so the return value of the'rows. Err () ' method must be checked to ensure that the query operation is successful
+	if err := rows.Err(); err != nil {
+		log.Errorf("query clickhouse Error: %s, sql: %s, query_uuid: %s", err, sqlstr, c.Debug.QueryUUID)
+		c.Debug.Error = fmt.Sprintf("%s", err)
+		return nil, err
 	}
 	queryTime := time.Since(start)
 	resRows := len(values)


### PR DESCRIPTION
- run automation test(querier_sql) pass

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


