### PR TITLE
[querier] fix rfc3339 for query promql in 62

### DIFF
--- a/server/querier/prometheus/promql.go
+++ b/server/querier/prometheus/promql.go
@@ -63,7 +63,7 @@ const _SUCCESS = "success"
 
 // API Spec: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
 func PromQueryExecute(args *common.PromQueryParams, ctx context.Context) (result *common.PromQueryResponse, err error) {
-	timeS, err := (strconv.ParseFloat(args.StartTime, 64))
+	timeS, err := parseTime(args.StartTime)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func PromQueryExecute(args *common.PromQueryParams, ctx context.Context) (result
 	}
 	e := promql.NewEngine(opts)
 	//pp.Println(opts.MaxSamples)
-	qry, err := e.NewInstantQuery(&RemoteReadQuerierable{Args: args, Ctx: ctx}, nil, args.Promql, time.Unix(int64(timeS), 0))
+	qry, err := e.NewInstantQuery(&RemoteReadQuerierable{Args: args, Ctx: ctx}, nil, args.Promql, timeS)
 	if qry == nil || err != nil {
 		//pp.Println(err)
 		log.Error(err)
@@ -108,12 +108,12 @@ func durationMilliseconds(d time.Duration) int64 {
 }
 
 func PromQueryRangeExecute(args *common.PromQueryParams, ctx context.Context) (result *common.PromQueryResponse, err error) {
-	startS, err := (strconv.ParseFloat(args.StartTime, 64))
+	startS, err := parseTime(args.StartTime)
 	if err != nil {
 		log.Error(err)
 		return nil, err
 	}
-	endS, err := (strconv.ParseFloat(args.EndTime, 64))
+	endS, err := parseTime(args.EndTime)
 	if err != nil {
 		log.Error(err)
 		return nil, err
@@ -137,7 +137,7 @@ func PromQueryRangeExecute(args *common.PromQueryParams, ctx context.Context) (r
 	}
 	e := promql.NewEngine(opts)
 	//pp.Println(opts.MaxSamples)
-	qry, err := e.NewRangeQuery(&RemoteReadRangeQuerierable{Args: args, Ctx: ctx}, nil, args.Promql, time.Unix(int64(startS), 0), time.Unix(int64(endS), 0), step)
+	qry, err := e.NewRangeQuery(&RemoteReadRangeQuerierable{Args: args, Ctx: ctx}, nil, args.Promql, startS, endS, step)
 	if qry == nil || err != nil {
 		log.Error(err)
 		return nil, err

--- a/server/querier/prometheus/queryable.go
+++ b/server/querier/prometheus/queryable.go
@@ -18,7 +18,6 @@ package prometheus
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/prometheus/prometheus/model/labels"
@@ -46,19 +45,17 @@ type RemoteReadQuerier struct {
 
 // For PromQL instant query
 func (q *RemoteReadQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	startTimeS, err := (strconv.ParseFloat(q.Args.StartTime, 64))
+	startTimeS, err := parseTime(q.Args.StartTime)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
 	}
-	startTimeMs := int64(startTimeS * 1000)
-	endTimeS, err := (strconv.ParseFloat(q.Args.EndTime, 64))
+	endTimeS, err := parseTime(q.Args.EndTime)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
 	}
-	endTimeMs := int64(endTimeS * 1000)
-	prompbQuery, err := remote.ToQuery(startTimeMs, endTimeMs, matchers, hints)
+	prompbQuery, err := remote.ToQuery(startTimeS.UnixMilli(), endTimeS.UnixMilli(), matchers, hints)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
@@ -103,19 +100,17 @@ type RemoteReadRangeQuerier struct {
 
 // For PromQL range query
 func (q *RemoteReadRangeQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
-	startS, err := (strconv.ParseFloat(q.Args.StartTime, 64))
+	startS, err := parseTime(q.Args.StartTime)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
 	}
-	endS, err := (strconv.ParseFloat(q.Args.EndTime, 64))
+	endS, err := parseTime(q.Args.EndTime)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
 	}
-	startMs := int64(startS * 1000)
-	endMs := int64(endS * 1000)
-	prompbQuery, err := remote.ToQuery(startMs, endMs, matchers, hints)
+	prompbQuery, err := remote.ToQuery(startS.UnixMilli(), endS.UnixMilli(), matchers, hints)
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server 

### Fixes support promql query with rfc3339 time format in v6.2
#### Steps to reproduce the bug
- using promql to query series

#### Changes to fix the bug
- change `strconv.ParseFloat` to `parseTime` (which contains convert rfc3339 time format)
#### Affected branches
- v6.2


