### PR TITLE
[querier] fix query k8s label

### DIFF
--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -18,8 +18,9 @@ package config
 
 type Prometheus struct {
 	QPSLimit              int    `default:"100" yaml:"qps-limit"`
-	SeriesLimit           int    `default:"100" yaml:"series-limit"`
+	SeriesLimit           int    `default:"500" yaml:"series-limit"`
 	MaxSamples            int    `default:"50000000" yaml:"max-samples"`
 	AutoTaggingPrefix     string `default:"df_" yaml:"auto-tagging-prefix"`
 	RequestQueryWithDebug bool   `default:"false" yaml:"request-query-with-debug"`
+	ExternalTagCacheSize  int    `default:"1024" yaml:"external-tag-cache-size"`
 }

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -157,6 +157,7 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		}
 		// append all `SHOW tags`
 		metricsArray = append(metricsArray, tagsArray...)
+		expectedDeepFlowNativeTags = make(map[string]string, len(q.Matchers)-1)
 	} else {
 		if db != DB_NAME_EXT_METRICS && db != DB_NAME_DEEPFLOW_SYSTEM && db != chCommon.DB_NAME_PROMETHEUS && db != "" {
 			// DeepFlow native metrics needs aggregation for query
@@ -188,7 +189,7 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 
 			// should append all labels in query & grouping clause
 			for _, groupLabel := range q.Hints.Grouping {
-				tagName, tagAlias, _ := parsePromQLTag(prefixType, db, groupLabel)
+				tagName, tagAlias, _ := p.parsePromQLTag(prefixType, db, groupLabel)
 
 				if tagAlias == "" {
 					groupBy = append(groupBy, tagName)
@@ -235,15 +236,15 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 			}
 		} else {
 			if len(q.Hints.Grouping) > 0 {
-				expectedDeepFlowNativeTags = make(map[string]string, len(q.Hints.Grouping)+len(q.Matchers))
+				expectedDeepFlowNativeTags = make(map[string]string, len(q.Hints.Grouping)+len(q.Matchers)-1)
 				for _, q := range q.Hints.Grouping {
-					tagName, tagAlias, isDeepFlowTag := parsePromQLTag(prefixType, db, q)
+					tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixType, db, q)
 					if isDeepFlowTag {
 						expectedDeepFlowNativeTags[tagName] = tagAlias
 					}
 				}
 			} else {
-				expectedDeepFlowNativeTags = make(map[string]string, len(q.Matchers))
+				expectedDeepFlowNativeTags = make(map[string]string, len(q.Matchers)-1)
 			}
 		}
 	}
@@ -281,7 +282,7 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 			return ctx, "", "", "", "", fmt.Errorf("unknown match type %v", matcher.Type)
 		}
 
-		tagName, tagAlias, isDeepFlowTag := parsePromQLTag(prefixType, db, matcher.Name)
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixType, db, matcher.Name)
 		if prefixType != prefixNone && isDeepFlowTag && tagAlias != "" {
 			// for Prometheus metrics, query DeepFlow enum tag can only use tag alias(x_enum) in filter clause
 			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagAlias, operation, matcher.Value))
@@ -477,7 +478,7 @@ func parsePrometheusTag(tag string) string {
 	return fmt.Sprintf("`tag.%s`", tag)
 }
 
-func parsePromQLTag(prefixType prefix, db, tag string) (tagName string, tagAlias string, isDeepFlowTag bool) {
+func (p *prometheusReader) parsePromQLTag(prefixType prefix, db, tag string) (tagName string, tagAlias string, isDeepFlowTag bool) {
 	switch prefixType {
 	case prefixTag:
 		// query ext_metrics/prometheus
@@ -485,13 +486,13 @@ func parsePromQLTag(prefixType prefix, db, tag string) (tagName string, tagAlias
 			tagName = parsePrometheusTag(removeTagPrefix(tag))
 			isDeepFlowTag = false
 		} else {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, convertToQuerierAllowedTagName(tag))
+			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(tag))
 			isDeepFlowTag = true
 		}
 	case prefixDeepFlow:
 		// query prometheus native metrics
 		if strings.HasPrefix(tag, config.Cfg.Prometheus.AutoTaggingPrefix) {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, convertToQuerierAllowedTagName(removeDeepFlowPrefix(tag)))
+			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(removeDeepFlowPrefix(tag)))
 			isDeepFlowTag = true
 		} else {
 			tagName = parsePrometheusTag(removeTagPrefix(tag))
@@ -502,7 +503,7 @@ func parsePromQLTag(prefixType prefix, db, tag string) (tagName string, tagAlias
 		if db == chCommon.DB_NAME_DEEPFLOW_SYSTEM {
 			tagName = parsePrometheusTag(tag)
 		} else {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, convertToQuerierAllowedTagName(tag))
+			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(tag))
 		}
 		isDeepFlowTag = true
 	}
@@ -650,15 +651,19 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 				}
 				if tagIndex > -1 && prefix == prefixDeepFlow {
 					// deepflow tag for prometheus metrics
+					formatTag := formatTagName(result.Columns[idx].(string))
 					pairs = append(pairs, prompb.Label{
-						Name:  appendDeepFlowPrefix(extractEnumTag(formatTagName(result.Columns[idx].(string)))),
+						Name:  appendDeepFlowPrefix(extractEnumTag(formatTag)),
 						Value: getValue(values[idx]),
 					})
+					p.addExternalTagCache(formatTag, result.Columns[idx].(string))
 				} else {
+					formatTag := formatTagName(result.Columns[idx].(string))
 					pairs = append(pairs, prompb.Label{
-						Name:  extractEnumTag(formatTagName(result.Columns[idx].(string))),
+						Name:  extractEnumTag(formatTag),
 						Value: getValue(values[idx]),
 					})
+					p.addExternalTagCache(formatTag, result.Columns[idx].(string))
 				}
 			}
 
@@ -788,11 +793,20 @@ func formatEnumTag(tagName string) (string, bool) {
 	return tagName, exists
 }
 
+// k8s label character set: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+// prometheus label character set: https://prometheus.io/docs/concepts/data_model/
 func formatTagName(tagName string) (newTagName string) {
 	newTagName = strings.ReplaceAll(tagName, ".", "_")
 	newTagName = strings.ReplaceAll(newTagName, "-", "_")
 	newTagName = strings.ReplaceAll(newTagName, "/", "_")
 	return newTagName
+}
+
+func (p *prometheusReader) addExternalTagCache(tag string, originTag string) {
+	// we don't need to add all tags into cache
+	if strings.Contains(tag, ".") || strings.Contains(tag, "-") || strings.Contains(tag, "/") {
+		p.addExternalTagToCache(tag, originTag)
+	}
 }
 
 func appendDeepFlowPrefix(tag string) string {
@@ -803,16 +817,12 @@ func appendPrometheusPrefix(tag string) string {
 	return fmt.Sprintf("tag_%s", tag)
 }
 
-// FIXME: should reverse `formatTagName` funtion, build a `tag` map during series query
-func convertToQuerierAllowedTagName(matcherName string) (tagName string) {
-	tagName = matcherName
-	for k, v := range matcherRules {
-		if strings.HasPrefix(tagName, k) {
-			tagName = strings.Replace(tagName, k, v, 1)
-			return tagName
-		}
+func (p *prometheusReader) convertToQuerierAllowedTagName(matcherName string) (tagName string) {
+	if realTag := p.getExternalTagFromCache(matcherName); realTag != "" {
+		return realTag
+	} else {
+		return matcherName
 	}
-	return tagName
 }
 
 func removeDeepFlowPrefix(tag string) string {

--- a/server/querier/app/prometheus/service/promql.go
+++ b/server/querier/app/prometheus/service/promql.go
@@ -37,8 +37,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/deepflowio/deepflow/server/libs/lru"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/config"
+	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
+	tagdescription "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/tag"
 )
 
 // The Series API supports returning the following time series (metrics):
@@ -69,10 +72,16 @@ import (
 const _SUCCESS = "success"
 
 // executors for prometheus query
-type prometheusExecutor struct{}
+type prometheusExecutor struct {
+	extraLabelCache *lru.Cache[string, string]
+}
 
 func NewPrometheusExecutor() *prometheusExecutor {
-	return &prometheusExecutor{}
+	executor := &prometheusExecutor{
+		extraLabelCache: lru.NewCache[string, string](config.Cfg.Prometheus.ExternalTagCacheSize),
+	}
+	executor.loadExternalTagCache()
+	return executor
 }
 
 // API Spec: https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
@@ -99,6 +108,8 @@ func (p *prometheusExecutor) promQueryExecute(ctx context.Context, args *model.P
 		slimit = slimitArgs
 	}
 	reader := newPrometheusReader(slimit)
+	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
+	reader.addExternalTagToCache = p.addExtraLabelConvertion
 	// instant query will hint default query range:
 	// query.lookback-delta: https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go#L398
 	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
@@ -160,6 +171,8 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 		slimit = slimitArgs
 	}
 	reader := newPrometheusReader(slimit)
+	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
+	reader.addExternalTagToCache = p.addExtraLabelConvertion
 	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
 	qry, err := engine.NewRangeQuery(queriable, nil, args.Promql, start, end, step)
 	if qry == nil || err != nil {
@@ -189,6 +202,8 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 func (p *prometheusExecutor) promRemoteReadExecute(ctx context.Context, req *prompb.ReadRequest) (resp *prompb.ReadResponse, err error) {
 	// analysis for ReadRequest
 	reader := newPrometheusReader(config.Cfg.Prometheus.SeriesLimit)
+	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
+	reader.addExternalTagToCache = p.addExtraLabelConvertion
 	result, _, _, err := reader.promReaderExecute(ctx, req, false)
 	return result, err
 }
@@ -279,6 +294,8 @@ func (p *prometheusExecutor) series(ctx context.Context, args *model.PromQueryPa
 		return nil, err
 	}
 	reader := newPrometheusReader(config.Cfg.Prometheus.SeriesLimit)
+	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
+	reader.addExternalTagToCache = p.addExtraLabelConvertion
 	querierable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
 	q, err := querierable.Querier(ctx, timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
@@ -340,4 +357,42 @@ func (p *prometheusExecutor) beforePrometheusCalculate(q promql.Query, f func(e 
 		}
 	}
 	return nil
+}
+
+func (p *prometheusExecutor) loadExternalTagCache() {
+	// DeepFlow Source have same tag collections, so just try query 1 table to add all external tags
+	showTags := fmt.Sprintf("show tags from %s", VTAP_FLOW_PORT_TABLE)
+	data, err := tagdescription.GetTagDescriptions(chCommon.DB_NAME_FLOW_METRICS, VTAP_FLOW_PORT_TABLE, showTags, context.Background())
+	if err != nil {
+		log.Errorf("load external tag error when start up prometheus executor: %s", err)
+	}
+	for _, value := range data.Values {
+		values := value.([]interface{})
+		if values[4].(string) != "map_item" {
+			continue
+		}
+		tag := values[0].(string)
+		p.addExtraLabelConvertion(formatTagName(tag), tag)
+	}
+}
+
+// convert external tag to querier tag
+// e.g.: k8s_label_helm_sh_chart_0 to 'k8s.label/helm.sh-chart'
+func (p *prometheusExecutor) convertExternalTagToQuerierAllowTag(displayTag string) string {
+	var suffix string
+	if strings.HasSuffix(displayTag, "_0") {
+		suffix = "_0"
+	} else if strings.HasSuffix(displayTag, "_1") {
+		suffix = "_1"
+	}
+	cacheTag := strings.TrimSuffix(displayTag, suffix)
+	querierTag, ok := p.extraLabelCache.Get(cacheTag)
+	if ok {
+		return fmt.Sprintf("%s%s", querierTag, suffix)
+	}
+	return ""
+}
+
+func (p *prometheusExecutor) addExtraLabelConvertion(displayTag string, querierTag string) {
+	p.extraLabelCache.Add(displayTag, querierTag)
 }

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -36,6 +36,8 @@ import (
 type prometheusReader struct {
 	slimit                  int
 	interceptPrometheusExpr func(func(e *parser.AggregateExpr) error) error
+	getExternalTagFromCache func(string) string
+	addExternalTagToCache   func(string, string)
 }
 
 func newPrometheusReader(slimit int) *prometheusReader {

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -258,10 +258,11 @@ querier:
 
   prometheus:
     qps-limit: 100 # setting to 0 means no limit
-    series-limit: 10000
+    series-limit: 500
     max-samples: 50000000
     auto-tagging-prefix: df_
     request-query-with-debug: true
+    external-tag-cache-size: 1024
 
 ingester:
   #ckdb:


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query auto discover k8s label
#### Steps to reproduce the bug
- query `metrics` with some auto discover k8s label like `k8s.label.app.kubernetes.io/managed-by`
#### Changes to fix the bug
- add lru cache to cache all labels with `./-` or load from `show tags` with `map_item` type when init `prometheus executor`
- when query some tags like this, parse it to real tag name

- extra fix: modify `series-limit` default value to 500, which is more suitable for real scene
#### Affected branches
- main

