### PR TITLE
[Agent] fix redis command incorrect when request fragment

### DIFF
--- a/agent/src/flow_generator/protocol_logs/sql/redis.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis.rs
@@ -258,8 +258,10 @@ impl RedisLog {
             decode(payload, direction == PacketDirection::ClientToServer)
                 .ok_or(Error::RedisLogParseFailed)?;
         match direction {
-            PacketDirection::ClientToServer => self.fill_request(context),
+            // only parse the request with payload start with '*' which indicate is a command start, otherwise assume tcp fragment of request
+            PacketDirection::ClientToServer if payload[0] == b'*' => self.fill_request(context),
             PacketDirection::ServerToClient => self.fill_response(context, error_response),
+            _ => {}
         };
         Ok(())
     }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes bug 21220 redis commnad incorrect
#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
    

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


