### PR TITLE
[querier] fix-guangda-query-deepflow-series-error

### DIFF
--- a/server/querier/prometheus/converters.go
+++ b/server/querier/prometheus/converters.go
@@ -159,7 +159,8 @@ func PromReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest) (contxt 
 					db = metricsSplit[0]
 					table = metricsSplit[1] // FIXME: should fix deepflow_system table name like 'deepflow_server.xxx'
 					metricsName = metricsSplit[2]
-					var aggOperator, aggMetrics string
+					aggMetrics := metricsName
+					var aggOperator string
 
 					if db != DB_NAME_EXT_METRICS && db != DB_NAME_DEEPFLOW_SYSTEM && !isShowTagStatement {
 						// DeepFlow native metrics needs aggregation for query


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

### Fixes Query DeepFlow series error
#### Steps to reproduce the bug
- query series with `api/v1/series/` interface and with `match[]=${deepflow_metrics}`
#### Changes to fix the bug
- make `aggMetrics` = `metric name` before query, then it will query `metrics` in `select` statements
#### Affected branches
- v6.2
