### PR TITLE
[CONTROLLER/CLOUD] closes http keep-alive #21273

### DIFF
--- a/server/controller/cloud/common/http.go
+++ b/server/controller/cloud/common/http.go
@@ -33,7 +33,8 @@ func GetUnverifyHTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
+			DisableKeepAlives: true,
 		},
 	}
 }
@@ -50,7 +51,6 @@ func RequestGet(url, token string, timeout time.Duration) (jsonResp *simplejson.
 	req.Header.Set("X-Auth-Token", token)
 	req.Header.Set("Accept", "application/json, text/plain")
 
-	// TODO: 通过配置文件获取API超时时间
 	client := GetUnverifyHTTPClient(time.Second * timeout)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -88,7 +88,6 @@ func RequestPost(url string, timeout time.Duration, body map[string]interface{})
 	}
 	req.Header.Set("content-type", "application/json")
 
-	// TODO: 通过配置文件获取API超时时间
 	client := GetUnverifyHTTPClient(time.Second * timeout)
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
### This PR is for:
- Server

### Fixes http eof error
#### Steps to reproduce the bug
#### Changes to fix the bug
- closes http keep-alive
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
