### PR TITLE
[Agent] fix cann't get ctrl_ip and ctrl_mac

### DIFF
--- a/agent/crates/public/src/utils/net/windows.rs
+++ b/agent/crates/public/src/utils/net/windows.rs
@@ -19,7 +19,7 @@ use std::{
     ptr,
 };
 
-use log::warn;
+use log::{debug, warn};
 use pcap;
 use regex::Regex;
 use windows::Win32::{
@@ -126,6 +126,7 @@ pub fn neighbor_lookup(mut dest_addr: IpAddr) -> Result<NeighborEntry> {
 
 pub fn get_interface_by_index(if_index: u32) -> Result<Link> {
     let adapters = get_pcap_interfaces()?;
+    debug!("adapters: {:?}, if_index: {}", adapters.clone(), if_index);
     adapters
         .into_iter()
         .find(|link| link.if_index == if_index)


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes cann't get ctrl_ip and ctrl_mac
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Increase three retry opportunities to ensure access to ctrl_ip and ctrl_mac
#### Affected branches
- main
- v6.1
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.


