### PR TITLE
[Agent] Fixed an issue where packet_sequence_block was not restricted by l4_log_ignore_tap_sides configuration #21698

### DIFF
--- a/agent/benches/flow_generator/flow_map.rs
+++ b/agent/benches/flow_generator/flow_map.rs
@@ -34,6 +34,7 @@ pub(super) fn bench(c: &mut Criterion) {
             let config = Config {
                 flow: &module_config.flow,
                 log_parser: &module_config.log_parser,
+                collector: &module_config.collector,
                 #[cfg(target_os = "linux")]
                 ebpf: None,
             };
@@ -61,6 +62,7 @@ pub(super) fn bench(c: &mut Criterion) {
             let config = Config {
                 flow: &module_config.flow,
                 log_parser: &module_config.log_parser,
+                collector: &module_config.collector,
                 #[cfg(target_os = "linux")]
                 ebpf: None,
             };

--- a/agent/src/dispatcher/analyzer_mode_dispatcher.rs
+++ b/agent/src/dispatcher/analyzer_mode_dispatcher.rs
@@ -243,6 +243,7 @@ impl AnalyzerModeDispatcher {
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
         let log_parse_config = base.log_parse_config.clone();
+        let collector_config = base.collector_config.clone();
         let packet_sequence_output_queue = base.packet_sequence_output_queue.clone(); // Enterprise Edition Feature: packet-sequence
         let stats = base.stats.clone();
 
@@ -269,6 +270,7 @@ impl AnalyzerModeDispatcher {
                         let config = Config {
                             flow: &flow_map_config.load(),
                             log_parser: &log_parse_config.load(),
+                            collector: &collector_config.load(),
                             #[cfg(target_os = "linux")]
                             ebpf: None,
                         };

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -37,7 +37,7 @@ use super::{
 
 use special_recv_engine::Libpcap;
 
-use crate::config::handler::LogParserAccess;
+use crate::config::handler::{CollectorAccess, LogParserAccess};
 #[cfg(target_os = "linux")]
 use crate::platform::GenericPoller;
 use crate::{
@@ -85,6 +85,7 @@ pub(super) struct BaseDispatcher {
     pub(super) tap_interfaces: Arc<Mutex<Vec<Link>>>,
     pub(super) flow_map_config: FlowAccess,
     pub(super) log_parse_config: LogParserAccess,
+    pub(super) collector_config: CollectorAccess,
 
     pub(super) tunnel_type_bitmap: Arc<Mutex<TunnelTypeBitmap>>,
     pub(super) tunnel_info: TunnelInfo,

--- a/agent/src/dispatcher/local_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_mode_dispatcher.rs
@@ -83,6 +83,7 @@ impl LocalModeDispatcher {
             let config = Config {
                 flow: &base.flow_map_config.load(),
                 log_parser: &base.log_parse_config.load(),
+                collector: &base.collector_config.load(),
                 #[cfg(target_os = "linux")]
                 ebpf: None,
             };

--- a/agent/src/dispatcher/mirror_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_mode_dispatcher.rs
@@ -391,6 +391,7 @@ impl MirrorModeDispatcher {
             let config = Config {
                 flow: &self.base.flow_map_config.load(),
                 log_parser: &self.base.log_parse_config.load(),
+                collector: &self.base.collector_config.load(),
                 #[cfg(target_os = "linux")]
                 ebpf: None,
             };

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -61,6 +61,7 @@ pub use recv_engine::{
 
 #[cfg(target_os = "linux")]
 use self::base_dispatcher::TapInterfaceWhitelist;
+use crate::config::handler::CollectorAccess;
 #[cfg(target_os = "linux")]
 use crate::platform::GenericPoller;
 use crate::utils::environment::get_mac_by_name;
@@ -640,6 +641,7 @@ pub struct DispatcherBuilder {
     stats_collector: Option<Arc<Collector>>,
     flow_map_config: Option<FlowAccess>,
     log_parse_config: Option<LogParserAccess>,
+    collector_config: Option<CollectorAccess>,
     policy_getter: Option<PolicyGetter>,
     #[cfg(target_os = "linux")]
     platform_poller: Option<Arc<GenericPoller>>,
@@ -749,6 +751,11 @@ impl DispatcherBuilder {
 
     pub fn log_parse_config(mut self, v: LogParserAccess) -> Self {
         self.log_parse_config = Some(v);
+        self
+    }
+
+    pub fn collector_config(mut self, v: CollectorAccess) -> Self {
+        self.collector_config = Some(v);
         self
     }
 
@@ -914,6 +921,10 @@ impl DispatcherBuilder {
                 .log_parse_config
                 .take()
                 .ok_or(Error::ConfigIncomplete("no log parse config".into()))?,
+            collector_config: self
+                .collector_config
+                .take()
+                .ok_or(Error::ConfigIncomplete("no collector config".into()))?,
             policy_getter: self
                 .policy_getter
                 .ok_or(Error::ConfigIncomplete("no policy".into()))?,

--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -32,7 +32,7 @@ use crate::common::l7_protocol_log::{
 use crate::common::meta_packet::MetaPacket;
 use crate::common::proc_event::{BoxedProcEvents, EventType, ProcEvent};
 use crate::common::TaggedFlow;
-use crate::config::handler::{EbpfAccess, EbpfConfig, LogParserAccess};
+use crate::config::handler::{CollectorAccess, EbpfAccess, EbpfConfig, LogParserAccess};
 use crate::config::FlowAccess;
 use crate::ebpf::{
     self, set_allow_port_bitmap, set_bypass_port_bitmap, set_profiler_cpu_aggregation,
@@ -194,6 +194,7 @@ struct EbpfDispatcher {
     // GRPC配置
     log_parser_config: LogParserAccess,
     flow_map_config: FlowAccess,
+    collector_config: CollectorAccess,
 
     config: EbpfAccess,
     output: DebugSender<Box<MetaAppProto>>, // Send MetaAppProtos to the AppProtoLogsParser
@@ -223,6 +224,7 @@ impl EbpfDispatcher {
             let config = Config {
                 flow: &self.flow_map_config.load(),
                 log_parser: &self.log_parser_config.load(),
+                collector: &self.collector_config.load(),
                 ebpf: Some(&ebpf_config),
             };
 
@@ -578,6 +580,7 @@ impl EbpfCollector {
         config: EbpfAccess,
         log_parser_config: LogParserAccess,
         flow_map_config: FlowAccess,
+        collector_config: CollectorAccess,
         policy_getter: PolicyGetter,
         output: DebugSender<Box<MetaAppProto>>,
         flow_output: DebugSender<BatchedBox<TaggedFlow>>,
@@ -619,6 +622,7 @@ impl EbpfCollector {
                 flow_output,
                 flow_map_config,
                 stats_collector,
+                collector_config,
             },
             thread_handle: None,
             counter: EbpfCounter { rx: 0 },

--- a/agent/src/flow_generator/flow_state.rs
+++ b/agent/src/flow_generator/flow_state.rs
@@ -958,6 +958,7 @@ mod tests {
         let config = Config {
             flow: &module_config.flow,
             log_parser: &module_config.log_parser,
+            collector: &module_config.collector,
             #[cfg(target_os = "linux")]
             ebpf: None,
         };

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -1868,6 +1868,7 @@ impl AgentComponents {
                 .stats_collector(stats_collector.clone())
                 .flow_map_config(config_handler.flow())
                 .log_parse_config(config_handler.log_parser())
+                .collector_config(config_handler.collector())
                 .policy_getter(policy_getter)
                 .exception_handler(exception_handler.clone())
                 .ntp_diff(synchronizer.ntp_diff())
@@ -2031,6 +2032,7 @@ impl AgentComponents {
                 config_handler.ebpf(),
                 config_handler.log_parser(),
                 config_handler.flow(),
+                config_handler.collector(),
                 policy_getter,
                 log_sender,
                 flow_sender,


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes an issue where packet_sequence_block was not restricted by l4_log_ignore_tap_sides configuration #21698
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
