### PR TITLE
[Agent] Fixes a problem where statistics were incorrect because stats was not reset #22164

### DIFF
--- a/agent/src/flow_generator/flow_node.rs
+++ b/agent/src/flow_generator/flow_node.rs
@@ -21,7 +21,7 @@ use crate::common::{
     decapsulate::TunnelType,
     endpoint::EndpointDataPov,
     enums::{EthernetType, TapType, TcpFlags},
-    flow::{FlowMetricsPeer, PacketDirection, SignalSource},
+    flow::{FlowMetricsPeer, L7PerfStats, PacketDirection, SignalSource, TcpPerfStats},
     lookup_key::LookupKey,
     meta_packet::MetaPacket,
     tagged_flow::TaggedFlow,
@@ -162,6 +162,11 @@ impl FlowNode {
         flow_metrics_peer_dst.l3_byte_count = 0;
         flow_metrics_peer_dst.l4_byte_count = 0;
         flow_metrics_peer_dst.tcp_flags = TcpFlags::empty();
+
+        if let Some(ref mut flow_perf_stats) = &mut flow.flow_perf_stats {
+            flow_perf_stats.tcp = TcpPerfStats::default();
+            flow_perf_stats.l7 = L7PerfStats::default();
+        }
     }
 
     pub fn match_node(


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes a problem where statistics were incorrect because stats was not reset #22164
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- reset the stats when report force
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
