### PR TITLE
[Server] fix process name too long

### DIFF
--- a/server/controller/recorder/updater/process.go
+++ b/server/controller/recorder/updater/process.go
@@ -46,6 +46,12 @@ func (p *Process) getDiffBaseByCloudItem(cloudItem *cloudmodel.Process) (diffBas
 }
 
 func (p *Process) generateDBItemToAdd(cloudItem *cloudmodel.Process) (*mysql.Process, bool) {
+	// prevent database insert from failing
+	if len(cloudItem.Name) > 256 {
+		log.Warningf("process name too long: %v, command line: %v, pid: %v, domain: %v, subdomain: %v",
+			cloudItem.Name, cloudItem.CommandLine, cloudItem.PID, p.cache.DomainLcuuid, cloudItem.SubDomainLcuuid)
+		cloudItem.Name = cloudItem.Name[:256]
+	}
 	dbItem := &mysql.Process{
 		Name:        cloudItem.Name,
 		VTapID:      cloudItem.VTapID,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
