### PR TITLE
[querier] fix init panic

### DIFF
--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -17,10 +17,11 @@
 package config
 
 type Prometheus struct {
-	QPSLimit              int    `default:"100" yaml:"qps-limit"`
-	SeriesLimit           int    `default:"500" yaml:"series-limit"`
-	MaxSamples            int    `default:"50000000" yaml:"max-samples"`
-	AutoTaggingPrefix     string `default:"df_" yaml:"auto-tagging-prefix"`
-	RequestQueryWithDebug bool   `default:"false" yaml:"request-query-with-debug"`
-	ExternalTagCacheSize  int    `default:"1024" yaml:"external-tag-cache-size"`
+	QPSLimit                int    `default:"100" yaml:"qps-limit"`
+	SeriesLimit             int    `default:"500" yaml:"series-limit"`
+	MaxSamples              int    `default:"50000000" yaml:"max-samples"`
+	AutoTaggingPrefix       string `default:"df_" yaml:"auto-tagging-prefix"`
+	RequestQueryWithDebug   bool   `default:"false" yaml:"request-query-with-debug"`
+	ExternalTagCacheSize    int    `default:"1024" yaml:"external-tag-cache-size"`
+	ExternalTagLoadInterval int    `default:"300" yaml:"external-tag-load-interval"`
 }

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -413,7 +413,7 @@ func showTags(ctx context.Context, db string, table string, startTime int64, end
 	} else {
 		data, err = tagdescription.GetTagDescriptions(db, table, fmt.Sprintf(showTags, db, table, startTime, endTime), ctx)
 	}
-	if err != nil {
+	if err != nil || data == nil {
 		return tagsArray, err
 	}
 
@@ -428,6 +428,9 @@ func showTags(ctx context.Context, db string, table string, startTime int64, end
 		// "columns": ["name","client_name","server_name","display_name","type","category","operators","permissions","description","related_tag"]
 		// i.e.: columns[i] defines name of values[i]
 		values := value.([]interface{})
+		if values == nil {
+			continue
+		}
 		tagName := values[0].(string)
 		if common.IsValueInSliceString(tagName, ignorableTagNames) {
 			continue

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -263,6 +263,7 @@ querier:
     auto-tagging-prefix: df_
     request-query-with-debug: true
     external-tag-cache-size: 1024
+    external-tag-load-interval: 300
 
 ingester:
   #ckdb:


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes when ingester is not start up completely and try to query database
#### Steps to reproduce the bug
- deploy a new `deepflow` in a new environment, `querier` and `ingester` will initialize at the same time
- before ingester init complete, try to query database in querier
#### Changes to fix the bug
- judge if `data` from query is nil
- add trigger to load cache by ticker
- add recover in ticker
#### Affected branches
- main
