### PR TITLE
[eBPF] Add fetch system hugepage size legacy interface

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -261,4 +261,5 @@ void fetch_linux_release(const char *buf, int buf_len);
 u64 get_process_starttime_and_comm(pid_t pid,
 				   char *name_base,
 				   int len);
+u32 legacy_fetch_log2_page_size(void);
 #endif /* DF_COMMON_H */

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -529,7 +529,7 @@ static int resolve_bin_file(const char *path, int pid,
 
 	if (syms_count == 0) {
 		ret = ETR_NOSYMBOL;
-		ebpf_warning(
+		ebpf_debug(
 			"Go process pid %d [path: %s] (version: go%d.%d). Not find any symbols!\n",
 			pid, path, go_ver->major, go_ver->minor);
 		goto failed;

--- a/agent/src/ebpf/user/mem.c
+++ b/agent/src/ebpf/user/mem.c
@@ -289,9 +289,11 @@ void clib_mem_init(void)
 		mm->log2_default_hugepage_sz = mem_get_fd_log2_page_size(fd);
 		close(fd);
 	} else {
-		ebpf_error
-		    ("Not fetch system hugeppage size. need linux 4.14+\n");
+		/* likely kernel older than 4.14 */
+		mm->log2_default_hugepage_sz = legacy_fetch_log2_page_size();
 	}
+
+	ebpf_info("log2_default_hugepage_sz %d\n", mm->log2_default_hugepage_sz);
 
 #ifdef DF_MEM_DEBUG
 	init_list_head(&mm->mem_list_head);

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -109,8 +109,8 @@ int check_kernel_version(int maj_limit, int min_limit)
 
 	if (major < maj_limit || (major == maj_limit && minor < min_limit)) {
 		ebpf_info
-		    ("Current kernel version is %s, but need > %s, eBPF not support.\n",
-		     uts.release, "4.14");
+		    ("Current kernel version is %s, but need > %d.%d, eBPF not support.\n",
+		     uts.release, maj_limit, min_limit);
 		return ETR_INVAL;
 	}
 


### PR DESCRIPTION
Add fetch system hugepage size legacy interface.
Avoid kernel restrictions for interface `syscall(__NR_memfd_create, "test", MFD_HUGETLB)` on kernel versions (need 4.14+).

### This PR is for:

- Agent


#### Affected branches
- main

