### PR TITLE
[Agent] Increase the flush operation of flow_map with read queue timeout

### DIFF
--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -213,18 +213,20 @@ impl EbpfDispatcher {
         const QUEUE_BATCH_SIZE: usize = 1024;
         let mut batch = Vec::with_capacity(QUEUE_BATCH_SIZE);
         while unsafe { SWITCH } {
-            if self
-                .receiver
-                .recv_all(&mut batch, Some(Duration::from_secs(1)))
-                .is_err()
-            {
-                continue;
-            }
             let config = Config {
                 flow: &self.flow_map_config.load(),
                 log_parser: &self.log_parser_config.load(),
                 ebpf: Some(&ebpf_config),
             };
+
+            if self
+                .receiver
+                .recv_all(&mut batch, Some(Duration::from_secs(1)))
+                .is_err()
+            {
+                flow_map.inject_flush_ticker(&config, Duration::ZERO);
+                continue;
+            }
 
             for mut packet in batch.drain(..) {
                 sync_counter.counter().rx += 1;


### PR DESCRIPTION
### This PR is for:

- Agent

### Increase the flush operation of flow_map with read queue timeout
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.1
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
