### PR TITLE
[Agent] add env log and change K8S_MEM_LIMIT_FOR_DEEPFLOW's default unit from B to MB

### DIFF
--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -82,7 +82,8 @@ use crate::{
         command::get_hostname,
         environment::{
             check, controller_ip_check, free_memory_check, free_space_checker, get_ctrl_ip_and_mac,
-            kernel_check, running_in_container, tap_interface_check, trident_process_check,
+            get_env, kernel_check, running_in_container, tap_interface_check,
+            trident_process_check,
         },
         guard::Guard,
         logger::{LogLevelWriter, LogWriterAdapter, RemoteLogConfig, RemoteLogWriter},
@@ -333,6 +334,7 @@ impl Trident {
         config_path: Option<PathBuf>,
     ) -> Result<()> {
         info!("==================== Launching DeepFlow-Agent ====================");
+        info!("Environment variables: {:?}", get_env());
 
         let (ctrl_ip, ctrl_mac) = get_ctrl_ip_and_mac(config.controller_ips[0].parse()?);
         if running_in_container() {

--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -61,9 +61,17 @@ use public::utils::net::{
 pub type Checker = Box<dyn Fn() -> Result<()>>;
 
 // K8S environment node ip environment variable
-pub const K8S_NODE_IP_FOR_DEEPFLOW: &str = "K8S_NODE_IP_FOR_DEEPFLOW";
-pub const ENV_INTERFACE_NAME: &str = "CTRL_NETWORK_INTERFACE";
-pub const K8S_POD_IP_FOR_DEEPFLOW: &str = "K8S_POD_IP_FOR_DEEPFLOW";
+const K8S_NODE_IP_FOR_DEEPFLOW: &str = "K8S_NODE_IP_FOR_DEEPFLOW";
+const ENV_INTERFACE_NAME: &str = "CTRL_NETWORK_INTERFACE";
+const K8S_POD_IP_FOR_DEEPFLOW: &str = "K8S_POD_IP_FOR_DEEPFLOW";
+const IN_CONTAINER: &str = "IN_CONTAINER";
+const K8S_MEM_LIMIT_FOR_DEEPFLOW: &str = "K8S_MEM_LIMIT_FOR_DEEPFLOW";
+const ONLY_WATCH_K8S_RESOURCE: &str = "ONLY_WATCH_K8S_RESOURCE";
+
+const BYTES_PER_MEGABYTE: u64 = 1024 * 1024;
+const MIN_MEMORY_LIMIT_MEGABYTE: u64 = 128; // uint: Megabyte
+const MAX_MEMORY_LIMIT_MEGABYTE: u64 = 100000; // uint: Megabyte
+
 #[cfg(target_os = "linux")]
 const CORE_FILE_CONFIG: &str = "/proc/sys/kernel/core_pattern";
 #[cfg(target_os = "linux")]
@@ -446,19 +454,39 @@ pub fn get_k8s_local_node_ip() -> Option<IpAddr> {
 
 pub fn running_in_container() -> bool {
     // Environment variable "IN_CONTAINTER" is set in dockerfile
-    env::var_os("IN_CONTAINER").is_some()
+    env::var_os(IN_CONTAINER).is_some()
 }
 
 pub fn k8s_mem_limit_for_deepflow() -> Option<u64> {
     // Environment variable "K8S_MEM_LIMIT_FOR_DEEPFLOW" is set from container fields
     // https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables
-    env::var("K8S_MEM_LIMIT_FOR_DEEPFLOW")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
+    env::var(K8S_MEM_LIMIT_FOR_DEEPFLOW).ok().and_then(|v| {
+        v.parse::<u64>().ok().and_then(|v| {
+            if v < MIN_MEMORY_LIMIT_MEGABYTE || v > MAX_MEMORY_LIMIT_MEGABYTE {
+                warn!("the K8S_MEM_LIMIT_FOR_DEEPFLOW: {} Mi is out of [{} Mi, {} Mi], use the limit value from server instead", v, MIN_MEMORY_LIMIT_MEGABYTE, MAX_MEMORY_LIMIT_MEGABYTE);
+                None
+            } else {
+                Some(v * BYTES_PER_MEGABYTE)
+            }
+        })
+    })
+}
+
+pub fn get_env() -> String {
+    format!(
+        "
+    K8S_NODE_IP_FOR_DEEPFLOW: {:?}, ENV_INTERFACE_NAME: {:?}, K8S_POD_IP_FOR_DEEPFLOW: {:?}, IN_CONTAINER: {:?}, K8S_MEM_LIMIT_FOR_DEEPFLOW: {:?}, ONLY_WATCH_K8S_RESOURCE: {:?}",
+        env::var(K8S_NODE_IP_FOR_DEEPFLOW).ok(),
+        env::var(ENV_INTERFACE_NAME).ok(),
+        env::var(K8S_POD_IP_FOR_DEEPFLOW).ok(),
+        env::var(IN_CONTAINER).ok(),
+        env::var(K8S_MEM_LIMIT_FOR_DEEPFLOW).ok(),
+        env::var(ONLY_WATCH_K8S_RESOURCE).ok()
+    )
 }
 
 pub fn running_in_only_watch_k8s_mode() -> bool {
-    running_in_container() && env::var_os("ONLY_WATCH_K8S_RESOURCE").is_some()
+    running_in_container() && env::var_os(ONLY_WATCH_K8S_RESOURCE).is_some()
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
### This PR is for:

- Agent
### Add env log and change K8S_MEM_LIMIT_FOR_DEEPFLOW's default unit from B to MB
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.2
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
