### PR TITLE
[eBPF] Fix process name change problem

### DIFF
--- a/agent/src/ebpf/samples/rust/profiler/src/main.rs
+++ b/agent/src/ebpf/samples/rust/profiler/src/main.rs
@@ -54,9 +54,17 @@ fn sk_data_str_safe(sd: *mut stack_profile_data) -> String {
 }
 
 #[allow(dead_code)]
-fn cp_process_name_safe(cp: *mut stack_profile_data) -> String {
+fn cp_comm_safe(cp: *mut stack_profile_data) -> String {
     unsafe {
         let v = &(*cp).comm;
+        String::from_utf8_lossy(v).to_string()
+    }
+}
+
+#[allow(dead_code)]
+fn cp_process_name_safe(cp: *mut stack_profile_data) -> String {
+    unsafe {
+        let v = &(*cp).process_name;
         String::from_utf8_lossy(v).to_string()
     }
 }
@@ -80,7 +88,7 @@ extern "C" fn continuous_profiler_callback(cp: *mut stack_profile_data) {
         increment_counter(1, 0);
         //let data = sk_data_str_safe(cp);
         //println!("\n+ --------------------------------- +");
-        //println!("{} PID {} START-TIME {} NETNS-ID {} U-STACKID {} K-STACKID {} COMM {} CPU {} COUNT {} LEN {} \n  - {}",
+        //println!("{} PID {} START-TIME {} NETNS-ID {} U-STACKID {} K-STACKID {} PROCESS_NAME {} COMM {} CPU {} COUNT {} LEN {} \n  - {}",
         //         date_time((*cp).timestamp),
         //         (*cp).pid,
         //         (*cp).stime,
@@ -88,6 +96,7 @@ extern "C" fn continuous_profiler_callback(cp: *mut stack_profile_data) {
         //         (*cp).u_stack_id,
         //         (*cp).k_stack_id,
         //         cp_process_name_safe(cp),
+        //         cp_comm_safe(cp),
         //         (*cp).cpu,
         //         (*cp).count,
         //         (*cp).stack_data_len, data);

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -431,6 +431,11 @@ u64 get_process_starttime(pid_t pid)
 	return ((etime_ticks * msecs_per_tick) + sys_boot);
 }
 
+u64 current_sys_time_secs(void)
+{
+	return (get_sys_uptime() + (get_sys_btime_msecs() / 1000));
+}
+
 /*
  * Get the start time (in milliseconds) of a given PID,
  * and fetch process comm.

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -265,4 +265,5 @@ u64 get_process_starttime_and_comm(pid_t pid,
 				   int len);
 u32 legacy_fetch_log2_page_size(void);
 u64 get_netns_id_from_pid(pid_t pid);
+u64 current_sys_time_secs(void);
 #endif /* DF_COMMON_H */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -141,4 +141,9 @@ enum {
 
 #define PROFILER_READER_EPOLL_TIMEOUT		500 //msecs
 #define EPOLL_SHORT_TIMEOUT			100  //mescs
+
+/* Process information recalibration time, this time is the number of seconds
+ * lost from the process startup time to the current time. */
+#define PROC_INFO_VERIFY_TIME  10 // 10 seconds
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -625,10 +625,10 @@ void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
 	kv.k.pid = (u64) pid;
 	kv.v.proc_info_p = 0;
 	kv.v.cache = 0;
+	struct symbolizer_proc_info *p;
 	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
 				      (symbol_caches_hash_kv *) & kv) != 0) {
-		struct symbolizer_proc_info *p =
-		    clib_mem_alloc_aligned("sym_proc_info",
+		p = clib_mem_alloc_aligned("sym_proc_info",
 					   sizeof(struct symbolizer_proc_info),
 					   0, NULL);
 		if (p == NULL) {
@@ -654,6 +654,13 @@ void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
 			return;
 		}
 
+		if ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
+		    PROC_INFO_VERIFY_TIME) {
+			p->verified = true;
+		} else {
+			p->verified = false;
+		}
+
 		kv.v.proc_info_p = pointer_to_uword(p);
 		kv.v.cache = 0;
 		if (symbol_caches_hash_add_del
@@ -665,6 +672,21 @@ void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
 			return;
 		} else
 			__sync_fetch_and_add(&h->hash_elems_count, 1);
+	} else {
+		p = (struct symbolizer_proc_info *)kv.v.proc_info_p; 
+		if (!p->verified && ((current_sys_time_secs() - (p->stime / 1000ULL)) >= 
+				     PROC_INFO_VERIFY_TIME)) {
+			p->stime = (u64) get_process_starttime_and_comm(pid,
+									p->comm,
+									sizeof(p->comm));
+			p->comm[sizeof(p->comm) - 1] = '\0';
+			if (p->stime == 0) {
+				ebpf_warning("pid %d get_process_starttime_and_comm() error\n",
+					     pid);
+			}
+
+			p->verified = true;
+		}
 	}
 
 	copy_process_name(&kv, name);
@@ -780,6 +802,13 @@ int create_and_init_symbolizer_caches(void)
 			if (p->stime == 0) {
 				clib_mem_free(p);
 				continue;
+			}
+
+			if ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
+			    PROC_INFO_VERIFY_TIME) {
+				p->verified = true;
+			} else {
+				p->verified = false;
 			}
 
 			sym.v.proc_info_p = pointer_to_uword(p);

--- a/agent/src/ebpf/user/symbol.h
+++ b/agent/src/ebpf/user/symbol.h
@@ -54,6 +54,12 @@ struct symbolizer_proc_info {
 	 * system boot, (in milliseconds) */
 	u64 stime;
 	u64 netns_id;
+	/*
+	 * Sometimes the process name set by some processes will be delayed.
+	 * When the process is just started, the name may change later. This
+	 * is used to delay confirmation.
+	 */
+	bool verified;
 	/* process name */
 	char comm[TASK_COMM_LEN];
 };


### PR DESCRIPTION
Sometimes there is a delay in setting the process name for some processes. The name may change later when the process is first started. Added delayed confirmation mechanism.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.3