### PR TITLE
[querier] v62 fix max-samples and resulttype

### DIFF
--- a/server/querier/config/config.go
+++ b/server/querier/config/config.go
@@ -68,6 +68,7 @@ type Clickhouse struct {
 type Prometheus struct {
 	QPSLimit              int    `default:"100" yaml:"qps-limit"`
 	SeriesLimit           int    `default:"100" yaml:"series-limit"`
+	MaxSamples            int    `default:"50000000" yaml:"max-samples"`
 	AutoTaggingPrefix     string `default:"df_" yaml:"auto-tagging-prefix"`
 	RequestQueryWithDebug bool   `default:"false" yaml:"request-query-with-debug"`
 }

--- a/server/querier/prometheus/promql.go
+++ b/server/querier/prometheus/promql.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/deepflowio/deepflow/server/querier/config"
+
 	//"github.com/k0kubun/pp"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
@@ -71,7 +73,7 @@ func PromQueryExecute(args *common.PromQueryParams, ctx context.Context) (result
 	opts := promql.EngineOpts{
 		Logger:                   nil,
 		Reg:                      nil,
-		MaxSamples:               100000,
+		MaxSamples:               config.Cfg.Prometheus.MaxSamples,
 		Timeout:                  100 * time.Second,
 		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
 		EnableAtModifier:         true,
@@ -90,17 +92,15 @@ func PromQueryExecute(args *common.PromQueryParams, ctx context.Context) (result
 	//pp.Println(res.Err)
 	//pp.Println(res)
 	//pp.Println(res.Value.(promql.Vector))
-	var resultType parser.ValueType
-	if res.Value == nil {
-		resultType = parser.ValueTypeNone
-	} else {
-		resultType = res.Value.Type()
+	if res.Err != nil {
+		log.Error(res.Err)
+		return nil, res.Err
 	}
-	return &common.PromQueryResponse{
-		Data: &common.PromQueryData{
-			ResultType: resultType,
-			Result:     res.Value,
-		}, Status: _SUCCESS}, err
+	result = &common.PromQueryResponse{
+		Data:   &common.PromQueryData{ResultType: res.Value.Type(), Result: res.Value},
+		Status: _SUCCESS,
+	}
+	return result, err
 }
 
 func durationMilliseconds(d time.Duration) int64 {
@@ -128,7 +128,7 @@ func PromQueryRangeExecute(args *common.PromQueryParams, ctx context.Context) (r
 	opts := promql.EngineOpts{
 		Logger:                   nil,
 		Reg:                      nil,
-		MaxSamples:               100000,
+		MaxSamples:               config.Cfg.Prometheus.MaxSamples,
 		Timeout:                  100 * time.Second,
 		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
 		EnableAtModifier:         true,
@@ -146,17 +146,15 @@ func PromQueryRangeExecute(args *common.PromQueryParams, ctx context.Context) (r
 	//pp.Println(res.Value.(promql.Matrix))
 	//pp.Println(res.Err)
 	//pp.Println(res)
-	var resultType parser.ValueType
-	if res.Value == nil {
-		resultType = parser.ValueTypeNone
-	} else {
-		resultType = res.Value.Type()
+	if res.Err != nil {
+		log.Error(res.Err)
+		return nil, res.Err
 	}
-	return &common.PromQueryResponse{
-		Data: &common.PromQueryData{
-			ResultType: resultType,
-			Result:     res.Value,
-		}, Status: _SUCCESS}, err
+	result = &common.PromQueryResponse{
+		Data:   &common.PromQueryData{ResultType: res.Value.Type(), Result: res.Value},
+		Status: _SUCCESS,
+	}
+	return result, err
 }
 
 func parseDuration(s string) (time.Duration, error) {

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -238,6 +238,7 @@ querier:
   prometheus:
     qps-limit: 100 # setting to 0 means no limit
     series-limit: 10000
+    max-samples: 50000000
     auto-tagging-prefix: df_
     request-query-with-debug: true
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes query when samples too large
#### Steps to reproduce the bug
- use promql to make a complex query which contains large amount of samples
#### Changes to fix the bug
- make `default` max samples same as `default` value in prometheus
- return real `error` instead of `none` type result
#### Affected branches
- v6.2


