### PR TITLE
[workflow] Use libelf static library instead of dynamic library

### DIFF
--- a/.github/workflows/agent-build-rust-env.yml
+++ b/.github/workflows/agent-build-rust-env.yml
@@ -51,9 +51,9 @@ jobs:
           file: agent/docker/DockerfileToFix.build
           platforms: linux/amd64
           tags: |
-            "ghcr.io/${{ github.repository_owner }}/rust-build:1.22"
+            "ghcr.io/${{ github.repository_owner }}/rust-build:1.23"
             "ghcr.io/${{ github.repository_owner }}/rust-build:latest"
-            "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:1.22"
+            "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:1.23"
             "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:latest"
 
   build_agent_env_arm64:
@@ -98,7 +98,7 @@ jobs:
           file: agent/docker/DockerfileToFix-aarch64.build
           platforms: linux/arm64
           tags: |
-            "ghcr.io/${{ github.repository_owner }}/rust-build:1.21-arm64"
+            "ghcr.io/${{ github.repository_owner }}/rust-build:1.22-arm64"
             "ghcr.io/${{ github.repository_owner }}/rust-build:latest-arm64"
-            "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:1.21-arm64"
+            "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:1.22-arm64"
             "${{ secrets.REGISTRY_ALIYUN_ADDR }}/public/rust-build:latest-arm64"

--- a/agent/docker/DockerfileToFix-aarch64.build
+++ b/agent/docker/DockerfileToFix-aarch64.build
@@ -65,7 +65,9 @@ RUN cd /usr/aarch64-linux-musl/lib64  && \
     curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/aarch64/libbcc.a --silent -o /usr/lib64/libbcc.a && \
     chmod 755 /usr/lib64/libbcc.a && \
     curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/aarch64/libbcc_bpf.a --silent -o /usr/lib64/libbcc_bpf.a && \
-    chmod 755 /usr/lib64/libbcc_bpf.a
+    chmod 755 /usr/lib64/libbcc_bpf.a && \
+    curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/aarch64/libelf.a --silent -o /usr/lib64/libelf.a && \
+    chmod 755 /usr/lib64/libelf.a
 
 RUN rustup target add aarch64-unknown-linux-musl
 # rust uses dependency cache

--- a/agent/docker/DockerfileToFix.build
+++ b/agent/docker/DockerfileToFix.build
@@ -62,7 +62,9 @@ RUN yum -y install https://forensics.cert.org/cert-forensics-tools-release-el7.r
     curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/x86_64/libbcc.a --silent -o /usr/lib64/libbcc.a && \
     chmod 755 /usr/lib64/libbcc.a && \
     curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/x86_64/libbcc_bpf.a --silent -o /usr/lib64/libbcc_bpf.a && \
-    chmod 755 /usr/lib64/libbcc_bpf.a
+    chmod 755 /usr/lib64/libbcc_bpf.a && \
+    curl https://deepflow-ce.oss-cn-beijing.aliyuncs.com/pkg/compile/x86_64/libelf.a --silent -o /usr/lib64/libelf.a && \
+    chmod 755 /usr/lib64/libelf.a
 
 RUN rustup target add x86_64-unknown-linux-musl
 ## 使用依赖缓存


### PR DESCRIPTION
Use libelf static library instead of dynamic library

### This PR is for:


- Workflow

#### Affected branches
- main

