### PR TITLE
[eBPF] Reduced restrictions on using uprobe

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -228,5 +228,5 @@ clean:
 test: $(ELFFILES) $(LIBTRACE)
 	$(Q)$(MAKE) -C test --no-print-directory
 
-.PHONY: all build clean tools test
+.PHONY: all build clean tools test rust-sample .socket-tracer .profiler
 

--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -530,6 +530,10 @@ static __inline bool skip_http2_uprobe(struct ebpf_proc_info *info)
 		return true;
 	}
 
+	if (info->net_TCPConn_itab != 0) {
+		return false;
+	}
+
 	if (info->crypto_tls_Conn_itab != 0) {
 		return false;
 	}

--- a/agent/src/ebpf/kernel/uprobe_base_bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base_bpf.c
@@ -197,9 +197,9 @@ static __inline bool skip_http2_kprobe(void)
 	if (!info) {
 		return false;
 	}
-	// must have net_TCPConn_itab
-	if (!info->net_TCPConn_itab) {
-		return false;
+
+	if (info->net_TCPConn_itab) {
+		return true;
 	}
 	// HTTP2
 	if (info->crypto_tls_Conn_itab) {


### PR DESCRIPTION

### This PR is for:

- Agent

### Reduced restrictions on using uprobe
#### Steps to reproduce the bug

plaintext go grpc uses kprobe instead of uprobe

#### Changes to fix the bug

Relaxed use of go uprobe

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.