### PR TITLE
[message] add netns_id in platformData and processData

### DIFF
--- a/agent/src/platform/platform_synchronizer/linux.rs
+++ b/agent/src/platform/platform_synchronizer/linux.rs
@@ -574,6 +574,7 @@ impl PlatformSynchronizer {
                 ip: interface_info.ips.iter().map(ToString::to_string).collect(),
                 device_name: None,
                 netns: Some(interface_info.tap_ns.to_string()),
+                netns_id: Some(0 as u32), // FIXME: set real netns_id
             })
             .chain(
                 self_xml_interfaces
@@ -586,6 +587,7 @@ impl PlatformSynchronizer {
                         ip: vec![],
                         tap_index: None,
                         netns: None,
+                        netns_id: Some(0 as u32),
                     }),
             )
             .collect();

--- a/agent/src/platform/platform_synchronizer/linux_process.rs
+++ b/agent/src/platform/platform_synchronizer/linux_process.rs
@@ -155,6 +155,7 @@ impl From<&ProcessData> for ProcessInfo {
             cmdline: Some(p.cmd.join(" ")),
             user: Some(p.user.clone()),
             start_time: Some(u32::try_from(p.start_time.as_secs()).unwrap_or_default()),
+            netns_id: Some(0 as u32), // FIXME: set real value
             os_app_tags: {
                 let mut tags = vec![];
                 for t in p.os_app_tags.iter() {

--- a/message/trident.proto
+++ b/message/trident.proto
@@ -320,6 +320,7 @@ message Interface {
     optional uint32 pod_ns_id = 24;
     optional uint32 pod_id = 25;
     optional uint32 pod_cluster_id = 26;
+    optional uint32 netns_id = 27 [default = 0];
 
     optional bool is_vip_interface = 100 [default = false]; // 目前仅微软MUX设配为true
 }
@@ -579,6 +580,7 @@ message InterfaceInfo {
     optional string device_name = 6;
 
     optional string netns = 7 [default = ""];
+    optional uint32 netns_id = 8 [default = 0];
 }
 
 message Tag {
@@ -593,6 +595,7 @@ message ProcessInfo {
     optional string cmdline = 4;
     optional string user = 5;
     optional uint32 start_time = 6;
+    optional uint32 netns_id = 7 [default = 0];
     repeated Tag os_app_tags = 11;
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Message

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


