### PR TITLE
[AGENT] Fix monitor zero net statistics

### DIFF
--- a/agent/crates/public/src/utils/net/mod.rs
+++ b/agent/crates/public/src/utils/net/mod.rs
@@ -109,6 +109,7 @@ pub struct Link {
     pub if_type: Option<String>,
     pub peer_index: Option<u32>,
     pub link_netnsid: Option<u32>,
+    pub stats: LinkStats,
 }
 
 impl PartialEq for Link {
@@ -129,6 +130,16 @@ impl Ord for Link {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.if_index.cmp(&other.if_index)
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct LinkStats {
+    pub rx_packets: u64,
+    pub tx_packets: u64,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+    pub rx_dropped: u64,
+    pub tx_dropped: u64,
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
### This PR is for:
- Agent

### Fixes monitor zero net statistics
Current approach (with lib sysinfo) fetches interface statistics from `/sys/class/net`, which contains symlinks to net devices in current net namespace. However, `setns()` will not trigger an update in this folder, making it impossible to fetch statistics in this manner.
The new approach uses netlink to fetch interface statistics.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


