### PR TITLE
[AGENT] Fix agent exit in platform_synchronizer

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -71,6 +71,8 @@ use public::proto::{
     common::TridentType,
     trident::{self, CaptureSocketType, Exception, IfMacSource, SocketType, TapMode},
 };
+#[cfg(target_os = "linux")]
+use public::{consts::NORMAL_EXIT_WITH_RESTART, netns::NetNs};
 
 use crate::utils::cgroups::is_kernel_available_for_cgroup;
 #[cfg(target_os = "windows")]
@@ -1276,14 +1278,37 @@ impl ConfigHandler {
                     new_config.dispatcher.extra_netns_regex
                 );
                 if let Some(c) = components.as_ref() {
+                    let old_regex = if candidate_config.dispatcher.extra_netns_regex != "" {
+                        Regex::new(&candidate_config.dispatcher.extra_netns_regex).ok()
+                    } else {
+                        None
+                    };
+
                     let regex = new_config.dispatcher.extra_netns_regex.as_ref();
                     let regex = if regex != "" {
-                        info!("platform monitoring extra netns: /{}/", regex);
-                        Some(Regex::new(regex).unwrap())
+                        match Regex::new(regex) {
+                            Ok(re) => {
+                                info!("platform monitoring extra netns: /{}/", regex);
+                                Some(re)
+                            }
+                            Err(_) => {
+                                warn!("platform monitoring no extra netns because regex /{}/ is invalid", regex);
+                                None
+                            }
+                        }
                     } else {
                         info!("platform monitoring no extra netns");
                         None
                     };
+
+                    let old_netns = old_regex.map(|re| NetNs::find_ns_files_by_regex(&re));
+                    let new_netns = regex.as_ref().map(|re| NetNs::find_ns_files_by_regex(&re));
+                    if old_netns != new_netns {
+                        info!("query net namespaces changed from {:?} to {:?}, restart agent to create dispatcher for extra namespaces, deepflow-agent restart...", old_netns, new_netns);
+                        thread::sleep(Duration::from_secs(1));
+                        process::exit(NORMAL_EXIT_WITH_RESTART);
+                    }
+
                     c.platform_synchronizer.set_netns_regex(regex.clone());
                     c.kubernetes_poller.set_netns_regex(regex);
                 }

--- a/agent/src/platform/kubernetes/active_poller.rs
+++ b/agent/src/platform/kubernetes/active_poller.rs
@@ -16,7 +16,6 @@
 
 use std::{
     collections::{hash_map::Entry, HashMap},
-    process,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Condvar, Mutex,
@@ -29,10 +28,7 @@ use log::{debug, info, log_enabled, trace, warn, Level};
 use regex::Regex;
 
 use super::Poller;
-use public::{
-    consts::NORMAL_EXIT_WITH_RESTART,
-    netns::{InterfaceInfo, NetNs, NsFile},
-};
+use public::netns::{InterfaceInfo, NetNs, NsFile};
 
 const ENTRY_EXPIRE_COUNT: u8 = 3;
 
@@ -120,9 +116,11 @@ impl ActivePoller {
                 new_nss.extend(extra_ns);
             }
             if nss != new_nss {
-                info!("query net namespaces changed from {:?} to {:?}, restart agent to create dispatcher for extra namespaces, deepflow-agent restart...", nss, new_nss);
-                thread::sleep(Duration::from_secs(1));
-                process::exit(NORMAL_EXIT_WITH_RESTART);
+                info!(
+                    "query net namespaces changed from {:?} to {:?}",
+                    nss, new_nss
+                );
+                nss = new_nss;
             }
             let mut new_interface_info = Self::query(&nss);
             // compare two lists

--- a/agent/src/platform/platform_synchronizer/linux.rs
+++ b/agent/src/platform/platform_synchronizer/linux.rs
@@ -17,7 +17,6 @@
 use std::{
     net::{IpAddr, SocketAddr, SocketAddrV4},
     path::Path,
-    process,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Condvar, Mutex, MutexGuard,
@@ -55,7 +54,6 @@ use crate::{
 };
 
 use public::{
-    consts::NORMAL_EXIT_WITH_RESTART,
     netns::{InterfaceInfo, NetNs, NsFile},
     proto::{
         common::TridentType,
@@ -652,9 +650,11 @@ impl PlatformSynchronizer {
             if netns.is_empty() {
                 netns = new_netns;
             } else if netns != new_netns {
-                info!("query net namespaces changed from {:?} to {:?}, restart agent to create dispatcher for extra namespaces, deepflow-agent restart...", netns, new_netns);
-                thread::sleep(Duration::from_secs(1));
-                process::exit(NORMAL_EXIT_WITH_RESTART);
+                info!(
+                    "query net namespaces changed from {:?} to {:?}",
+                    netns, new_netns
+                );
+                netns = new_netns;
             }
 
             let config_guard = args.config.load();


### PR DESCRIPTION
Cause by extra_netns_regex change in first config

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

### Fixes agent exit in platform_synchronizer
#### Steps to reproduce the bug
- Config extra_netns_regex and start agent
- Receiving first config from server will trigger platform_synchronizer to restart
#### Changes to fix the bug
- Move netns change check to `src/config/handler.rs` to avoid restart
#### Affected branches
- main
- 6.2
- 6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


