### PR TITLE
[ingester] prometheus init app label column count

### DIFF
--- a/server/ingester/prometheus/config/config.go
+++ b/server/ingester/prometheus/config/config.go
@@ -35,6 +35,7 @@ const (
 	DefaultLabelMsgMaxSize              = 100 << 20 // 100M
 	DefaultLabelRequestMetricBatchCount = 128
 	DefaultAppLabelColumnIncrement      = 4
+	DefaultAppLabelColumnMinCount       = 8
 )
 
 type Config struct {
@@ -46,6 +47,7 @@ type Config struct {
 	LabelMsgMaxSize              int                   `yaml:"prometheus-label-msg-max-size"`
 	LabelRequestMetricBatchCount int                   `yaml:"prometheus-label-request-metric-batch-count"`
 	AppLabelColumnIncrement      int                   `yaml:"prometheus-app-label-column-increment"`
+	AppLabelColumnMinCount       int                   `yaml:"prometheus-app-label-column-min-count"`
 	IgnoreUniversalTag           bool                  `yaml:"prometheus-sample-ignore-universal-tag"`
 }
 
@@ -69,6 +71,9 @@ func (c *Config) Validate() error {
 	if c.AppLabelColumnIncrement <= 0 {
 		c.AppLabelColumnIncrement = DefaultAppLabelColumnIncrement
 	}
+	if c.AppLabelColumnMinCount <= 0 {
+		c.AppLabelColumnMinCount = DefaultAppLabelColumnMinCount
+	}
 
 	return nil
 }
@@ -84,6 +89,7 @@ func Load(base *config.Config, path string) *Config {
 			LabelMsgMaxSize:              DefaultLabelMsgMaxSize,
 			LabelRequestMetricBatchCount: DefaultLabelRequestMetricBatchCount,
 			AppLabelColumnIncrement:      DefaultAppLabelColumnIncrement,
+			AppLabelColumnMinCount:       DefaultAppLabelColumnMinCount,
 		},
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/server/ingester/prometheus/decoder/grpc_label_ids.go
+++ b/server/ingester/prometheus/decoder/grpc_label_ids.go
@@ -242,6 +242,10 @@ func (t *PrometheusLabelTable) updatePrometheusLabels(resp *trident.PrometheusLa
 	}
 }
 
+func (t *PrometheusLabelTable) GetMaxAppLabelColumnIndex() int {
+	return int(getUInt64MapMaxValue(t.labelColumnIndexs))
+}
+
 func (t *PrometheusLabelTable) metricIDsString(filter string) string {
 	sb := &strings.Builder{}
 	sb.WriteString("\nmetricName                                                                                            metricId\n")

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -429,9 +429,10 @@ ingester:
   ## prometheus label request/response msg max size (unit: bytes)
   #prometheus-label-msg-max-size: 104857600
 
-  # when prometheus requests labels, how many metric batch requests
+  ## when prometheus requests labels, how many metric batch requests
   #prometheus-label-request-metric-batch-count: 128
   #prometheus-app-label-column-increment: 4
+  #prometheus-app-label-column-min-count: 8
 
   ## Whether to ignore the writing of Universal Tag, the default is false, which means writing
   #prometheus-sample-ignore-universal-tag: false
@@ -495,7 +496,7 @@ ingester:
   ## size of unmarshall queue, defaults to 10240
   #unmarshall-queue-size: 10240
 
-  ## writer all queue limit max size
+  ## the maximum threshold for processing l4/l7 flow logs per second.(threshold for each flow log)
   #throttle: 50000
 
   ## 分别控制l4流日志, l7流日志，默认值为0，表示使用throttle的设置值.若非0，则使用设置值


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


