### PR TITLE
[querier] fix query prometheus recording rules metrics

### DIFF
--- a/server/querier/prometheus/converters.go
+++ b/server/querier/prometheus/converters.go
@@ -419,7 +419,7 @@ func PromReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest) (contxt 
 		sqlBuilder.WriteString(fmt.Sprintf(" ORDER BY %s desc LIMIT %s", EXT_METRICS_TIME_COLUMNS, config.Cfg.Limit))
 		sql = sqlBuilder.String()
 	} else {
-		sql = fmt.Sprintf("SELECT %s FROM prometheus.%s WHERE %s ORDER BY time desc LIMIT %s",
+		sql = fmt.Sprintf("SELECT %s FROM `prometheus.%s` WHERE %s ORDER BY time desc LIMIT %s",
 			strings.Join(metrics, ","), metricsName, strings.Join(filters, " AND "), config.Cfg.Limit)
 	}
 	return ctx, sql, db, datasource, nil


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query prometheus recording rules metrics
#### Steps to reproduce the bug
- add prometheus recording rules for pre-aggregate metrics
- use promql to query
#### Changes to fix the bug
- fix query table in v6.2 (use  "from \`table\`" instead of "from table")
#### Affected branches
- v6.2

