### PR TITLE
[querier] add promql query cache

### DIFF
--- a/server/querier/app/prometheus/cache/cache.go
+++ b/server/querier/app/prometheus/cache/cache.go
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/deepflowio/deepflow/server/libs/lru"
+	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/deepflowio/deepflow/server/querier/config"
+	"github.com/deepflowio/deepflow/server/querier/statsd"
+	"github.com/op/go-logging"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+var log = logging.MustGetLogger("prometheus.cache")
+
+type CacheItem struct {
+	startTime int64 // unit: ms, cache item start time
+	endTime   int64 // unit: ms, cache item end time
+	data      *common.Result
+	rwLock    *sync.RWMutex
+}
+
+func (c *CacheItem) Range() int64 {
+	return c.endTime - c.startTime
+}
+
+func (c *CacheItem) Size() uint64 {
+	return unsafeSize(c.data)
+}
+
+func (c *CacheItem) replace(d *common.Result) bool {
+	new_size := unsafeSize(d)
+	if new_size <= config.Cfg.Prometheus.Cache.CacheItemSize {
+		// if new_size < max size, replace it
+		c.data = d
+		return true
+	} else {
+		// if new_size > max size, mark overflow, do not replace it, delete key
+		log.Debugf("case size overflow when replace data, range: [%d-%d], size: %d", c.startTime, c.endTime, new_size)
+		return false
+	}
+}
+
+func (c *CacheItem) Hit(start int64, end int64) CacheHit {
+	// outside cache: cache miss
+	if end < c.startTime || start > c.endTime {
+		return CacheMiss
+	}
+
+	// inner cache: cache hit perfectly
+	if start >= c.startTime && end <= c.endTime {
+		// cache hit
+		return CacheHitFull
+	}
+
+	// range greater than cache: replace cache
+	if start < c.startTime && end > c.endTime {
+		return CacheHitPart
+	}
+
+	// deviation: fix up start time, cache hit right
+	if end <= c.endTime && end > c.startTime {
+		return CacheHitPart
+	}
+
+	// deviation: fix up end time, cache hit left
+	if start < c.endTime && start >= c.startTime {
+		return CacheHitPart
+	}
+	return CacheMiss
+}
+
+func (c *CacheItem) Deviation(start int64, end int64) (int64, int64) {
+	// only cache hit part needs to re-calculate deviation
+
+	// both side out of cache, query all
+	if start < c.startTime && end > c.endTime {
+		return start, end
+	}
+
+	// if the deviation between start & c.start > maxAllowDeviation, directy query all data to replace cache
+	// add left data
+	if end <= c.endTime && end > c.startTime {
+		if math.Abs(float64(c.startTime-start)) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+			return start, end
+		} else {
+			return start, c.startTime
+		}
+	}
+
+	// add right data
+	if start < c.endTime && start >= c.startTime {
+		if math.Abs(float64(c.endTime-end)) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+			return start, end
+		} else {
+			return c.endTime, end
+		}
+	}
+
+	return start, end
+}
+
+func (c *CacheItem) Data() *common.Result {
+	return c.data
+}
+
+func (c *CacheItem) Merge(start, end int64, data *common.Result) (*common.Result, bool) {
+	if data == nil || len(data.Values) == 0 {
+		return data, true
+	}
+
+	// re-calculate cache time, because other session may already update cache
+	c.rwLock.Lock()
+	defer c.rwLock.Unlock()
+
+	if start >= c.startTime && end <= c.endTime {
+		// not merge
+		log.Debugf("cache not merge, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+		return c.data, true
+	}
+	// no matter c.replace(data) success or not, we should return data
+	// extern both side
+
+	if start < c.startTime && end > c.endTime {
+		log.Debugf("cache extern both side, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+		c.startTime = start
+		c.endTime = end
+		return data, c.replace(data)
+	}
+
+	// extern left
+	if end <= c.endTime && end > c.startTime {
+		if math.Abs(float64(c.startTime-start)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+			log.Debugf("cache replace due to deviation too large, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+			c.startTime = start
+			c.endTime = end
+		} else {
+			log.Debugf("cache merge extern left, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+			c.startTime = start
+			data.Values = append(data.Values, c.data.Values...)
+		}
+		return data, c.replace(data)
+	}
+
+	// extern right
+	if start < c.endTime && start >= c.startTime {
+		if math.Abs(float64(c.endTime-end)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+			log.Debugf("cache replace due to deviation too large, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+			c.startTime = start
+			c.endTime = end
+		} else {
+			log.Debugf("cache merge extern right, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+			c.endTime = end
+			data.Values = append(c.data.Values, data.Values...)
+		}
+		return data, c.replace(data)
+	}
+
+	return data, true
+}
+
+type RemoteReadQueryCache struct {
+	cache   *lru.Cache[string, *CacheItem]
+	counter *CacheCounter
+}
+
+var (
+	remoteReadQueryCache *RemoteReadQueryCache
+	once                 sync.Once
+)
+
+func RemoteReadCache() *RemoteReadQueryCache {
+	once.Do(func() {
+		remoteReadQueryCache = NewRemoteReadQueryCache()
+	})
+	return remoteReadQueryCache
+}
+
+func NewRemoteReadQueryCache() *RemoteReadQueryCache {
+	s := &RemoteReadQueryCache{
+		cache:   lru.NewCache[string, *CacheItem](config.Cfg.Prometheus.Cache.CacheMaxCount),
+		counter: &CacheCounter{Stats: &CacheStats{}},
+	}
+	statsd.RegisterCountableForIngester("prometheus_cache_counter", s.counter)
+	return s
+}
+
+func (s *RemoteReadQueryCache) AddOrMerge(req *prompb.ReadRequest, data *common.Result, item *CacheItem) *common.Result {
+	if req == nil || len(req.Queries) == 0 {
+		return nil
+	}
+	q := req.Queries[0]
+	if q.Hints.Func == "series" {
+		return data
+	}
+
+	key, _, start, end := promRequestToCacheKey(q)
+	start, end = timeAlign(start, end)
+	if item == nil {
+		// cache miss
+		s.cache.Add(key, &CacheItem{startTime: start, endTime: end, data: data, rwLock: &sync.RWMutex{}})
+		return data
+	} else {
+		// cache hit, merge data
+		atomic.AddUint64(&s.counter.Stats.CacheMerge, 1)
+		t1 := time.Now()
+		result, ok := item.Merge(start, end, data)
+		d := time.Since(t1)
+		atomic.AddUint64(&s.counter.Stats.CacheMergeDuration, uint64(d.Seconds()))
+		if !ok {
+			// if cache size overflow, means this cache is expired, should delete it
+			// maybe 2 ways to resolve: in next query, rewrite cache
+			// or add more limitation of cache size
+			log.Debugf("case size overflow, cache key: [%s], range: [%d-%d]", key, start, end)
+			atomic.AddUint64(&s.counter.Stats.CacheSizeOverFlow, 1)
+			s.cache.Remove(key)
+		}
+		return result
+	}
+}
+
+func (s *RemoteReadQueryCache) Get(req *prompb.ReadRequest) (*CacheItem, CacheHit, string, int64, int64) {
+	if req == nil || len(req.Queries) == 0 {
+		return nil, CacheMiss, "", 0, 0
+	}
+	q := req.Queries[0]
+	if q.Hints.Func == "series" {
+		// for series api, don't use cache
+		// not count cache miss here
+		return nil, CacheMiss, "", q.Hints.StartMs, q.Hints.EndMs
+	}
+
+	if !config.Cfg.Prometheus.Cache.Enabled {
+		return nil, CacheMiss, "", q.Hints.StartMs, q.Hints.EndMs
+	}
+
+	// for query api, cache query samples
+	key, metric, start, end := promRequestToCacheKey(q)
+	start, end = timeAlign(start, end)
+	item, ok := s.cache.Get(key)
+	if !ok {
+		atomic.AddUint64(&s.counter.Stats.CacheMiss, 1)
+		// totally cache miss, no such key
+		return nil, CacheMiss, metric, start, end
+	}
+
+	switch item.Hit(start, end) {
+	case CacheMiss:
+		atomic.AddUint64(&s.counter.Stats.CacheMiss, 1)
+		return nil, CacheMiss, metric, start, end
+	case CacheHitFull:
+		atomic.AddUint64(&s.counter.Stats.CacheHit, 1)
+		return item, CacheHitFull, metric, start, end
+	case CacheHitPart:
+		atomic.AddUint64(&s.counter.Stats.CacheHit, 1)
+		query_start, query_end := item.Deviation(start, end)
+		return item, CacheHitPart, metric, query_start, query_end
+	default:
+		return nil, CacheMiss, metric, start, end
+	}
+}

--- a/server/querier/app/prometheus/cache/counter.go
+++ b/server/querier/app/prometheus/cache/counter.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import "sync"
+
+type CacheCounter struct {
+	Stats *CacheStats
+
+	*sync.Mutex
+	exited bool
+}
+
+type CacheStats struct {
+	CacheSizeOverFlow  uint64 `statsd:"cache_size_overflow"`
+	CacheMiss          uint64 `statsd:"cache_miss"`
+	CacheHit           uint64 `statsd:"cache_hit"`
+	CacheMerge         uint64 `statsd:"cache_merge"`
+	CacheMergeDuration uint64 `statsd:"cache_merge_duration"`
+}
+
+func (c *CacheCounter) GetCounter() interface{} {
+	stats := &CacheStats{}
+	stats, c.Stats = c.Stats, stats
+	return stats
+}
+
+func (c *CacheCounter) Close() {
+	c.exited = true
+}
+
+func (c *CacheCounter) Closed() bool {
+	return c.exited
+}

--- a/server/querier/app/prometheus/cache/utils.go
+++ b/server/querier/app/prometheus/cache/utils.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"reflect"
+	"strings"
+	"unsafe"
+
+	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/prometheus/prometheus/prompb"
+)
+
+type CacheHit int
+
+const (
+	CacheMiss CacheHit = iota
+	CacheHitPart
+	CacheHitFull
+)
+
+// start time & end time align to 0 second
+// e.g.: query 13s-117s, cache 0s-120s
+func timeAlign(startMs int64, endMs int64) (int64, int64) {
+	return startMs - startMs%60000, endMs + (60000 - endMs%60000)
+}
+
+func promRequestToCacheKey(q *prompb.Query) (string, string, int64, int64) {
+	matcher := &strings.Builder{}
+	var metric string
+	for i := 0; i < len(q.Matchers); i++ {
+		matcher.WriteString(q.Matchers[i].GetName() + q.Matchers[i].Type.String() + q.Matchers[i].GetValue())
+		matcher.WriteByte('-')
+
+		if q.Matchers[i].Name == "__name__" {
+			metric = q.Matchers[i].Value
+		}
+	}
+	return matcher.String(), metric, q.Hints.StartMs, q.Hints.EndMs
+}
+
+func unsafeSize(d *common.Result) uint64 {
+	if d == nil || len(d.Values) == 0 {
+		return 0
+	}
+	v1 := d.Values[0].([]interface{})
+	var size uintptr
+	if v1 != nil {
+		for i := 0; i < len(v1); i++ {
+			// for slice/array: calcute size of every element
+			// for string: add len(string)
+			// for others: only add sizeof(v) now
+			c := reflect.Indirect(reflect.ValueOf(v1[i]))
+			switch c.Kind() {
+			case reflect.Slice:
+				if c.Len() > 0 {
+					size += unsafe.Sizeof(c.Index(0)) * uintptr(c.Len())
+				}
+			case reflect.Array:
+				if c.Len() > 0 {
+					size += unsafe.Sizeof(c.Index(0)) * uintptr(c.Len())
+				}
+			case reflect.String:
+				size += uintptr(len(c.String()))
+			default:
+				size += unsafe.Sizeof(v1[i])
+			}
+		}
+	}
+	// d.values would have the same structure, so simply just sizeof(0)*len(value) would probably equals real size(not 100% exactly)
+	return uint64(size) * uint64(len(d.Values))
+}

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -17,11 +17,19 @@
 package config
 
 type Prometheus struct {
-	QPSLimit                int    `default:"100" yaml:"qps-limit"`
-	SeriesLimit             int    `default:"500" yaml:"series-limit"`
-	MaxSamples              int    `default:"50000000" yaml:"max-samples"`
-	AutoTaggingPrefix       string `default:"df_" yaml:"auto-tagging-prefix"`
-	RequestQueryWithDebug   bool   `default:"false" yaml:"request-query-with-debug"`
-	ExternalTagCacheSize    int    `default:"1024" yaml:"external-tag-cache-size"`
-	ExternalTagLoadInterval int    `default:"300" yaml:"external-tag-load-interval"`
+	QPSLimit                int             `default:"100" yaml:"qps-limit"`
+	SeriesLimit             int             `default:"500" yaml:"series-limit"`
+	MaxSamples              int             `default:"50000000" yaml:"max-samples"`
+	AutoTaggingPrefix       string          `default:"df_" yaml:"auto-tagging-prefix"`
+	RequestQueryWithDebug   bool            `default:"false" yaml:"request-query-with-debug"`
+	ExternalTagCacheSize    int             `default:"1024" yaml:"external-tag-cache-size"`
+	ExternalTagLoadInterval int             `default:"300" yaml:"external-tag-load-interval"`
+	Cache                   PrometheusCache `yaml:"cache"`
+}
+
+type PrometheusCache struct {
+	Enabled                bool    `default:"true" yaml:"enabled"`
+	CacheItemSize          uint64  `default:"51200000" yaml:"cache-item-size"` // cache-item-size for each cache item, default: 50M
+	CacheMaxCount          int     `default:"1024" yaml:"cache-max-count"`     // cache-max-count for list of cache size
+	CacheMaxAllowDeviation float64 `default:"3600" yaml:"cache-max-allow-deviation"`
 }

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -114,7 +114,7 @@ const (
 
 type ctxKeyPrefixType struct{}
 
-func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest) (context.Context, string, string, string, string, error) {
+func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest, startTime int64, endTime int64) (context.Context, string, string, string, string, error) {
 	// QPS Limit Check
 	// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
 	if !QPSLeakyBucket.Acquire(1000) {
@@ -126,8 +126,8 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		return ctx, "", "", "", "", errors.New("len(req.Queries) == 0, this feature is not yet implemented!")
 	}
 	q := queriers[0]
-	startTime := q.Hints.StartMs / 1000
-	endTime := q.Hints.EndMs / 1000
+	startTime = startTime / 1000
+	endTime = endTime / 1000
 	if q.EndTimestampMs%1000 > 0 {
 		endTime += 1
 	}

--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -362,7 +362,7 @@ func TestPromReaderTransToSQL(t *testing.T) {
 				},
 			})
 
-			_, sql, db, ds, metricName, err := prometheusReader.promReaderTransToSQL(ctx, &prompb.ReadRequest{Queries: queries})
+			_, sql, db, ds, metricName, err := prometheusReader.promReaderTransToSQL(ctx, &prompb.ReadRequest{Queries: queries}, startMs, endMs)
 
 			if !p.hasError {
 				So(err, ShouldBeNil)

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -28,9 +28,11 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/cache"
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/config"
 	"github.com/deepflowio/deepflow/server/querier/engine/clickhouse"
+	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
 )
 
 type prometheusReader struct {
@@ -47,78 +49,103 @@ func newPrometheusReader(slimit int) *prometheusReader {
 func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.ReadRequest, debug bool) (resp *prompb.ReadResponse, sql string, duration float64, err error) {
 	// promrequest trans to sql
 	// pp.Println(req)
-	ctx, sql, db, datasource, metricName, err := p.promReaderTransToSQL(ctx, req)
-	// fmt.Println(sql, db)
-	if err != nil {
-		return nil, "", 0, err
-	}
-	if db == "" {
-		db = "prometheus"
-	}
-	query_uuid := uuid.New()
-	// mark query comes from promql
-	if db == "prometheus" {
-		//lint:ignore SA1029 use string as context key, ensure no `type` reference to app/prometheus
-		ctx = context.WithValue(ctx, "remote_read", true)
-	}
-	// if `api` pass `debug` or config debug, get debug info from querier
-	debugQuerier := debug || config.Cfg.Prometheus.RequestQueryWithDebug
-	args := common.QuerierParams{
-		DB:         db,
-		Sql:        sql,
-		DataSource: datasource,
-		Debug:      strconv.FormatBool(debugQuerier),
-		QueryUUID:  query_uuid.String(),
-		Context:    ctx,
-	}
-	// get parentSpan for inject others attribute below
-	parentSpan := trace.SpanFromContext(ctx)
+	var metricName string
+	var result *common.Result
 
-	// start span trace query time of any query uuid
-	var span trace.Span
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
-		tr := otel.GetTracerProvider().Tracer("querier/prometheus/clickhouseQuery")
-		ctx, span = tr.Start(ctx, "PromReaderExecute",
-			trace.WithSpanKind(trace.SpanKindClient),
-			trace.WithAttributes(attribute.String("query_uuid", query_uuid.String())))
+	item, hit, metricName, start, end := cache.RemoteReadCache().Get(req)
+	if hit == cache.CacheHitFull {
+		result = item.Data()
+		if strings.Contains(metricName, "__") {
+			metricsSplit := strings.Split(metricName, "__")
+			if _, ok := chCommon.DB_TABLE_MAP[metricsSplit[0]]; ok {
+				if metricsSplit[0] == DB_NAME_EXT_METRICS || metricsSplit[0] == chCommon.DB_NAME_PROMETHEUS {
+					ctx = context.WithValue(ctx, ctxKeyPrefixType{}, prefixTag)
+				}
+			}
+		} else {
+			ctx = context.WithValue(ctx, ctxKeyPrefixType{}, prefixDeepFlow)
+		}
+	} else {
+		var sql, db, datasource string
+		var debugInfo map[string]interface{}
+		ctx, sql, db, datasource, metricName, err = p.promReaderTransToSQL(ctx, req, start, end)
+		// fmt.Println(sql, db)
+		if err != nil {
+			return nil, "", 0, err
+		}
+		if db == "" {
+			db = "prometheus"
+		}
+		query_uuid := uuid.New()
+		// mark query comes from promql
+		if db == "prometheus" {
+			//lint:ignore SA1029 use string as context key, ensure no `type` reference to app/prometheus
+			ctx = context.WithValue(ctx, "remote_read", true)
+		}
+		// if `api` pass `debug` or config debug, get debug info from querier
+		debugQuerier := debug || config.Cfg.Prometheus.RequestQueryWithDebug
+		args := common.QuerierParams{
+			DB:         db,
+			Sql:        sql,
+			DataSource: datasource,
+			Debug:      strconv.FormatBool(debugQuerier),
+			QueryUUID:  query_uuid.String(),
+			Context:    ctx,
+		}
+		// get parentSpan for inject others attribute below
+		parentSpan := trace.SpanFromContext(ctx)
 
-		defer span.End()
-	}
+		// start span trace query time of any query uuid
+		var span trace.Span
+		if config.Cfg.Prometheus.RequestQueryWithDebug {
+			tr := otel.GetTracerProvider().Tracer("querier/prometheus/clickhouseQuery")
+			ctx, span = tr.Start(ctx, "PromReaderExecute",
+				trace.WithSpanKind(trace.SpanKindClient),
+				trace.WithAttributes(attribute.String("query_uuid", query_uuid.String())))
 
-	ckEngine := &clickhouse.CHEngine{DB: args.DB, DataSource: args.DataSource}
-	ckEngine.Init()
-	result, debugInfo, err := ckEngine.ExecuteQuery(&args)
-	if err != nil {
-		log.Errorf("ExecuteQuery failed, debug info = %v, err info = %v", debugInfo, err)
-		return nil, "", 0, err
-	}
+			defer span.End()
+		}
 
-	if debugQuerier {
-		duration = extractQueryTimeFromQueryResponse(debugInfo)
-		sql = extractQuerySQLFromQueryResponse(debugInfo)
-	}
+		ckEngine := &clickhouse.CHEngine{DB: args.DB, DataSource: args.DataSource}
+		ckEngine.Init()
+		result, debugInfo, err = ckEngine.ExecuteQuery(&args)
+		if err != nil {
+			log.Errorf("ExecuteQuery failed, debug info = %v, err info = %v", debugInfo, err)
+			return nil, "", 0, err
+		}
 
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
-		// inject query_time for current span
-		span.SetAttributes(attribute.Float64("query_time", duration))
+		if debugQuerier {
+			duration = extractQueryTimeFromQueryResponse(debugInfo)
+			sql = extractQuerySQLFromQueryResponse(debugInfo)
+		}
 
-		// inject labels for parent span
-		targetLabels := make([]string, 0, len(result.Schemas))
-		appLabels := make([]string, 0, len(result.Schemas))
-		for i := 0; i < len(result.Schemas); i++ {
-			labelType := result.Schemas[i].LabelType
-			if labelType == "app" {
-				appLabels = append(appLabels, strings.TrimPrefix(result.Columns[i].(string), "tag."))
-			} else if labelType == "target" {
-				targetLabels = append(targetLabels, strings.TrimPrefix(result.Columns[i].(string), "tag."))
+		if config.Cfg.Prometheus.RequestQueryWithDebug {
+			// inject query_time for current span
+			span.SetAttributes(attribute.Float64("query_time", duration))
+
+			// inject labels for parent span
+			targetLabels := make([]string, 0, len(result.Schemas))
+			appLabels := make([]string, 0, len(result.Schemas))
+			for i := 0; i < len(result.Schemas); i++ {
+				labelType := result.Schemas[i].LabelType
+				if labelType == "app" {
+					appLabels = append(appLabels, strings.TrimPrefix(result.Columns[i].(string), "tag."))
+				} else if labelType == "target" {
+					targetLabels = append(targetLabels, strings.TrimPrefix(result.Columns[i].(string), "tag."))
+				}
+			}
+			if len(targetLabels) > 0 {
+				parentSpan.SetAttributes(attribute.String("promql.query.metric.targetLabel", strings.Join(targetLabels, ",")))
+			}
+			if len(appLabels) > 0 {
+				parentSpan.SetAttributes(attribute.String("promql.query.metric.appLabel", strings.Join(appLabels, ",")))
 			}
 		}
-		if len(targetLabels) > 0 {
-			parentSpan.SetAttributes(attribute.String("promql.query.metric.targetLabel", strings.Join(targetLabels, ",")))
-		}
-		if len(appLabels) > 0 {
-			parentSpan.SetAttributes(attribute.String("promql.query.metric.appLabel", strings.Join(appLabels, ",")))
-		}
+	}
+
+	if config.Cfg.Prometheus.Cache.Enabled {
+		// add or merge query result
+		result = cache.RemoteReadCache().AddOrMerge(req, result, item)
 	}
 
 	// response trans to prom resp

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -264,6 +264,11 @@ querier:
     request-query-with-debug: true
     external-tag-cache-size: 1024
     external-tag-load-interval: 300
+    cache:
+      enabled: true
+      cache-item-size: 512000 # max size of cache item, unit: byte
+      cache-max-count: 1024 # max capacity of cache list
+      cache-max-allow-deviation: 3600 # unit:s 
 
 ingester:
   ## whether Ingester store metrics/flow_log... to database


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Improves the performance of prometheus query
#### Added benchmark
- `wrk2 command: wrk2 -c 15 -t 15 -L -R 100 -d 180`
#### Benchmark result
```text
Testcase: #1 / #18
PromQL: node_memory_PageTables_bytes{instance="host-1011",job="node_exporter"}
 50.000%    1.03ms
 99.000%    8.30ms
Requests/sec:    100.08

Sat Aug 12 10:50:29 CST 2023
Testcase: #2 / #18
PromQL: (node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_SwapFree_bytes{instance="host-1011",job="node_exporter"})
 50.000%    1.15ms
 99.000%    8.95ms
Requests/sec:    100.08

Sat Aug 12 10:53:30 CST 2023
Testcase: #3 / #18
PromQL: ((node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_SwapFree_bytes{instance="host-1011",job="node_exporter"}) / (node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} )) * 100
 50.000%    1.32ms
 99.000%    8.70ms
Requests/sec:    100.08

Sat Aug 12 10:56:31 CST 2023
Testcase: #4 / #18
PromQL: node_memory_MemTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_MemFree_bytes{instance="host-1011",job="node_exporter"} - (node_memory_Cached_bytes{instance="host-1011",job="node_exporter"} + node_memory_Buffers_bytes{instance="host-1011",job="node_exporter"} + node_memory_SReclaimable_bytes{instance="host-1011",job="node_exporter"})
 50.000%    1.43ms
 99.000%    8.67ms
Requests/sec:    100.08
````

---

not using cache:

```
Sat Aug 12 11:05:55 CST 2023
Testcase: #1 / #18
PromQL: node_memory_PageTables_bytes{instance="host-1011",job="node_exporter"}
 50.000%   81.98ms
 99.000%  212.35ms
Requests/sec:     99.99

Sat Aug 12 11:08:56 CST 2023
Testcase: #2 / #18
PromQL: (node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_SwapFree_bytes{instance="host-1011",job="node_exporter"})
 50.000%   15.52s
 99.000%   26.21s
Requests/sec:     85.36

Sat Aug 12 11:11:57 CST 2023
Testcase: #3 / #18
PromQL: ((node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_SwapFree_bytes{instance="host-1011",job="node_exporter"}) / (node_memory_SwapTotal_bytes{instance="host-1011",job="node_exporter"} )) * 100
 50.000%   40.86s
 99.000%    1.29m
Requests/sec:     56.64

Sat Aug 12 11:14:58 CST 2023
Testcase: #4 / #18
PromQL: node_memory_MemTotal_bytes{instance="host-1011",job="node_exporter"} - node_memory_MemFree_bytes{instance="host-1011",job="node_exporter"} - (node_memory_Cached_bytes{instance="host-1011",job="node_exporter"} + node_memory_Buffers_bytes{instance="host-1011",job="node_exporter"} + node_memory_SReclaimable_bytes{instance="host-1011",job="node_exporter"})
 50.000%    1.05m
 99.000%    1.82m
Requests/sec:     38.97
```