### PR TITLE
[AGENT] ApiWatcher send first sync when all watcher is ready

### DIFF
--- a/agent/src/platform/kubernetes/api_watcher.rs
+++ b/agent/src/platform/kubernetes/api_watcher.rs
@@ -572,6 +572,14 @@ impl ApiWatcher {
             let resource_watchers_guard = resource_watchers.lock().unwrap();
             for (resource, watcher_version) in watcher_versions.iter_mut() {
                 if let Some(watcher) = resource_watchers_guard.get(resource) {
+                    if !watcher.ready() {
+                        err_msgs_guard.push(format!("{} watcher is not ready", resource));
+                        if let Some(msg) = watcher.error() {
+                            err_msgs_guard.push(msg);
+                        }
+                        continue;
+                    }
+
                     let new_version = watcher.version();
                     if new_version != *watcher_version {
                         updated_versions.push(format!(
@@ -795,13 +803,13 @@ impl ApiWatcher {
         let mut wait_count = 0;
         while !Self::ready_stop(&running, &timer, INIT_WAIT_INTERVAL) {
             let ws = resource_watchers.lock().unwrap();
-            let mut ready = false;
-            for (k, v) in ws.iter() {
-                if k.name == "nodes" {
-                    ready = v.ready();
-                    break;
+            let ready = ws.iter().all(|(n, v)| {
+                let r = v.ready();
+                if !r {
+                    debug!("{} watcher is not ready yet", n);
                 }
-            }
+                r
+            });
             if !ready {
                 wait_count += 1;
                 if wait_count >= sync_interval.as_secs() / INIT_WAIT_INTERVAL.as_secs() {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

### Fixes ApiWatcher send partial info on restarts

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


