### PR TITLE
[querier] fix promql query

### DIFF
--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -119,7 +119,7 @@ func TestParseMetric(t *testing.T) {
 			output: "container_memory_usage_bytes",
 			db:     "ext_metrics",
 			table:  "prometheus.container_memory_usage_bytes",
-			alias:  "metrics.%s",
+			alias:  "`metrics.%s`",
 			prefix: prefixTag,
 		},
 	}
@@ -294,7 +294,7 @@ func TestPromReaderTransToSQL(t *testing.T) {
 		{
 			hints:    promqlHints{stepMs: 0, aggOp: "", matcher: "ext_metrics__metrics__prometheus_demo_cpu_usage_seconds_total"},
 			input:    "ext_metrics__metrics__prometheus_demo_cpu_usage_seconds_total",
-			output:   fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,metrics.demo_cpu_usage_seconds_total,`tag` FROM prometheus.demo_cpu_usage_seconds_total WHERE (time >= %d AND time <= %d)  ORDER BY timestamp desc LIMIT %s", startS, endS, limit),
+			output:   fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`metrics.demo_cpu_usage_seconds_total`,`tag` FROM prometheus.demo_cpu_usage_seconds_total WHERE (time >= %d AND time <= %d)  ORDER BY timestamp desc LIMIT %s", startS, endS, limit),
 			ds:       "",
 			db:       "ext_metrics",
 			hasError: false,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

### Fixes prom query problems
#### Steps to reproduce the bug
- 1. Query DeepFlow native metrics with native enum tag. When enum `value = 0`, it will be ignore due to [zero value remove](https://github.com/deepflowio/deepflow/blob/e098eaeb7cd5c90f1f01fdac122186c2b4f99b98/server/querier/app/prometheus/service/converters.go#L526), but that would make series error.
- 2. Query Prometheus metrics aggregation by deepflow native tags, like: `sum(node_load5)by(df_chost)`, we ignore deepflow tags now and it didn't append in series.
#### Changes to fix the bug
- 1. query `enum value` instead of `enum number`.
- 2. append deepflow tags into prometheus series when query series with aggregation functions.
#### Affected branches
- main
- v6.2

