### PR TITLE
[Agent] Increase the flush operation of flow_map with read queue timeout

### DIFF
--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -218,6 +218,7 @@ impl EbpfDispatcher {
                 .recv_all(&mut batch, Some(Duration::from_secs(1)))
                 .is_err()
             {
+                flow_map.inject_flush_ticker(Duration::ZERO);
                 continue;
             }
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Increase the flush operation of flow_map with read queue timeout
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.1
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
