### PR TITLE
[Agent] fix some l7 stats problems #21884 #21890

### DIFF
--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -273,11 +273,15 @@ impl SubQuadGen {
                 }
             }
         } else {
+            // app_meter.traffic.request and app_meter.traffic.response are 0, there is no need to save
+            if app_meter.traffic.request == 0 && app_meter.traffic.response == 0 {
+                return;
+            }
             // If l7_stats.flow.is_some(), set the flow of all meter belonging to this flow
             if let Some(tagged_flow) = &l7_stats.flow {
                 let (is_active_host0, is_active_host1) =
                     check_active(time_in_second.as_secs(), possible_host, &tagged_flow.flow);
-                let app_meter = Box::new(AppMeterWithFlow {
+                let boxed_app_meter = Box::new(AppMeterWithFlow {
                     app_meter: *app_meter,
                     flow: tagged_flow.clone(),
                     l7_protocol: l7_stats.l7_protocol,
@@ -286,7 +290,7 @@ impl SubQuadGen {
                     is_active_host0,
                     is_active_host1,
                 });
-                stash.meters.push(app_meter);
+                stash.meters.push(boxed_app_meter);
             } else {
                 let meter = AppMeterWithL7Protocol {
                     app_meter: *app_meter,

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -147,7 +147,11 @@ impl L7ProtocolInfoInterface for HttpInfo {
 
     fn get_endpoint(&self) -> Option<String> {
         if self.is_grpc() {
-            Some(self.path.clone())
+            if self.path.is_empty() {
+                None
+            } else {
+                Some(self.path.clone())
+            }
         } else {
             None
         }

--- a/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/krpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/krpc.rs
@@ -129,7 +129,7 @@ impl L7ProtocolInfoInterface for KrpcInfo {
     }
 
     fn get_endpoint(&self) -> Option<String> {
-        if !self.serv_id > 0 && !self.msg_id > 0 {
+        if self.serv_id > 0 && self.msg_id > 0 {
             Some(format!("{}/{}", self.serv_id, self.msg_id))
         } else {
             None


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes some l7 stats problems #21884 #21890
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Filter out the empty data ForceReported in the cycle
- fix  grpc、krpc  get_endpoint
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
