### PR TITLE
[LIBS] Adding TotalTCPFlags to the metrics structure

### DIFF
--- a/server/libs/datatype/flow.go
+++ b/server/libs/datatype/flow.go
@@ -197,12 +197,13 @@ type FlowMetricsPeer struct {
 	TotalPacketCount uint64        // 整个Flow生命周期的统计量
 	First, Last      time.Duration // 整个Flow生命周期首包和尾包的时间戳
 
-	L3EpcID      int32
-	IsL2End      bool
-	IsL3End      bool
-	IsActiveHost bool
-	IsDevice     bool  // true表明是从平台数据中获取的
-	TCPFlags     uint8 // 所有TCP的Flags或运算
+	L3EpcID       int32
+	IsL2End       bool
+	IsL3End       bool
+	IsActiveHost  bool
+	IsDevice      bool  // true表明是从平台数据中获取的
+	TCPFlags      uint8 // 每个流统计周期的TCP Flags或运算
+	TotalTCPFlags uint8 // 整个Flow生命周期的TCP Flags或运算
 	// TODO: IsVIPInterface、IsVIP流日志没有存储，Encode\Decode可以不做
 	IsVIPInterface bool // 目前仅支持微软Mux设备，从grpc Interface中获取
 	IsVIP          bool // 从grpc cidr中获取


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Libs


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


