### PR TITLE
[eBPF] Fix golang itab sym name

### DIFF
--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -572,14 +572,23 @@ static int resolve_bin_file(const char *path, int pid,
 			p_info->info.offsets[off->idx] = offset;
 		}
 
-		p_info->info.net_TCPConn_itab = get_symbol_addr_from_binary(
-			binary_path, "go.itab.*net.TCPConn,net.Conn");
-		p_info->info.crypto_tls_Conn_itab = get_symbol_addr_from_binary(
-			binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
-		p_info->info
-			.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-			binary_path,
-			"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		if (p_info->info.version < GO_VERSION(1, 20, 0)) {
+			p_info->info.net_TCPConn_itab =
+				get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
+			p_info->info.crypto_tls_Conn_itab =
+				get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
+			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+				binary_path,
+				"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		} else {
+			p_info->info.net_TCPConn_itab =
+				get_symbol_addr_from_binary(binary_path, "go:itab.*net.TCPConn,net.Conn");
+			p_info->info.crypto_tls_Conn_itab =
+				get_symbol_addr_from_binary(binary_path, "go:itab.*crypto/tls.Conn,net.Conn");
+			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+				binary_path,
+				"go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		}
 
 		p_info->has_updated = false;
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fix golang itab sym name

Go changed the symbolic name of itab in version 1.20, which made it impossible to find the type id. The type id is used in eBPF to determine the real type of the interface. The lack of the real type makes it impossible to obtain TCP quintuple information. It degenerates into using kprobe/tracepoint to obtain data.

#### Steps to reproduce the bug

- go 1.20 version cannot get golang uprobe data

#### Changes to fix the bug

Use different symbol names depending on go version

#### Affected branches

- main
-  6.2

#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

