### PR TITLE
[Agent] fix panic in centos 6 and set the correct memory limit in a k8s environment #21180 #21181

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -51,7 +51,7 @@ use crate::{
     trident::{Components, RunningMode},
     utils::{
         cgroups::is_kernel_available_for_cgroups,
-        environment::{get_ctrl_ip_and_mac, running_in_container},
+        environment::{get_ctrl_ip_and_mac, k8s_mem_limit_for_deepflow, running_in_container},
         logger::RemoteLogConfig,
     },
 };
@@ -757,7 +757,11 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
     type Error = ConfigError;
 
     fn try_from(conf: (Config, RuntimeConfig)) -> Result<Self, Self::Error> {
-        let (static_config, conf) = conf;
+        let (static_config, mut conf) = conf;
+        if let Some(k8s_mem_limit) = k8s_mem_limit_for_deepflow() {
+            // If the environment variable K8S_MEM_LIMIT_FOR_DEEPFLOW is set, its value is preferred as the memory limit
+            conf.max_memory = k8s_mem_limit;
+        }
         #[cfg(target_os = "linux")]
         let (ctrl_ip, ctrl_mac) =
             get_ctrl_ip_and_mac(static_config.controller_ips[0].parse().unwrap());

--- a/agent/src/utils/cgroups/linux.rs
+++ b/agent/src/utils/cgroups/linux.rs
@@ -63,7 +63,6 @@ impl Cgroups {
             )));
         }
         let hier = hierarchies::auto();
-        let mount_path = hier.root().to_str().unwrap().to_string();
         let is_v2 = hier.v2();
         let cg: Cgroup = CgroupBuilder::new(PROCESS_NAME).build(hier);
         let cpus: &cpu::CpuController = match cg.controller_of() {
@@ -109,7 +108,7 @@ impl Cgroups {
             thread: Mutex::new(None),
             running: Arc::new((Mutex::new(false), Condvar::new())),
             cgroup: cg,
-            mount_path,
+            mount_path: hierarchies::auto().root().to_str().unwrap().to_string(),
             is_v2,
         })
     }


### PR DESCRIPTION
### This PR is for:

- Agent
### Fixes panic in centos 6 and set the correct memory limit in a k8s environment
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- In some environments, the cgroups directory has not been mounted, and accessing its cgroups root will cause an error, delaying the operation of obtaining cgroups root
- If the environment variable K8S_MEM_LIMIT_FOR_DEEPFLOW is set, its value is preferred as the memory limit
#### Affected branches
- main
- v6.2
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
