### PR TITLE
[Agent] Update centos6 rpm config

### DIFF
--- a/agent/pkg/deepflow-agent.conf
+++ b/agent/pkg/deepflow-agent.conf
@@ -8,6 +8,7 @@ start on runlevel [2345]
 stop on runlevel [!2345]
 
 env RUST_BACKTRACE=1
+env LD_LIBRARY_PATH=/usr/local/deepflow/deps/
 
 respawn
 respawn limit 10 5


### PR DESCRIPTION
In a CentOS 6 environment, there is a need to have a dependency on libstdc++.so. However, the current version of this library is too low and requires an upgrade. To resolve this issue, the correct dependency needs to be placed in the specified directory.



### This PR is for:


- Agent


#### Affected branches
- main
