### PR TITLE
[eBPF] Fixing the segmentation fault caused by eBPF data length

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -203,7 +203,7 @@ static __inline void report_http2_header(struct pt_regs *ctx)
 	static const int SEND_SIZE_MAX =
 		sizeof(struct __socket_data) +
 		offsetof(typeof(struct __socket_data_buffer), data);
-	if (send_size < SEND_SIZE_MAX) {
+	if (send_size < SEND_SIZE_MAX && send_size > 0) {
 		bpf_perf_event_output(ctx, &NAME(socket_data),
 				      BPF_F_CURRENT_CPU, stack, 1 + send_size);
 		return;

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -612,6 +612,20 @@ static void reader_raw_cb(void *t, void *raw, int raw_size)
 	struct mem_block_head *block_head;	// 申请内存块的指针
 
 	struct __socket_data_buffer *buf = (struct __socket_data_buffer *)raw;
+	int data_offset = offsetof(typeof(struct __socket_data_buffer), data);
+	if (raw_size < data_offset) {
+		ebpf_warning("The amount(%d) of received data is less than the "
+			     "minimum value(%d).\n", raw_size, data_offset);
+		return;
+	}
+
+	if (raw_size < (buf->len + data_offset)) {
+		ebpf_warning("There is an error in the received data length."
+			     "raw_size %d events_num %u data_len %u.\n",
+			     raw_size, buf->events_num, buf->len);
+		return;
+	}
+
 	int i, start = 0;
 	struct __socket_data *sd;
 


### PR DESCRIPTION
Fixing the segmentation fault caused by eBPF data length

### This PR is for:

- Agent


#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
