### PR TITLE
Fix agent build command

### DIFF
--- a/agent/build.md
+++ b/agent/build.md
@@ -6,11 +6,13 @@ Here is the documentation about how to compile agent in Linux system
 
 The easiest way is to use our docker image:
 ```bash
+git clone --recursive https://github.com/deepflowio/deepflow.git 
+cd deepflow 
 docker run --privileged --rm -it -v \
-    $(pwd):/deepflow hub.deepflow.yunshan.net/public/rust-build bash -c \
-    "source /opt/rh/devtoolset-8/enable && git clone --recursive https://github.com/deepflowio/deepflow.git /deepflow && cd /deepflow/agent && cargo build"
+    $(pwd):/deepflow -v ~/.cargo:/usr/local/cargo hub.deepflow.yunshan.net/public/rust-build bash -c \
+    "source /opt/rh/devtoolset-8/enable && cd /deepflow/agent && cargo build"
 
-# binary file directory: ./deepflow/agent/target/debug/deepflow-agent
+# binary file directory: ./agent/target/debug/deepflow-agent
 ```
 
 ## Manually compilation

--- a/agent/build_cn.md
+++ b/agent/build_cn.md
@@ -6,11 +6,13 @@
 
 最简单的方法是使用我们构建好的编译环境：
 ```bash
+git clone --recursive https://github.com/deepflowio/deepflow.git 
+cd deepflow 
 docker run --privileged --rm -it -v \
-    $(pwd):/deepflow hub.deepflow.yunshan.net/public/rust-build bash -c \
-    "source /opt/rh/devtoolset-8/enable && git clone --recursive https://github.com/deepflowio/deepflow.git /deepflow && cd /deepflow/agent && cargo build"
+    $(pwd):/deepflow -v ~/.cargo:/usr/local/cargo hub.deepflow.yunshan.net/public/rust-build bash -c \
+    "source /opt/rh/devtoolset-8/enable && cd /deepflow/agent && cargo build"
 
-# binary file directory: ./deepflow/agent/target/debug/deepflow-agent
+# binary file directory: ./agent/target/debug/deepflow-agent
 ```
 
 ## 手动编译


### PR DESCRIPTION
The origin one will emit `fatal: destination path '/deepflow' already exists and is not an empty directory.`

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Documents

### Fix agent build command
The origin one will emit `fatal: destination path '/deepflow' already exists and is not an empty directory.`

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


