### PR TITLE
[message] add interface for get prometheus targets

### DIFF
--- a/message/trident.proto
+++ b/message/trident.proto
@@ -19,6 +19,7 @@ service Synchronizer {
     rpc ShareGPIDLocalData(ShareGPIDSyncRequests) returns (ShareGPIDSyncRequests) {}
     rpc Plugin (PluginRequest) returns (stream PluginResponse) {}
     rpc GetPrometheusLabelIDs (PrometheusLabelRequest) returns (PrometheusLabelResponse) {}
+    rpc GetPrometheusTargets (PrometheusTargetRequest) returns (PrometheusTargetResponse) {}
     rpc GetUniversalTagNameMaps (UniversalTagNameMapsRequest) returns (UniversalTagNameMapsResponse) {}
 }
 
@@ -866,6 +867,13 @@ message PrometheusLabelRequest {
 message PrometheusLabelResponse {
    repeated MetricLabelResponse response_label_ids = 1;
    repeated TargetResponse response_target_ids = 2;
+}
+
+message PrometheusTargetRequest{}
+
+message PrometheusTargetResponse {
+    optional uint32 version = 1;
+    repeated TargetResponse response_target_ids = 2;
 }
 
 message PodK8sLabelMap {

--- a/server/controller/grpc/synchronizer/service.go
+++ b/server/controller/grpc/synchronizer/service.go
@@ -158,6 +158,11 @@ func (s *service) GetPrometheusLabelIDs(ctx context.Context, in *api.PrometheusL
 	return resp, err
 }
 
+func (s *service) GetPrometheusTargets(ctx context.Context, in *api.PrometheusTargetRequest) (*api.PrometheusTargetResponse, error) {
+	// FIXME @zhengya
+	return nil, nil
+}
+
 func (s *service) Plugin(r *api.PluginRequest, in api.Synchronizer_PluginServer) error {
 	return s.pluginEvent.Plugin(r, in)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Message

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


