### PR TITLE
[querier] add go build flags for gin

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -4,8 +4,10 @@ COMMIT_DATE = $(shell git show -s --format=%cd --date=short HEAD)
 REVISION = $(shell git rev-parse HEAD)
 BRANCH = $(shell git branch  --show-current)
 COMPILE_TIME= $(shell date +"%Y-%m-%d %H:%M:%S")
+# build tags: [-tags=go-json] used for [gin-gonic/gin] marshal json
 FLAGS = -gcflags "-l -l" -ldflags "-X main.Branch=${BRANCH} -X main.RevCount=${REV_COUNT} -X main.Revision=${REVISION} -X main.CommitDate=${COMMIT_DATE} \
-		-X 'main.goVersion=$(shell go version)' -X 'main.CompileTime=${COMPILE_TIME}'"
+		-X 'main.goVersion=$(shell go version)' -X 'main.CompileTime=${COMPILE_TIME}'" \
+		-tags=go_json
 BINARY_SUFFIX :=
 
 .PHONY: all


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for: 
- Server


### Improves the performance of <promql query return>
#### Added profile result
- currently, using `gin` as promql query server, when return query result, it uses `encoding/json` as default lib. 
- update it to `go-json` with go bulid flags
- verification: there are `only one` package were infected by `-tags=go_json`
![image](https://github.com/deepflowio/deepflow/assets/45836837/72ed0341-ddc2-45ea-8d17-c67af86c7fc6)

##### when using encoding-json
![using-encoding-json-in-total](https://github.com/deepflowio/deepflow/assets/45836837/e10317dc-f659-4dbd-8792-a92e7d91b8eb)
![using-encoding-json-in-router](https://github.com/deepflowio/deepflow/assets/45836837/90a5874c-a5bd-45db-877a-237ca0696e1b)

##### when using go-json
![using-go-json-in-total](https://github.com/deepflowio/deepflow/assets/45836837/a9292004-be14-4cfb-9530-8e6f18934d9f)
![using-go-json-in-router](https://github.com/deepflowio/deepflow/assets/45836837/0bf26ab0-d755-495a-853f-7e9c41028414)



