### PR TITLE
[AGENT] ApiWatcher send first sync when all watcher is ready

### DIFF
--- a/agent/src/platform/kubernetes/resource_watcher.rs
+++ b/agent/src/platform/kubernetes/resource_watcher.rs
@@ -263,7 +263,9 @@ where
 
     async fn process(mut ctx: Context<K>) {
         let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-        Self::serialized_get_list_entry(&mut ctx, &mut encoder).await;
+        while !Self::serialized_get_list_entry(&mut ctx, &mut encoder).await {
+            time::sleep(SLEEP_INTERVAL).await;
+        }
         ctx.ready.store(true, Ordering::Relaxed);
         info!("{} watcher ready", ctx.kind);
 
@@ -293,15 +295,19 @@ where
         ctx.stats_counter.list_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    async fn serialized_get_list_entry(ctx: &mut Context<K>, encoder: &mut ZlibEncoder<Vec<u8>>) {
+    async fn serialized_get_list_entry(
+        ctx: &mut Context<K>,
+        encoder: &mut ZlibEncoder<Vec<u8>>,
+    ) -> bool {
         while let Err(_) =
             ctx.listing
                 .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         {
             time::sleep(SPIN_INTERVAL).await;
         }
-        Self::get_list_entry(ctx, encoder).await;
+        let r = Self::get_list_entry(ctx, encoder).await;
         ctx.listing.store(false, Ordering::SeqCst);
+        r
     }
 
     fn memory_trim(ctx: &mut Context<K>) {
@@ -361,7 +367,7 @@ where
 
     // calling list on multiple resources simultaneously may consume a lot of memory
     // use serialized_get_list_entry to avoid oom
-    async fn get_list_entry(ctx: &mut Context<K>, encoder: &mut ZlibEncoder<Vec<u8>>) {
+    async fn get_list_entry(ctx: &mut Context<K>, encoder: &mut ZlibEncoder<Vec<u8>>) -> bool {
         info!(
             "list {} entries with limit {}, memory trim percent: {:?}",
             ctx.kind, ctx.config.list_limit, ctx.config.memory_trim_percent,
@@ -382,7 +388,7 @@ where
                         ctx.stats_counter
                             .list_length
                             .fetch_add(total_count as u32, Ordering::Relaxed);
-                        return;
+                        return true;
                     }
                     debug!(
                         "{} list returns {} entries, {} remaining",
@@ -448,7 +454,7 @@ where
                                 .list_length
                                 .fetch_add(total_count as u32, Ordering::Relaxed);
                             Self::memory_trim(ctx);
-                            return;
+                            return true;
                         }
                         _ => (),
                     }
@@ -461,7 +467,7 @@ where
                     let msg = format!("{} watcher list failed: {}", ctx.kind, err);
                     warn!("{}", msg);
                     ctx.err_msg.lock().await.replace(msg);
-                    return;
+                    return false;
                 }
             }
         }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

### Fixes ApiWatcher send partial info on restarts

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


