### PR TITLE
[AGENT] Fix k8s_poller disregarding extra netns

### DIFF
--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -978,6 +978,9 @@ impl Components {
             .process_threshold;
         let feature_flags = FeatureFlags::from(&yaml_config.feature_flags);
 
+        // require an update because platfrom_synchronizer starts before receiving config from server
+        platform_synchronizer.set_netns_regex(&candidate_config.dispatcher.extra_netns_regex);
+
         let mut stats_sender = UniformSenderThread::new(
             stats::DFSTATS_SENDER_ID,
             "stats",


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

### Fixes k8s_poller disregarding extra netns
#### Steps to reproduce the bug
- In EE version, extra_netns_regex is ineffective
#### Changes to fix the bug
- Set extra_netns_regex after `Component::new()`
#### Affected branches
- main
- 6.2
- 6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


