### PR TITLE
Fix syscall trace id v6.3

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -1465,7 +1465,8 @@ infer_fastcgi_message(const char *buf, size_t count,
 	header = (struct fastcgi_header *)buf;
 
 	if (fastcgi_header_common_check(header) && count == 8 &&
-	    (header->type == FCGI_PARAMS || header->type == FCGI_STDOUT) &&
+	    (header->type == FCGI_BEGIN_REQUEST ||
+	     header->type == FCGI_PARAMS || header->type == FCGI_STDOUT) &&
 	    __bpf_ntohs(header->content_length) != 0) {
 		save_prev_data(buf, conn_info, 8);
 		return MSG_PRESTORE;
@@ -1491,7 +1492,7 @@ infer_fastcgi_message(const char *buf, size_t count,
 		return MSG_UNKNOWN;
 	}
 
-	if (header->type == FCGI_BEGIN_REQUEST) {
+	if (header->type == FCGI_BEGIN_REQUEST || header->type == FCGI_PARAMS) {
 		return MSG_REQUEST;
 	}
 	if (header->type == FCGI_STDOUT) {

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -124,6 +124,12 @@ BPF_HASH(active_read_args_map, __u64, struct data_args_t)
 // Key is {pid + fd}. value is struct socket_info_t
 BPF_HASH(socket_info_map, __u64, struct socket_info_t)
 
+// socket_info lifecycle is inconsistent with socket. If the role information
+// is saved to the socket_info_map, it will affect the generation of syscall
+// trace id. Create an independent map to save role information
+// Key is {pid + fd}. value is role type
+BPF_HASH(socket_role_map, __u64, __u32);
+
 // Key is struct trace_key_t. value is trace_info_t
 BPF_HASH(trace_map, struct trace_key_t, struct trace_info_t)
 
@@ -1085,21 +1091,16 @@ __data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 			      &thread_trace_id, time_stamp, &trace_key);
 
 	if (!is_socket_info_valid(socket_info_ptr)) {
-		if (socket_info_ptr) {
-			sk_info.role = socket_info_ptr->role;
-			if (conn_info->direction == T_EGRESS) {
-				sk_info.peer_fd = socket_info_ptr->peer_fd;
-				thread_trace_id = socket_info_ptr->trace_id;
-			}
+		if (socket_info_ptr && conn_info->direction == T_EGRESS) {
+			sk_info.peer_fd = socket_info_ptr->peer_fd;
+			thread_trace_id = socket_info_ptr->trace_id;
 		}
 
 		sk_info.uid = trace_conf->socket_id + 1;
 		trace_conf->socket_id++; // Ensure that socket_id is incremented.
 		sk_info.l7_proto = conn_info->protocol;
 		sk_info.direction = conn_info->direction;
-		if(conn_info->role){
-			sk_info.role = conn_info->role;
-		}
+		sk_info.role = conn_info->role;
 		sk_info.msg_type = conn_info->message_type;
 		sk_info.update_time = time_stamp / NS_PER_SEC;
 		sk_info.need_reconfirm = conn_info->need_reconfirm;
@@ -1131,7 +1132,6 @@ __data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 
 	if (is_socket_info_valid(socket_info_ptr)) {
 		sk_info.uid = socket_info_ptr->uid;
-		sk_info.role = socket_info_ptr->role;
 
 		/*
 		 * 同方向多个连续请求或回应的场景时，
@@ -1191,7 +1191,8 @@ __data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 	    (extra->source == DATA_SOURCE_OPENSSL_UPROBE))
 		v->data_type = PROTO_TLS_HTTP2;
 
-	v->socket_role = sk_info.role;
+	__u32 *socket_role = socket_role_map__lookup(&conn_key);
+	v->socket_role = socket_role ? *socket_role : 0;
 	v->socket_id = sk_info.uid;
 	v->data_seq = sk_info.seq;
 	v->tgid = tgid;
@@ -1826,6 +1827,8 @@ TPPROG(sys_enter_close) (struct syscall_comm_enter_ctx *ctx) {
 		struct socket_info_t *socket_info_ptr = socket_info_map__lookup(&conn_key);
 		if (socket_info_ptr != NULL)
 			delete_socket_info(conn_key, socket_info_ptr);
+		
+		socket_role_map__delete(&conn_key);
 	}
 
 	return 0;
@@ -1908,67 +1911,34 @@ TPPROG(sys_exit_socket) (struct syscall_comm_exit_ctx *ctx) {
 
 TPPROG(sys_exit_accept)(struct syscall_comm_exit_ctx *ctx)
 {
-	__u32 k0 = 0;
-	struct trace_conf_t *trace_conf = trace_conf_map__lookup(&k0);
-	struct trace_stats *trace_stats = trace_stats_map__lookup(&k0);
-	if (trace_conf && trace_stats) {
-		int sockfd = ctx->ret;
-		__u64 pid_tgid = bpf_get_current_pid_tgid();
-		__u32 tgid = (__u32)(pid_tgid >> 32);
-		__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
-
-		struct socket_info_t sk_info = {
-			.role = ROLE_SERVER,
-		};
-
-		if (!socket_info_map__update(&conn_key, &sk_info)) {
-			__sync_fetch_and_add(&trace_stats->socket_map_count, 1);
-		}
-	}
+	int sockfd = ctx->ret;
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tgid = (__u32)(pid_tgid >> 32);
+	__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
+	__u32 role = ROLE_SERVER;
+	socket_role_map__update(&conn_key, &role);
 	return 0;
 }
 
 TPPROG(sys_exit_accept4)(struct syscall_comm_exit_ctx *ctx)
 {
-	__u32 k0 = 0;
-	struct trace_conf_t *trace_conf = trace_conf_map__lookup(&k0);
-	struct trace_stats *trace_stats = trace_stats_map__lookup(&k0);
-	if (trace_conf && trace_stats) {
-		int sockfd = ctx->ret;
-		__u64 pid_tgid = bpf_get_current_pid_tgid();
-		__u32 tgid = (__u32)(pid_tgid >> 32);
-		__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
-
-		struct socket_info_t sk_info = {
-			.role = ROLE_SERVER,
-		};
-
-		if (!socket_info_map__update(&conn_key, &sk_info)) {
-			__sync_fetch_and_add(&trace_stats->socket_map_count, 1);
-		}
-	}
+	int sockfd = ctx->ret;
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tgid = (__u32)(pid_tgid >> 32);
+	__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
+	__u32 role = ROLE_SERVER;
+	socket_role_map__update(&conn_key, &role);
 	return 0;
 }
 
 TPPROG(sys_enter_connect)(struct syscall_comm_enter_ctx *ctx)
 {
-	__u32 k0 = 0;
-	struct trace_conf_t *trace_conf = trace_conf_map__lookup(&k0);
-	struct trace_stats *trace_stats = trace_stats_map__lookup(&k0);
-	if (trace_conf && trace_stats) {
-		int sockfd = ctx->fd;
-		__u64 pid_tgid = bpf_get_current_pid_tgid();
-		__u32 tgid = (__u32)(pid_tgid >> 32);
-		__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
-
-		struct socket_info_t sk_info = {
-			.role = ROLE_CLIENT,
-		};
-
-		if (!socket_info_map__update(&conn_key, &sk_info)) {
-			__sync_fetch_and_add(&trace_stats->socket_map_count, 1);
-		}
-	}
+	int sockfd = ctx->fd;
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tgid = (__u32)(pid_tgid >> 32);
+	__u64 conn_key = gen_conn_key_id((__u64)tgid, (__u64)sockfd);
+	__u32 role = ROLE_CLIENT;
+	socket_role_map__update(&conn_key, &role);
 	return 0;
 }
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fix syscall trace id

#### Affected branches
- main
- 6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.