### PR TITLE
[Agent] fix empty l7 stats #22042

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1724,6 +1724,7 @@ impl FlowMap {
                 return;
             }
             let mut l7_stats = L7Stats::default();
+            let mut collect_stats = false;
             if flow.flow_key.proto == IpProtocol::TCP || flow.flow_key.proto == IpProtocol::UDP {
                 if let Some(perf) = node.meta_flow_log.as_mut() {
                     perf.copy_and_reset_l4_perf_data(flow.reversed, flow);
@@ -1740,6 +1741,7 @@ impl FlowMap {
                     if flow.flow_key.proto == IpProtocol::TCP
                         || flow.flow_key.proto == IpProtocol::UDP
                     {
+                        collect_stats = true;
                         l7_stats.stats = l7_perf_stats;
                         l7_stats.endpoint = flow.last_endpoint.clone();
                         l7_stats.flow_id = flow.flow_id;
@@ -1776,9 +1778,11 @@ impl FlowMap {
                 self.tagged_flow_allocator
                     .allocate_one_with(node.tagged_flow.clone()),
             );
-            l7_stats.flow = Some(tagged_flow.clone());
-            self.l7_stats_buffer
-                .push(self.l7_stats_allocator.allocate_one_with(l7_stats));
+            if collect_stats {
+                l7_stats.flow = Some(tagged_flow.clone());
+                self.l7_stats_buffer
+                    .push(self.l7_stats_allocator.allocate_one_with(l7_stats));
+            }
             self.push_to_flow_stats_queue(tagged_flow);
             node.reset_flow_stat_info();
         }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes extra empty l7_stats
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
