### PR TITLE
[eBPF] Support symbolization of Java program addresses. (#4007)

### DIFF
--- a/.github/workflows/agent-verify.yml
+++ b/.github/workflows/agent-verify.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: verify agent
         run: |
-          docker run --rm  -t  --privileged --workdir /deepflow/  -v $(pwd):"/deepflow/"  --entrypoint "bash" ghcr.io/deepflowio/rust-build:1.23 "-c" "\
+          docker run --rm  -t  --privileged --workdir /deepflow/  -v $(pwd):"/deepflow/"  --entrypoint "bash" ghcr.io/deepflowio/rust-build:1.24 "-c" "\
           source /opt/rh/devtoolset-8/enable && \
           cp agent/docker/rust-proxy-config /usr/local/cargo/config && \
           cd  agent/src/ebpf && \
@@ -75,7 +75,7 @@ jobs:
 
       - name: verify agent
         run: |
-          docker run --rm  -t  --privileged --workdir /deepflow/  -v $(pwd):"/deepflow/"  --entrypoint "bash" ghcr.io/deepflowio/rust-build:1.22-arm64 "-c" "\
+          docker run --rm  -t  --privileged --workdir /deepflow/  -v $(pwd):"/deepflow/"  --entrypoint "bash" ghcr.io/deepflowio/rust-build:1.23-arm64 "-c" "\
           source /opt/rh/devtoolset-8/enable && \
           cd  agent/src/ebpf && \
           make clean && \

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ target/
 /agent/src/ebpf/user/socket_trace_bpf_5_2_plus.c
 /agent/src/ebpf/user/socket_trace_bpf_kylin.c
 /agent/src/ebpf/user/perf_profiler_bpf_common.c
+/agent/src/ebpf/user/profile/java_agent_so_gnu.c
+/agent/src/ebpf/user/profile/java_agent_so_musl.c
+/agent/src/ebpf/tools/bintobuffer
+/agent/src/ebpf/deepflow-jattach
+/agent/src/ebpf/user/profile/deepflow_jattach_bin.c
 /agent/src/ebpf/.profiler
 /agent/src/ebpf/.socket-tracer
 /agent/src/ebpf/samples/rust/profiler/target
@@ -45,3 +50,7 @@ target/
 /agent/src/ebpf/samples/rust/socket-tracer/target
 /agent/src/ebpf/samples/rust/socket-tracer/src/ebpf.rs
 /agent/src/ebpf/.flamegraph.pl
+
+
+
+

--- a/agent/docker/dockerfile-build
+++ b/agent/docker/dockerfile-build
@@ -1,4 +1,4 @@
-FROM ghcr.io/deepflowio/rust-build:1.23 as builder
+FROM ghcr.io/deepflowio/rust-build:1.24 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/docker/dockerfile-build-aarch64
+++ b/agent/docker/dockerfile-build-aarch64
@@ -1,5 +1,5 @@
 # TODO : aarch64 env rust-build update
-FROM ghcr.io/deepflowio/rust-build:1.22-arm64 as builder
+FROM ghcr.io/deepflowio/rust-build:1.23-arm64 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/docker/dockerfile-build-aarch64-static-link
+++ b/agent/docker/dockerfile-build-aarch64-static-link
@@ -1,5 +1,5 @@
 # TODO : aarch64 env rust-build update
-FROM ghcr.io/deepflowio/rust-build:1.21-arm64 as builder
+FROM ghcr.io/deepflowio/rust-build:1.23-arm64 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/docker/dockerfile-build-static-link
+++ b/agent/docker/dockerfile-build-static-link
@@ -1,4 +1,4 @@
-FROM ghcr.io/deepflowio/rust-build:1.22 as builder
+FROM ghcr.io/deepflowio/rust-build:1.24 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/src/common/l7_protocol_info.rs
+++ b/agent/src/common/l7_protocol_info.rs
@@ -172,7 +172,7 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
                         msg_type: param.direction.into(),
                         time: param.time,
                         kafka_info,
-                        multi_merge_info:None,
+                        multi_merge_info: None,
                     },
                 );
 
@@ -181,7 +181,6 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
                         .swap(perf_cache.rrt_cache.len() as u64, Ordering::Relaxed);
                     f.l7_timeout_cache_len
                         .swap(perf_cache.timeout_cache.len() as u64, Ordering::Relaxed)
-
                 });
                 return None;
             };
@@ -310,7 +309,7 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
         };
 
         let Some(mut previous_log_info) = previous_log_info else {
-            if msg_type == LogMessageType::Request{
+            if msg_type == LogMessageType::Request {
                 *in_cached_req += 1;
             }
             perf_cache.put(
@@ -319,7 +318,7 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
                     msg_type: param.direction.into(),
                     time: param.time,
                     kafka_info: None,
-                    multi_merge_info: Some((req_end,resp_end,false)),
+                    multi_merge_info: Some((req_end, resp_end, false)),
                 },
             );
 
@@ -328,7 +327,6 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
                     .swap(perf_cache.rrt_cache.len() as u64, Ordering::Relaxed);
                 f.l7_timeout_cache_len
                     .swap(perf_cache.timeout_cache.len() as u64, Ordering::Relaxed)
-
             });
             return None;
         };

--- a/agent/src/debug/debugger.rs
+++ b/agent/src/debug/debugger.rs
@@ -127,15 +127,15 @@ impl Debugger {
                     .spawn(move || {
                         while running_clone.load(Ordering::Relaxed) {
                             thread::sleep(BEACON_INTERVAL);
-                            let Some(hostname) = override_os_hostname.as_ref().clone().or_else(|| {
-                                match get_hostname() {
+                            let Some(hostname) = override_os_hostname.as_ref().clone().or_else(
+                                || match get_hostname() {
                                     Ok(hostname) => Some(hostname),
                                     Err(e) => {
                                         warn!("get hostname failed: {}", e);
                                         None
                                     }
-                                }
-                            }) else {
+                                },
+                            ) else {
                                 continue;
                             };
 
@@ -256,15 +256,15 @@ impl Debugger {
                     .spawn(move || {
                         while running_clone.load(Ordering::Relaxed) {
                             thread::sleep(BEACON_INTERVAL);
-                            let Some(hostname) = override_os_hostname.as_ref().clone().or_else(|| {
-                                match get_hostname() {
+                            let Some(hostname) = override_os_hostname.as_ref().clone().or_else(
+                                || match get_hostname() {
                                     Ok(hostname) => Some(hostname),
                                     Err(e) => {
                                         warn!("get hostname failed: {}", e);
                                         None
                                     }
-                                }
-                            }) else {
+                                },
+                            ) else {
                                 continue;
                             };
 

--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -33,6 +33,8 @@ ARCH := $(shell uname -m)
 
 CLANG ?= /usr/bin/clang
 CC ?= gcc
+GNU_CC ?= gcc
+MUSL_CC ?= musl-gcc
 OBJDIR ?= .
 STATIC_OBJDIR := $(OBJDIR)/staticobjs
 
@@ -40,14 +42,14 @@ define compile_socket_trace_elf
 	@echo "  COMPILE ELF kernel version $(1)"
 	@cd kernel && make clean --no-print-directory && make socket_trace.elf $(2) --no-print-directory && cd ../
 	@echo "  Generate file user/socket_trace_bpf_$(strip $1).c"
-	@./tools/ebpftobuffer kernel/socket_trace.elf user/socket_trace_bpf_$(strip $1).c socket_trace_$(strip $1)_ebpf_data
+	@./tools/bintobuffer kernel/socket_trace.elf user/socket_trace_bpf_$(strip $1).c socket_trace_$(strip $1)_ebpf_data
 endef
 
 define compile_perf_profiler_elf
 	@echo "  COMPILE ELF kernel version $(1)"
 	@cd kernel && make clean --no-print-directory && make perf_profiler.elf $(2) --no-print-directory && cd ../
 	@echo "  Generate file user/perf_profiler_bpf_$(strip $1).c"
-	@./tools/ebpftobuffer kernel/perf_profiler.elf user/perf_profiler_bpf_$(strip $1).c perf_profiler_$(strip $1)_ebpf_data
+	@./tools/bintobuffer kernel/perf_profiler.elf user/perf_profiler_bpf_$(strip $1).c perf_profiler_$(strip $1)_ebpf_data
 endef
 
 define check_gcc_version
@@ -86,8 +88,16 @@ OBJS := user/elf.o \
 	user/mem.o \
 	user/vec.o \
 	user/bihash.o \
-	user/perf_profiler.o \
-	user/stringifier.o
+	user/profile/perf_profiler.o \
+	user/profile/stringifier.o \
+	user/profile/java/df_jattach.o \
+	user/profile/attach.o
+
+JAVA_TOOL := deepflow-jattach
+JAVA_AGENT_GNU_SO := df_java_agent.so
+JAVA_AGENT_MUSL_SO := df_java_agent_musl.so
+JAVA_AGENT_SO := $(JAVA_AGENT_GNU_SO) $(JAVA_AGENT_MUSL_SO)
+JAVA_AGENT_SRC := user/profile/java/agent.c
 
 STATIC_OBJS := $(addprefix $(STATIC_OBJDIR)/,$(OBJS))
 CFLAGS ?= -std=gnu99 -g -O2 -ffunction-sections -fdata-sections -fPIC -Wall -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
@@ -106,7 +116,7 @@ endif
 #  where the error occurred.
 # -DDF_MEM_DEBUG Used for memory leak detection, to check for memory
 #  leak issues during the debugging phase.
-CFLAGS += $(MACHINE_CFLAGS) -fno-omit-frame-pointer -I.
+CFLAGS += $(MACHINE_CFLAGS) -fno-omit-frame-pointer -I/usr/lib/jvm/java/include -I/usr/lib/jvm/java/include/linux -I.
 ifeq ($(findstring musl,$(CC)),musl)
     IS_MUSL := 1
     ifeq ($(findstring aarch64,$(ARCH)),aarch64)
@@ -119,14 +129,17 @@ endif
 all: build
 
 ELFFILES = ./.data_done
-$(ELFFILES):
+
+tools/bintobuffer:
+	$(call msg,TOOLS,tools/bintobuffer)
+	@$(CC) tools/bintobuffer.c -o tools/bintobuffer
+
+$(ELFFILES): tools/bintobuffer
 	$(call msg,Clang/LLVM,,$(CLANG_VER))
 	@if [ $(CLANG_VER_MAIN) -lt 10 ]; then \
                 echo "  check llvm-clang fail. expect Clang/LLVM 10+" && exit 1; \
         fi
 	@rm -rf data
-	$(call msg,Tools,,tools/ebpftobuffer)
-	@$(CC) tools/ebpftobuffer.c -o tools/ebpftobuffer
 	$(call compile_socket_trace_elf, common)
 	$(call compile_socket_trace_elf, 5_2_plus, LINUX_VER_5_2_PLUS=1)
 	$(call compile_socket_trace_elf, kylin, LINUX_VER_KYLIN=1)
@@ -135,7 +148,7 @@ $(ELFFILES):
 
 $(STATIC_OBJDIR) $(SHARED_OBJDIR):
 	$(call msg,MKDIR,$@)
-	$(Q)mkdir -p $@/user
+	$(Q)mkdir -p $@/user/profile/java
 
 $(STATIC_OBJDIR)/%.o: %.c | $(STATIC_OBJDIR)
 	$(call msg,CC,$@)
@@ -145,16 +158,34 @@ $(LIBTRACE): $(STATIC_OBJS)
 	$(call msg,AR,$@)
 	$(Q)$(AR) rcs $@ $^
 
-build: $(ELFFILES) $(LIBTRACE)
+$(JAVA_AGENT_GNU_SO): tools/bintobuffer
+	$(call msg,SO,$@)
+	$(Q)$(GNU_CC) $(CFLAGS) -shared -o $@ $(JAVA_AGENT_SRC)
+	@rm -rf user/profile/java_agent_so_gnu.c
+	@./tools/bintobuffer ./$@ user/profile/java_agent_so_gnu.c java_agent_so_gnu
+
+$(JAVA_AGENT_MUSL_SO): tools/bintobuffer
+	$(call msg,SO,$@)
+	$(Q)$(MUSL_CC) $(CFLAGS) -shared -o $@ $(JAVA_AGENT_SRC)
+	@rm -rf user/profile/java_agent_so_musl.c
+	@./tools/bintobuffer ./$@ user/profile/java_agent_so_musl.c java_agent_so_musl
+
+build: $(ELFFILES) $(JAVA_TOOL) $(LIBTRACE)
 
 tools: $(LIBTRACE)
 	$(call msg,TOOLS,deepflow-ebpfctl)
 	$(Q)$(CC) $(CFLAGS) --static -g -O2 user/ctrl_tracer.c user/ctrl.c $(LIBTRACE) -o deepflow-ebpfctl -lelf -lz -lpthread
 
+$(JAVA_TOOL): $(JAVA_AGENT_SO)
+	$(call msg,TOOLS,$@)
+	$(Q)$(CC) $(CFLAGS) -DJAVA_AGENT_ATTACH_TOOL user/profile/java/df_jattach.c user/log.c user/common.c -ljattach -o $@ -ldl
+	@rm -rf user/profile/deepflow_jattach_bin.c
+	@./tools/bintobuffer ./$@ user/profile/deepflow_jattach_bin.c deepflow_jattach_bin
+
 rust-sample: .socket-tracer .profiler
 socket-tracer: .socket-tracer
 profiler: .profiler
-.socket-tracer: $(ELFFILES) $(LIBTRACE)
+.socket-tracer: $(ELFFILES) $(JAVA_TOOL) $(LIBTRACE)
 	$(call msg,Current-DIR,,$(CURR))
 	$(Q)rm -rf samples/rust/socket-tracer/src/ebpf.rs
 	$(Q)cp mod.rs samples/rust/socket-tracer/src/ebpf.rs
@@ -183,7 +214,7 @@ profiler: .profiler
         fi
 	$(Q)touch .socket-tracer
 
-.profiler: $(ELFFILES) $(LIBTRACE)
+.profiler: $(ELFFILES) $(JAVA_TOOL) $(LIBTRACE)
 	$(call msg,Current-DIR,,$(CURR))
 	$(Q)rm -rf samples/rust/profiler/src/ebpf.rs
 	$(Q)cp mod.rs samples/rust/profiler/src/ebpf.rs
@@ -224,6 +255,7 @@ clean:
 	$(Q)rm -rf .profiler .socket-tracer
 	$(Q)rm -rf samples/rust/socket-tracer/target
 	$(Q)rm -rf samples/rust/profiler/target
+	$(Q)rm -rf $(JAVA_AGENT_SO) $(JAVA_TOOL) tools/bintobuffer
 
 test: $(ELFFILES) $(LIBTRACE)
 	$(Q)$(MAKE) -C test --no-print-directory

--- a/agent/src/ebpf/samples/rust/profiler/src/main.rs
+++ b/agent/src/ebpf/samples/rust/profiler/src/main.rs
@@ -147,7 +147,7 @@ fn main() {
 
         set_profiler_regex(
             CString::new(
-                "^(socket_tracer|deepflow-.*)$".as_bytes(),
+                "^(socket_tracer|java|deepflow-.*)$".as_bytes(),
             )
             .unwrap()
             .as_c_str()

--- a/agent/src/ebpf/test/Makefile
+++ b/agent/src/ebpf/test/Makefile
@@ -27,9 +27,9 @@ CFLAGS ?= -std=gnu99 --static -g -O2 -ffunction-sections -fdata-sections -fPIC -
 EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec
 ifeq ($(ARCH), x86_64)
 #-lbcc -lstdc++
-        LDLIBS += ../libtrace.a -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++
+        LDLIBS += ../libtrace.a -ljattach -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl
 else ifeq ($(ARCH), aarch64)
-        LDLIBS += ../libtrace.a -lGoReSym -lbcc_bpf -ldwarf -lelf -lz -lpthread -lbcc -lstdc++
+        LDLIBS += ../libtrace.a -ljattach -lGoReSym -lbcc_bpf -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl
 endif
 
 all: $(EXECS) 

--- a/agent/src/ebpf/tools/bintobuffer.c
+++ b/agent/src/ebpf/tools/bintobuffer.c
@@ -1,9 +1,25 @@
 /*
- * file: tools/ebpftobuffer.c
+ * Copyright (c) 2023 Yunshan Networks
  *
- * This tool is used to convert eBPF bytecode into a buffer in C file.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Uage: ebpftobuffer <ebpf-elf-file> <target-file> <variable-name>
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * file: tools/bintobuffer.c
+ *
+ * This tool is used to convert eBPF/library bytecode into a buffer in C file.
+ *
+ * Uage: bintobuffer <ebpf-elf-file/library-file> <target-file> <variable-name>
  * @ebpf-elf-file : eBPF binary file path (to be converted)
  * @target-file : target c file path
  * @variable-name : buffer variable name
@@ -52,7 +68,7 @@ static unsigned char *read_bin_file(char *name, int *len)
 int main(int argc, char *argv[])
 {
 	if (argc < 4) {
-		printf("Uage:%s <ebpf-elf-file> <target-file> <variable-name>\n",
+		printf("Uage:%s <ebpf-elf-file/library-file> <target-file> <variable-name>\n",
 		       argv[0]);
 		return -1;
 	}

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -41,6 +41,8 @@
 #define NELEMS(a) (sizeof(a) / sizeof((a)[0]))
 #endif
 
+#define MAX_PATH_LENGTH 1024
+
 struct sysinfo {
 	long uptime;
 	unsigned long loads[3];
@@ -265,5 +267,12 @@ u64 get_process_starttime_and_comm(pid_t pid,
 				   int len);
 u32 legacy_fetch_log2_page_size(void);
 u64 get_netns_id_from_pid(pid_t pid);
+int get_nspid(int pid);
+int get_target_uid_and_gid(int target_pid, int *uid, int *gid);
+int copy_file(const char *src_file, const char *dest_file);
+int df_enter_ns(int pid, const char *type, int *self_fd);
+void df_exit_ns(int fd);
+int gen_file_from_mem(const char *mem_ptr, int write_bytes, const char *path);
+int exec_command(const char *cmd, const char *args);
 u64 current_sys_time_secs(void);
 #endif /* DF_COMMON_H */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -142,8 +142,13 @@ enum {
 #define PROFILER_READER_EPOLL_TIMEOUT		500 //msecs
 #define EPOLL_SHORT_TIMEOUT			100  //mescs
 
-/* Process information recalibration time, this time is the number of seconds
- * lost from the process startup time to the current time. */
-#define PROC_INFO_VERIFY_TIME  10 // 10 seconds
+/*
+ * Process information recalibration time, this time is the number of seconds
+ * lost from the process startup time to the current time.
+ * For Java :
+ *   The Java process will delay obtaining the symbol table by
+ *   'PROC_INFO_VERIFY_TIME' seconds after it starts running.
+ */
+#define PROC_INFO_VERIFY_TIME  60 // 60 seconds
 
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/log.c
+++ b/agent/src/ebpf/user/log.c
@@ -50,8 +50,10 @@ void os_puts(FILE *stream, char *string, uint32_t string_length, bool is_stdout)
 	iovs[n_iovs].iov_len = string_length;
 	n_iovs++;
 
-	if (is_stdout)
+	if (is_stdout) {
 		writev(1, iovs, n_iovs);
+		fflush(stdout);
+	}
 
 	if (!stream)
 		return;

--- a/agent/src/ebpf/user/profile/attach.c
+++ b/agent/src/ebpf/user/profile/attach.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <dlfcn.h>
+
+#include "../common.h"
+#include "../log.h"
+#include "java/df_jattach.h"
+#include "attach.h"
+
+void gen_java_symbols_file(int pid)
+{
+	int target_ns_pid = get_nspid(pid);
+	if (target_ns_pid < 0) {
+		return;
+	}
+
+	char path[128];
+	snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
+	/* If it already exists in the deepflow agent namespace, it will delete it. */
+	clear_target_ns_tmp_file(path);
+
+	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.log",
+		 pid, target_ns_pid);
+	if (access(path, F_OK) == 0) {
+		copy_file_from_target_ns(pid, target_ns_pid, "log");
+	}
+
+	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.map",
+		 pid, target_ns_pid);
+	/* If the file already exists, it will simply perform the copy operation and
+	 * then exit successfully.*/
+	if (access(path, F_OK) == 0) {
+		copy_file_from_target_ns(pid, target_ns_pid, "map");
+		return;
+	}
+
+	char args[32];
+	snprintf(args, sizeof(args), "%d", pid);
+
+	exec_command(DF_JAVA_ATTACH_CMD, args);
+
+	copy_file_from_target_ns(pid, target_ns_pid, "map");
+	copy_file_from_target_ns(pid, target_ns_pid, "log");
+	clear_target_ns(pid, target_ns_pid);
+}

--- a/agent/src/ebpf/user/profile/attach.h
+++ b/agent/src/ebpf/user/profile/attach.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ATTACH_H
+#define ATTACH_H
+
+#define DF_JAVA_ATTACH_CMD "/usr/bin/deepflow-jattach"
+void gen_java_symbols_file(int pid);
+#endif /* ATTACH_H */

--- a/agent/src/ebpf/user/profile/java/agent.c
+++ b/agent/src/ebpf/user/profile/java/agent.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file is compiled into agent.so, a shared library that will be injected
+ * into the target Java process. After injection, it creates a symbol log file
+ * into which each symbol is written.
+ */
+
+#include <sys/types.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <jni.h>
+#include <jvmti.h>
+#include <jvmticmlr.h>
+
+#define STRING_BUFFER_SIZE 2000
+#define BIG_STRING_BUFFER_SIZE 20000
+
+#define PERF_MAP_FILE_FMT "/tmp/perf-%d.map"
+#define PERF_MAP_LOG_FILE_FMT "/tmp/perf-%d.log"
+
+FILE *perf_map_file_ptr = NULL;
+FILE *perf_map_log_file_ptr = NULL;
+
+#define _(e)                                                                \
+	if (e != JNI_OK) {                                                  \
+		df_log("DF java agent failed, %s, error code: %d.", #e, e); \
+		return e;                                                   \
+	}
+
+void df_log(const char *format, ...)
+{
+	if (perf_map_log_file_ptr) {
+		va_list ap;
+		va_start(ap, format);
+		vfprintf(perf_map_log_file_ptr, format, ap);
+		fprintf(perf_map_log_file_ptr, "\n");
+		fflush(perf_map_log_file_ptr);
+		va_end(ap);
+	}
+}
+
+jint df_open_file(pid_t pid, const char *fmt, FILE ** ptr)
+{
+	FILE *file_ptr;
+	char filename[50];	// Assuming the filename won't exceed 50 characters
+
+	// Create the filename using snprintf
+	snprintf(filename, sizeof(filename), fmt, pid);
+
+	// Open the file for writing
+	file_ptr = fopen(filename, "w");
+	if (file_ptr == NULL) {
+		fprintf(stderr, "Couldn't open %s: errno(%d)", filename, errno);
+		return JNI_ERR;
+	}
+
+	*ptr = file_ptr;
+
+	return JNI_OK;
+}
+
+jint open_perf_map_file(pid_t pid)
+{
+	return df_open_file(pid, PERF_MAP_FILE_FMT, &perf_map_file_ptr);
+}
+
+jint open_perf_map_log_file(pid_t pid)
+{
+	return df_open_file(pid, PERF_MAP_LOG_FILE_FMT, &perf_map_log_file_ptr);
+}
+
+jint close_files(void)
+{
+	if (perf_map_file_ptr)
+		fclose(perf_map_file_ptr);
+
+	if (perf_map_log_file_ptr)
+		fclose(perf_map_log_file_ptr);
+
+	return JNI_OK;
+}
+
+JNIEXPORT uint64_t df_java_agent_so_libs_test(void)
+{
+       /*
+	* This function is used during the attach phase to select which
+	* agent shared object libraries (GNU or musl libc) to use, using
+	* dlopen() and dlsym().
+	*/
+	return 3302;
+}
+
+jint get_jvmti_env(JavaVM * jvm, jvmtiEnv ** jvmti)
+{
+	if (jvm == NULL || jvmti == NULL) {
+		return JNI_ERR;
+	}
+
+	jint error = (*jvm)->GetEnv(jvm, (void **)jvmti, JVMTI_VERSION_1_0);
+	if (error != JNI_OK || *jvmti == NULL) {
+		df_log("[error] Unable to access JVMTI.");
+		return JNI_ERR;
+	}
+	return JNI_OK;
+}
+
+void jvmti_err_log(jvmtiEnv * jvmti, const jvmtiError err_num,
+		   const char *help_msg_or_null)
+{
+	if (err_num == JVMTI_ERROR_NONE) {
+		return;		// No need to log if there's no error
+	}
+
+	const char *err_name_str = "unknown";
+	char *err_name_or_null;
+
+	if ((*jvmti)->GetErrorName(jvmti, err_num, &err_name_or_null) ==
+	    JVMTI_ERROR_NONE && err_name_or_null != NULL) {
+		err_name_str = err_name_or_null;
+	}
+
+	const char *help_message =
+	    (help_msg_or_null != NULL) ? help_msg_or_null : "";
+
+	df_log("[error][%d] %s: %s.", err_num, err_name_str, help_message);
+}
+
+jint enable_capabilities(jvmtiEnv * jvmti)
+{
+	jvmtiCapabilities capabilities;
+	memset(&capabilities, 0, sizeof(jvmtiCapabilities));
+
+	capabilities.can_get_source_file_name = 1;
+	capabilities.can_get_line_numbers = 1;
+	capabilities.can_generate_compiled_method_load_events = 1;
+
+	jvmtiError error = (*jvmti)->AddCapabilities(jvmti, &capabilities);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "Unable to get necessary JVMTI capabilities.");
+		return JNI_ERR;
+	}
+
+	return JNI_OK;
+}
+
+void deallocate(jvmtiEnv * jvmti, void *string)
+{
+	if (string != NULL)
+		(*jvmti)->Deallocate(jvmti, (unsigned char *)string);
+}
+
+void write_symbol(const void *code_addr, unsigned int code_size,
+		  const char *entry)
+{
+	fprintf(perf_map_file_ptr, "%lx %x %s\n", (unsigned long)code_addr,
+		code_size, entry);
+}
+
+void generate_single_entry(jvmtiEnv * jvmti,
+			   jmethodID method, const void *code_addr,
+			   jint code_size)
+{
+	jclass class;
+	char *method_name = NULL;
+	char *msig = NULL;
+	char *csig = NULL;
+
+	char output[STRING_BUFFER_SIZE];
+	char source_info[1000] = "";
+	char *method_signature = "";
+	size_t noutput = sizeof(output);
+
+	strncpy(output, "<error writing signature>", noutput);
+
+	if ((*jvmti)->GetMethodName(jvmti, method, &method_name, &msig, NULL) ==
+	    JVMTI_ERROR_NONE
+	    && (*jvmti)->GetMethodDeclaringClass(jvmti, method,
+						 &class) == JVMTI_ERROR_NONE
+	    && (*jvmti)->GetClassSignature(jvmti, class, &csig,
+					   NULL) == JVMTI_ERROR_NONE) {
+		char class_name[STRING_BUFFER_SIZE];
+		memset(class_name, 0, sizeof(class_name));
+		if (strlen(csig) < sizeof(class_name)) {
+			memcpy(class_name, csig, strlen(csig));
+		} else {
+			memcpy(class_name, csig, sizeof(class_name) - 1);
+		}
+		snprintf(output, noutput, "%s::%s%s%s", class_name,
+			 method_name, method_signature, source_info);
+
+		deallocate(jvmti, (unsigned char *)csig);
+	}
+
+	deallocate(jvmti, (unsigned char *)method_name);
+	deallocate(jvmti, (unsigned char *)msig);
+
+	write_symbol(code_addr, (unsigned int)code_size, output);
+}
+
+static void JNICALL
+cbCompiledMethodLoad(jvmtiEnv * jvmti,
+		     jmethodID method,
+		     jint code_size,
+		     const void *code_addr,
+		     jint map_length,
+		     const jvmtiAddrLocationMap * map, const void *compile_info)
+{
+	generate_single_entry(jvmti, method, code_addr, code_size);
+}
+
+void JNICALL
+cbDynamicCodeGenerated(jvmtiEnv * jvmti,
+		       const char *name, const void *address, jint length)
+{
+
+	write_symbol(address, (unsigned int)length, name);
+}
+
+void JNICALL
+cbCompiledMethodUnload(jvmtiEnv * jvmti,
+		       jmethodID method, const void *address)
+{
+
+	write_symbol(address, 0, "");
+}
+
+jvmtiError set_callback_funs(jvmtiEnv * jvmti)
+{
+	jvmtiEventCallbacks callbacks;
+
+	memset(&callbacks, 0, sizeof(callbacks));
+	callbacks.CompiledMethodLoad = &cbCompiledMethodLoad;
+	callbacks.CompiledMethodUnload = &cbCompiledMethodUnload;
+	callbacks.DynamicCodeGenerated = &cbDynamicCodeGenerated;
+
+	jvmtiError err = (*jvmti)->SetEventCallbacks(jvmti, &callbacks,
+						     (jint) sizeof(callbacks));
+	if (err != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, err,
+			      "Unable to attach CompiledMethodLoad callback.");
+		return JNI_ERR;
+	}
+
+	return JNI_OK;
+}
+
+jint set_notification_modes(jvmtiEnv * jvmti, jvmtiEventMode mode)
+{
+	jvmtiError error;
+
+	error =
+	    (*jvmti)->SetEventNotificationMode(jvmti, mode,
+					       JVMTI_EVENT_COMPILED_METHOD_LOAD,
+					       NULL);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "Unable to set notification mode for CompiledMethodLoad.");
+		return JNI_ERR;
+	}
+
+	error =
+	    (*jvmti)->SetEventNotificationMode(jvmti, mode,
+					       JVMTI_EVENT_COMPILED_METHOD_UNLOAD,
+					       NULL);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "Unable to set notification mode for CompiledMethodUnload.");
+		return JNI_ERR;
+	}
+
+	error =
+	    (*jvmti)->SetEventNotificationMode(jvmti, mode,
+					       JVMTI_EVENT_DYNAMIC_CODE_GENERATED,
+					       NULL);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "Unable to set notification mode for DynamicCodeGenerated.");
+		return JNI_ERR;
+	}
+
+	return JNI_OK;
+}
+
+jint replay_callbacks(jvmtiEnv * jvmti)
+{
+	jvmtiError error;
+	jvmtiPhase phase;
+
+	error = (*jvmti)->GetPhase(jvmti, &phase);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "replay_callbacks(): GetPhase() error.");
+		return JNI_ERR;
+	}
+
+	if (phase != JVMTI_PHASE_LIVE) {
+		df_log("Skipping replay_callbacks(), not in live phase.");
+		return JNI_OK;
+	}
+
+	error =
+	    (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_DYNAMIC_CODE_GENERATED);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "GenerateEvents(JVMTI_EVENT_DYNAMIC_CODE_GENERATED).");
+		return JNI_ERR;
+	}
+
+	error =
+	    (*jvmti)->GenerateEvents(jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD);
+	if (error != JVMTI_ERROR_NONE) {
+		jvmti_err_log(jvmti, error,
+			      "GenerateEvents(JVMTI_EVENT_COMPILED_METHOD_LOAD).");
+		return JNI_ERR;
+	}
+
+	return JNI_OK;
+}
+
+JNIEXPORT jint JNICALL
+Agent_OnAttach(JavaVM * vm, char *options, void *reserved)
+{
+	jvmtiEnv *jvmti;
+	_(open_perf_map_log_file(getpid()));
+	_(open_perf_map_file(getpid()));
+	_(get_jvmti_env(vm, &jvmti));
+	_(enable_capabilities(jvmti));
+	_(set_callback_funs(jvmti));
+	_(set_notification_modes(jvmti, JVMTI_ENABLE));
+	_(replay_callbacks(jvmti));
+	_(set_notification_modes(jvmti, JVMTI_DISABLE));
+	_(close_files());
+
+	return 0;
+}

--- a/agent/src/ebpf/user/profile/java/df_jattach.c
+++ b/agent/src/ebpf/user/profile/java/df_jattach.c
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <dlfcn.h>
+
+#include "../../common.h"
+#include "../../log.h"
+#include "df_jattach.h"
+
+static char agent_lib_so_path[MAX_PATH_LENGTH];
+extern int jattach(int pid, int argc, char **argv);
+
+static int agent_so_lib_copy(const char *src, const char *dst, int uid, int gid)
+{
+	if (access(src, F_OK)) {
+		ebpf_info("Fun %s src file '%s' not exist.\n", __func__, src);
+		return ETR_NOTEXIST;
+	}
+
+	if (copy_file(src, dst)) {
+		return ETR_INVAL;
+	}
+
+	if (chown(dst, uid, gid) != 0) {
+		ebpf_warning
+		    ("Failed to change ownership and group. file '%s'\n", dst);
+		return ETR_INVAL;
+	}
+
+	return ETR_OK;
+}
+
+static int copy_agent_libs_into_target_ns(pid_t target_pid, int target_uid,
+					  int target_gid)
+{
+	/*
+	 * Call this function only when the target process is in a subordinate
+	 * namespace. Here, we copy the agent.so to a temporary path within t-
+	 * he mounted namespace. We also change the file ownership so that the
+	 * target process sees itself as the owner of the file (this is neces-
+	 * sary because some versions of Java might reject proxy injection
+	 * otherwise).
+	 */
+	int ret;
+	char copy_target_path[MAX_PATH_LENGTH];
+	int len = snprintf(copy_target_path, sizeof(copy_target_path),
+			   "/proc/%d/root/tmp", target_pid);
+	if (access(copy_target_path, F_OK)) {
+		if (mkdir(copy_target_path, 0777) != 0) {
+			ebpf_info(JAVA_LOG_TAG "Fun %s cannot mkdir() '%s'\n",
+				  __func__, copy_target_path);
+
+			return ETR_NOTEXIST;
+		}
+	}
+
+	snprintf(copy_target_path + len, sizeof(copy_target_path) - len,
+		 "/%s", AGENT_LIB_NAME);
+
+	if ((ret =
+	     agent_so_lib_copy(AGENT_LIB_SRC_PATH,
+			       copy_target_path, target_uid,
+			       target_gid)) != ETR_OK) {
+		return ret;
+	}
+
+	snprintf(copy_target_path + len, sizeof(copy_target_path) - len,
+		 "/%s", AGENT_MUSL_LIB_NAME);
+
+	if ((ret =
+	     agent_so_lib_copy(AGENT_MUSL_LIB_SRC_PATH,
+			       copy_target_path, target_uid,
+			       target_gid)) != ETR_OK) {
+		return ret;
+	}
+
+	return ETR_OK;
+}
+
+bool test_dl_open(const char *so_lib_file_path)
+{
+	if (access(so_lib_file_path, F_OK)) {
+		ebpf_info(JAVA_LOG_TAG "Fun %s file '%s' not exist.\n",
+			  __func__, so_lib_file_path);
+
+		return false;
+	}
+
+	/*
+	 * By calling dlerror() before each dlopen()/dlsym() invocation,
+	 * you can clear any prior error state, ensuring that you accur-
+	 * ately obtain error information pertaining to the current
+	 * operation.
+	 */
+	dlerror();
+	void *h = dlopen(so_lib_file_path, RTLD_LAZY);
+
+	if (h == NULL) {
+		ebpf_info(JAVA_LOG_TAG "Fuc '%s' dlopen() path %s failure: %s.",
+			  __func__, so_lib_file_path, dlerror());
+		return false;
+	}
+
+	dlerror();
+	agent_test_t test_fn =
+	    (uint64_t(*)(void))dlsym(h, "df_java_agent_so_libs_test");
+
+	if (test_fn == NULL) {
+		ebpf_info(JAVA_LOG_TAG "Func '%s' dlsym() path %s failure: %s.",
+			  __func__, so_lib_file_path, dlerror());
+		return false;
+	}
+
+	const uint64_t expected_test_fn_result = 3302;
+	const uint64_t observed_test_fn_result = test_fn();
+
+	if (observed_test_fn_result != expected_test_fn_result) {
+		ebpf_info(JAVA_LOG_TAG
+			  "%s test '%s' function returned: %lu, expected %lu.",
+			  __func__, so_lib_file_path, observed_test_fn_result,
+			  expected_test_fn_result);
+		return false;
+	}
+
+	ebpf_info(JAVA_LOG_TAG "%s: Success for %s.", __func__,
+		  so_lib_file_path);
+	return true;
+}
+
+static void select_sitable_agent_lib(pid_t pid)
+{
+	/* Enter pid & mount namespace for target pid,
+	 * and use dlopen() in that namespace.*/
+	int pid_self_fd, mnt_self_fd;
+	df_enter_ns(pid, "pid", &pid_self_fd);
+	df_enter_ns(pid, "mnt", &mnt_self_fd);
+
+	agent_lib_so_path[0] = '\0';
+	if (test_dl_open(AGENT_LIB_SRC_PATH)) {
+		snprintf(agent_lib_so_path, MAX_PATH_LENGTH, "%s",
+			 AGENT_LIB_SRC_PATH);
+		ebpf_info(JAVA_LOG_TAG
+			  "Func %s target PID %d test %s, success.\n", __func__,
+			  pid, AGENT_LIB_SRC_PATH);
+		goto found;
+	}
+
+	if (test_dl_open(AGENT_MUSL_LIB_SRC_PATH)) {
+		snprintf(agent_lib_so_path, MAX_PATH_LENGTH, "%s",
+			 AGENT_MUSL_LIB_SRC_PATH);
+		ebpf_info(JAVA_LOG_TAG
+			  "Func %s target PID %d test %s, success.\n", __func__,
+			  pid, AGENT_MUSL_LIB_SRC_PATH);
+		goto found;
+	}
+
+	ebpf_warning(JAVA_LOG_TAG "%s test agent so libs, failure.", __func__);
+
+found:
+	df_exit_ns(pid_self_fd);
+	df_exit_ns(mnt_self_fd);
+}
+
+static int attach(pid_t pid)
+{
+	char *argv[] = { "load", agent_lib_so_path, "true" };
+	int argc = sizeof(argv) / sizeof(argv[0]);
+	int ret = jattach(pid, argc, (char **)argv);
+	ebpf_info(JAVA_LOG_TAG
+		  "jattach pid %d argv: \"load %s true\" return %d\n", pid,
+		  agent_lib_so_path, ret);
+
+	return ret;
+}
+
+void clear_target_ns_tmp_file(const char *target_path)
+{
+	if (access(target_path, F_OK) == 0) {
+		if (unlink(target_path) != 0)
+			ebpf_info(JAVA_LOG_TAG "rm file %s failed\n",
+				  target_path);
+	}
+}
+
+static inline bool is_same_netns(int target_pid)
+{
+	struct stat self_st, target_st;
+	char path[64];
+	snprintf(path, sizeof(path), "/proc/self/ns/net");
+	if (stat(path, &self_st) != 0)
+		return false;
+
+	snprintf(path, sizeof(path), "/proc/%d/ns/net", target_pid);
+	if (stat(path, &target_st) != 0)
+		return false;
+
+	if (self_st.st_ino == target_st.st_ino) {
+		return true;
+	}
+
+	return false;
+}
+
+void clear_target_ns(int pid, int target_ns_pid)
+{
+	/*
+	 * Delete files:
+	 *  /tmp/perf-<pid>.map
+	 *  /tmp/perf-<pid>.log
+	 *  /tmp/df_java_agent.so
+	 *  /tmp/df_java_agent_musl.so
+	 */
+
+	if (is_same_netns(pid))
+		return;
+
+	char target_path[MAX_PATH_LENGTH];
+	snprintf(target_path, sizeof(target_path),
+		 "/proc/%d/root/tmp/perf-%d.map", pid, target_ns_pid);
+	clear_target_ns_tmp_file(target_path);
+	snprintf(target_path, sizeof(target_path),
+		 "/proc/%d/root/tmp/perf-%d.log", pid, target_ns_pid);
+	clear_target_ns_tmp_file(target_path);
+	snprintf(target_path, sizeof(target_path), "/proc/%d/root%s", pid,
+		 AGENT_MUSL_LIB_SRC_PATH);
+	clear_target_ns_tmp_file(target_path);
+	snprintf(target_path, sizeof(target_path), "/proc/%d/root%s", pid,
+		 AGENT_LIB_SRC_PATH);
+	clear_target_ns_tmp_file(target_path);
+}
+
+static int get_target_ns_info(const char *tag, struct stat *st)
+{
+	int fd;
+	char selfpath[64];
+	snprintf(selfpath, sizeof(selfpath), "/proc/self/ns/%s", tag);
+	if (st != NULL) {
+		if (stat(selfpath, st) != 0)
+			return -1;
+	}
+
+	fd = open(selfpath, O_RDONLY);
+	if (fd < 0)
+		return -1;
+
+	return fd;
+}
+
+static inline void get_nsfd_and_stat(const char *tag, struct stat *st, int *fd)
+{
+	*fd = get_target_ns_info(tag, st);
+}
+
+static inline void switch_to_root_ns(int root_fd)
+{
+	/*
+	 * If the user of the target namespace is a non-root user, it will be
+	 * impossible to switch the target namespace to the root namespace.
+	 * There may be a better solution.
+	 * (TODO @jiping)
+	 */
+	df_exit_ns(root_fd);
+}
+
+void copy_file_from_target_ns(int pid, int ns_pid, const char *file_type)
+{
+	if (is_same_netns(pid))
+		return;
+
+	char target_path[128];
+	char src_path[128];
+	snprintf(src_path, sizeof(src_path), "/proc/%d/root/tmp/perf-%d.%s",
+		 pid, ns_pid, file_type);
+	snprintf(target_path, sizeof(target_path), "/tmp/perf-%d.%s", pid,
+		 file_type);
+
+	if (access(src_path, F_OK) != 0) {
+		return;
+	}
+
+	if (access(target_path, F_OK) == 0) {
+		if (unlink(target_path) != 0)
+			return;
+	}
+
+	if (copy_file(src_path, target_path)) {
+		ebpf_warning("Copy '%s' to '%s' failed.\n", src_path,
+			     target_path);
+	}
+}
+
+int java_attach(pid_t pid)
+{
+#ifdef NS_FILES_COPY_TEST
+	int net_fd, ipc_fd, mnt_fd;
+	net_fd = ipc_fd = mnt_fd = -1;
+#endif
+	int ret;
+	int uid, gid;
+	if (get_target_uid_and_gid(pid, &uid, &gid)) {
+		return -1;
+	}
+
+	int target_ns_pid = get_nspid(pid);
+	if (target_ns_pid < 0) {
+		return -1;
+	}
+
+	char path[128];
+	snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
+	/* If it already exists in the root namespace, it will return directly. */
+	if (access(path, F_OK) == 0) {
+		return 0;
+	}
+
+	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.map",
+		 pid, target_ns_pid);
+	/* If the file already exists, it will simply perform the copy operation and
+	 * then exit successfully.*/
+	if (access(path, F_OK) == 0) {
+		copy_file_from_target_ns(pid, target_ns_pid, "map");
+		return 0;
+	}
+
+	if (!is_same_netns(pid)) {
+		/*
+		 * If the target Java process is in a subordinate namespace, copy the
+		 * 'agent.so' into the artifacts path (in /tmp) inside of that namespace
+		 * (for visibility to the target process).
+		 */
+		if (copy_agent_libs_into_target_ns(pid, uid, gid)) {
+			goto failed;
+		}
+	}
+
+	/*
+	 * In containers, different libc implementations may be used to compile agent
+	 * libraries, primarily two types: glibc and musl. We must provide both vers-
+	 * ions of the agent library. So, which one should we choose? To determine t-
+	 * his, we need to enter the target process's namespace and test each library
+	 * until we find one that can be successfully loaded using dlopen.
+	 */
+	select_sitable_agent_lib(pid);
+
+	if (strlen(agent_lib_so_path) == 0)
+		goto failed;
+
+	/* Invoke the jattach (https://github.com/apangin/jattach) to inject the
+	 * library as a JVMTI agent.*/
+
+#ifdef NS_FILES_COPY_TEST
+	/* The jattach() function will switch the namespace to the target PID.
+	 * After we have called jattach(), we need to return to the root namespace.*/
+
+	get_nsfd_and_stat("net", NULL, &net_fd);
+	get_nsfd_and_stat("ipc", NULL, &ipc_fd);
+	get_nsfd_and_stat("mnt", NULL, &mnt_fd);
+	if (net_fd < 0 || ipc_fd < 0 || mnt_fd < 0)
+		goto failed;
+#endif
+
+	ret = attach(pid);
+
+#ifdef NS_FILES_COPY_TEST
+	/*
+	 * Copy target namespace 'perf-<target_ns_pid>.map' to host root namespace
+	 * '/tmp/perf-<target_ns_pid>.map'
+	 */
+	if (target_ns_pid != pid) {
+		switch_to_root_ns(net_fd);
+		switch_to_root_ns(ipc_fd);
+		switch_to_root_ns(mnt_fd);
+		if (ret == 0) {
+			copy_file_from_target_ns(pid, target_ns_pid, "map");
+			copy_file_from_target_ns(pid, target_ns_pid, "log");
+		}
+		clear_target_ns(pid, target_ns_pid);
+	} else {
+		close(net_fd);
+		close(ipc_fd);
+		close(mnt_fd);
+	}
+#endif
+	return ret;
+
+failed:
+#ifdef NS_FILES_COPY_TEST
+	if (net_fd > 0)
+		close(net_fd);
+
+	if (ipc_fd > 0)
+		close(ipc_fd);
+
+	if (mnt_fd > 0)
+		close(mnt_fd);
+
+	/* Current at root namespace */
+	if (target_ns_pid != pid)
+		clear_target_ns(pid, target_ns_pid);
+#endif
+	return -1;
+}
+
+#ifdef JAVA_AGENT_ATTACH_TOOL
+int main(int argc, char **argv)
+{
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s <pid>\n", argv[0]);
+		return -1;
+	}
+
+	log_to_stdout = true;
+	int pid = atoi(argv[1]);
+	return java_attach(pid);
+}
+#endif /* JAVA_AGENT_ATTACH_TEST */

--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DF_JATTACH_H
+#define DF_JATTACH_H
+
+#define AGENT_LIB_NAME "df_java_agent.so"
+#define AGENT_LIB_SRC_PATH "/tmp/" AGENT_LIB_NAME
+
+#define AGENT_MUSL_LIB_NAME "df_java_agent_musl.so"
+#define AGENT_MUSL_LIB_SRC_PATH "/tmp/" AGENT_MUSL_LIB_NAME
+
+#define JAVA_LOG_TAG "[JAVA]"
+
+typedef uint64_t(*agent_test_t) (void);
+
+void clear_target_ns_tmp_file(const char *target_path);
+void copy_file_from_target_ns(int pid, int ns_pid, const char *file_type);
+void clear_target_ns(int pid, int target_ns_pid);
+#endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Yunshan Networks
+ * Copyright (c) 2023 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,44 @@
  * using musl.
  */
 #ifndef AARCH64_MUSL
+#include <sys/stat.h>
 #include <bcc/perf_reader.h>
-#include "config.h"
-#include "common.h"
-#include "mem.h"
-#include "log.h"
-#include "types.h"
-#include "vec.h"
-#include "tracer.h"
+#include "../config.h"
+#include "../common.h"
+#include "../mem.h"
+#include "../log.h"
+#include "../types.h"
+#include "../vec.h"
+#include "../tracer.h"
+#include "attach.h"
 #include "perf_profiler.h"
-#include "elf.h"
-#include "load.h"
-#include "../kernel/include/perf_profiler.h"
-#include "perf_reader.h"
-#include "bihash_8_8.h"
+#include "../elf.h"
+#include "../load.h"
+#include "../../kernel/include/perf_profiler.h"
+#include "../perf_reader.h"
+#include "../bihash_8_8.h"
 #include "stringifier.h"
-#include "table.h"
+#include "../table.h"
 #include <regex.h>
+#include "java/df_jattach.h"
 
-#include "perf_profiler_bpf_common.c"
+#include "../perf_profiler_bpf_common.c"
+
+/*
+ * This section is for symbolization of Java addresses, and we need
+ * to prepare two so librarys, one for GNU and the other for MUSL:
+ *
+ * df_java_agent.so
+ * df_java_agent_musl.so
+ *
+ * These two files need to be saved in the '/tmp' directory, and the
+ * agent so library will be injected into the JVM to generate
+ * 'perf-<pid>.map'.
+ */
+#include "java_agent_so_gnu.c"
+#include "java_agent_so_musl.c"
+/* use for java symbols generate */
+#include "deepflow_jattach_bin.c"
 
 #define LOG_CP_TAG	"[CP] "
 #define CP_TRACER_NAME	"continuous_profiler"
@@ -60,7 +79,9 @@ static __thread bool msg_clear_hash;
 
 // for flame-graph test
 static FILE *folded_file;
-#define FOLDED_FILE_PATH "./profiler.folded" 
+#define FOLDED_FILE_PATH "./profiler.folded"
+static char *flame_graph_start_time;
+static char *flame_graph_end_time;
 
 /* "Maximum data push interval time (in seconds). */
 #define MAX_PUSH_MSG_TIME_INTERVAL 10
@@ -115,8 +136,8 @@ static u64 transfer_count;
 static u64 process_count;
 
 static void print_profiler_status(struct bpf_tracer *t, u64 iter_count,
-				  stack_str_hash_t *h,
-				  stack_trace_msg_hash_t *msg_h);
+				  stack_str_hash_t * h,
+				  stack_trace_msg_hash_t * msg_h);
 static void print_cp_tracer_status(struct bpf_tracer *t);
 
 /*
@@ -124,7 +145,7 @@ static void print_cp_tracer_status(struct bpf_tracer *t);
  * to be missing (processes that start and exit quickly). This variable
  * is used to count the number of lost processes during the parsing process.
  */
-static atomic64_t process_lost_count; 
+static atomic64_t process_lost_count;
 
 static u64 get_process_lost_count(void)
 {
@@ -147,12 +168,11 @@ static inline stack_trace_msg_t *alloc_stack_trace_msg(int len)
 
 static void set_msg_kvp_by_comm(stack_trace_msg_kv_t * kvp,
 				const char *process_name,
-				struct stack_trace_key_t *v,
-				void *msg_value)
+				struct stack_trace_key_t *v, void *msg_value)
 {
 	if (process_name == NULL) {
 		strcpy_s_inline(kvp->c_k.comm, sizeof(kvp->c_k.comm),
-        	                v->comm, strlen(v->comm));
+				v->comm, strlen(v->comm));
 	} else {
 		strcpy_s_inline(kvp->c_k.comm, sizeof(kvp->c_k.comm),
 				process_name, strlen(process_name));
@@ -174,9 +194,7 @@ static void set_msg_kvp_by_comm(stack_trace_msg_kv_t * kvp,
 }
 
 static void set_msg_kvp(stack_trace_msg_kv_t * kvp,
-			struct stack_trace_key_t *v,
-			u64 stime,
-			void *msg_value)
+			struct stack_trace_key_t *v, u64 stime, void *msg_value)
 {
 	kvp->k.tgid = v->tgid;
 	kvp->k.pid = v->pid;
@@ -187,20 +205,17 @@ static void set_msg_kvp(stack_trace_msg_kv_t * kvp,
 	kvp->msg_ptr = pointer_to_uword(msg_value);
 }
 
-static void set_stack_trace_msg(stack_trace_msg_t *msg,
+static void set_stack_trace_msg(stack_trace_msg_t * msg,
 				struct stack_trace_key_t *v,
 				bool matched,
-				u64 stime,
-				u64 ns_id,
-				const char *process_name)
+				u64 stime, u64 ns_id, const char *process_name)
 {
 	msg->pid = v->tgid;
 	msg->tid = v->pid;
 	msg->cpu = v->cpu;
 	msg->u_stack_id = (u32) v->userstack;
 	msg->k_stack_id = (u32) v->kernstack;
-	strcpy_s_inline(msg->comm, sizeof(msg->comm),
-			v->comm, strlen(v->comm));
+	strcpy_s_inline(msg->comm, sizeof(msg->comm), v->comm, strlen(v->comm));
 	msg->stime = stime;
 	msg->netns_id = ns_id;
 
@@ -243,6 +258,11 @@ static void set_stack_trace_msg(stack_trace_msg_t *msg,
 	msg->time_stamp = gettime(CLOCK_REALTIME, TIME_TYPE_NAN);
 	msg->count = 1;
 	msg->data_ptr = pointer_to_uword(&msg->data[0]);
+
+	/* Only use for test flame graph. */
+	if (flame_graph_start_time == NULL) {
+		flame_graph_start_time = gen_file_name_by_datetime();
+	}
 }
 
 static void reader_lost_cb(void *t, u64 lost)
@@ -289,7 +309,7 @@ static int relase_profiler(struct bpf_tracer *tracer)
 	return ETR_OK;
 }
 
-static int init_stack_trace_msg_hash(stack_trace_msg_hash_t *h,
+static int init_stack_trace_msg_hash(stack_trace_msg_hash_t * h,
 				     const char *name)
 {
 	memset(h, 0, sizeof(*h));
@@ -299,24 +319,25 @@ static int init_stack_trace_msg_hash(stack_trace_msg_hash_t *h,
 					 nbuckets, hash_memory_size);
 }
 
-static int push_and_free_msg_kvp_cb(stack_trace_msg_hash_kv *kv, void *ctx)
+static int push_and_free_msg_kvp_cb(stack_trace_msg_hash_kv * kv, void *ctx)
 {
-	stack_trace_msg_kv_t *msg_kv = (stack_trace_msg_kv_t *)kv;
+	stack_trace_msg_kv_t *msg_kv = (stack_trace_msg_kv_t *) kv;
 	if (msg_kv->msg_ptr != 0) {
-		stack_trace_msg_t *msg = (stack_trace_msg_t *)msg_kv->msg_ptr;
+		stack_trace_msg_t *msg = (stack_trace_msg_t *) msg_kv->msg_ptr;
 #ifdef CP_DEBUG
-		ebpf_debug("tiemstamp %lu pid %u stime %lu u_stack_id %lu k_statck_id"
-			   "%lu cpu %u count %u comm %s datalen %u data %s\n",
-			   msg->time_stamp, msg->pid, msg->stime, msg->u_stack_id,
-			   msg->k_stack_id, msg->cpu, msg->count, msg->comm,
-			   msg->data_len, msg->data);
+		ebpf_debug
+		    ("tiemstamp %lu pid %u stime %lu u_stack_id %lu k_statck_id"
+		     "%lu cpu %u count %u comm %s datalen %u data %s\n",
+		     msg->time_stamp, msg->pid, msg->stime, msg->u_stack_id,
+		     msg->k_stack_id, msg->cpu, msg->count, msg->comm,
+		     msg->data_len, msg->data);
 #endif
 		tracer_callback_t fun = profiler_tracer->process_fn;
 		/*
- 		 * Execute callback function to hand over the data to the
- 		 * higher level for processing. The higher level will se-
- 		 * nd the data to the server for storage as required.
- 		 */
+		 * Execute callback function to hand over the data to the
+		 * higher level for processing. The higher level will se-
+		 * nd the data to the server for storage as required.
+		 */
 		if (likely(profiler_stop == 0))
 			fun(msg);
 
@@ -339,7 +360,7 @@ static int push_and_free_msg_kvp_cb(stack_trace_msg_hash_kv *kv, void *ctx)
  * Push the data and release the resources.
  * @is_force: Do you need to perform a forced release?
  */
-static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t *h,
+static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t * h,
 					     bool is_force)
 {
 	ASSERT(profiler_tracer != NULL);
@@ -378,7 +399,8 @@ static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t *h,
 	stack_trace_msg_hash_kv *v;
 	vec_foreach(v, trace_msg_kvps) {
 		if (stack_trace_msg_hash_add_del(h, v, 0 /* delete */ )) {
-			ebpf_warning("stack_trace_msg_hash_add_del() failed.\n");
+			ebpf_warning
+			    ("stack_trace_msg_hash_add_del() failed.\n");
 			msg_clear_hash = true;
 		}
 	}
@@ -405,9 +427,9 @@ static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t *h,
 
 static void aggregate_stack_traces(struct bpf_tracer *t,
 				   const char *stack_map_name,
-				   stack_str_hash_t *stack_str_hash,
-				   stack_trace_msg_hash_t *msg_hash,
-				   u32 *count)
+				   stack_str_hash_t * stack_str_hash,
+				   stack_trace_msg_hash_t * msg_hash,
+				   u32 * count)
 {
 	struct stack_trace_key_t *v;
 	vec_foreach(v, raw_stack_data) {
@@ -457,7 +479,8 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 		stack_trace_msg_kv_t kv;
 		char name[TASK_COMM_LEN];
 		u64 stime, netns_id;
-		get_process_info_by_pid(v->tgid, &stime, &netns_id, (char *)name);
+		get_process_info_by_pid(v->tgid, &stime, &netns_id,
+					(char *)name);
 		char *process_name = NULL;
 		bool matched = false;
 
@@ -467,20 +490,24 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 			else
 				process_name = name;
 
-			matched = (regexec(&profiler_regex, process_name, 0, NULL, 0) == 0);
+			matched =
+			    (regexec(&profiler_regex, process_name, 0, NULL, 0)
+			     == 0);
 			if (matched)
 				set_msg_kvp(&kv, v, stime, (void *)0);
 			else
-				set_msg_kvp_by_comm(&kv, process_name, v, (void *)0);
+				set_msg_kvp_by_comm(&kv, process_name, v,
+						    (void *)0);
 		} else {
 			/* Not find process in procfs. */
 			set_msg_kvp_by_comm(&kv, NULL, v, (void *)0);
 		}
 
-		if (stack_trace_msg_hash_search(msg_hash, (stack_trace_msg_hash_kv *)&kv,
-						(stack_trace_msg_hash_kv *)&kv) == 0) {
+		if (stack_trace_msg_hash_search
+		    (msg_hash, (stack_trace_msg_hash_kv *) & kv,
+		     (stack_trace_msg_hash_kv *) & kv) == 0) {
 			__sync_fetch_and_add(&msg_hash->hit_hash_count, 1);
-			((stack_trace_msg_t *)kv.msg_ptr)->count++;
+			((stack_trace_msg_t *) kv.msg_ptr)->count++;
 
 			continue;
 		}
@@ -495,8 +522,8 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 		 */
 
 		char *trace_str =
-			resolve_and_gen_stack_trace_str(t, v, stack_map_name,
-							stack_str_hash, matched);
+		    resolve_and_gen_stack_trace_str(t, v, stack_map_name,
+						    stack_str_hash, matched);
 		if (trace_str) {
 			/*
 			 * append process/thread name to stack string
@@ -510,19 +537,24 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 				continue;
 			}
 
-			set_stack_trace_msg(msg, v, matched, stime, netns_id, process_name);
-			snprintf((char *)&msg->data[0], str_len, "%s;%s", v->comm, trace_str);
+			set_stack_trace_msg(msg, v, matched, stime, netns_id,
+					    process_name);
+			snprintf((char *)&msg->data[0], str_len, "%s;%s",
+				 v->comm, trace_str);
 			msg->data_len = str_len - 1;
 			clib_mem_free(trace_str);
 			kv.msg_ptr = pointer_to_uword(msg);
-			
+
 			if (stack_trace_msg_hash_add_del(msg_hash,
-							 (stack_trace_msg_hash_kv *)&kv,
+							 (stack_trace_msg_hash_kv
+							  *) & kv,
 							 1 /* is_add */ )) {
-				ebpf_warning("stack_trace_msg_hash_add_del() failed.\n");
+				ebpf_warning
+				    ("stack_trace_msg_hash_add_del() failed.\n");
 				clib_mem_free(msg);
 			} else {
-				__sync_fetch_and_add(&msg_hash->hash_elems_count, 1);
+				__sync_fetch_and_add(&msg_hash->
+						     hash_elems_count, 1);
 			}
 		}
 
@@ -606,7 +638,7 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 
 	if (nfds > 0) {
 
-check_again:
+	      check_again:
 		if (unlikely(profiler_stop == 1))
 			goto release_iter;
 
@@ -633,7 +665,8 @@ check_again:
 		 * to incomplete processing.
 		 */
 		if (bpf_table_get_value(t, MAP_PROFILER_STATE_MAP,
-					sample_count_idx, (void *)&sample_cnt_val)) {
+					sample_count_idx,
+					(void *)&sample_cnt_val)) {
 			if (sample_cnt_val > count) {
 				nfds = reader_epoll_short_wait(r, events);
 				if (nfds > 0)
@@ -685,7 +718,7 @@ static void cp_reader_work(void *arg)
 	}
 
 exit:
-        print_cp_tracer_status(t);
+	print_cp_tracer_status(t);
 
 	print_hash_stack_str(&g_stack_str_hash);
 	/* free stack_str_hash */
@@ -747,12 +780,12 @@ static int create_profiler(struct bpf_tracer *tracer)
 		return ETR_NORESOURCE;
 	}
 
-	/* attach perf event */
-	tracer_hooks_attach(tracer);
-
 	/* syms_cache_hash maps from pid to BCC symbol cache.
 	 * Use of void* is inherited from the BCC library. */
 	create_and_init_symbolizer_caches();
+
+	/* attach perf event */
+	tracer_hooks_attach(tracer);
 
 	/*
 	 * Start a new thread to execute the data
@@ -772,6 +805,10 @@ static int create_profiler(struct bpf_tracer *tracer)
 int stop_continuous_profiler(void)
 {
 	profiler_stop = 1;
+	if (flame_graph_end_time == NULL) {
+		flame_graph_end_time = gen_file_name_by_datetime();
+	}
+
 	release_bpf_tracer(CP_TRACER_NAME);
 	profiler_tracer = NULL;
 
@@ -832,17 +869,18 @@ static void print_cp_tracer_status(struct bpf_tracer *t)
 		  " - output_err_cnt:\t%lu\n"
 		  " - iter_max_cnt:\t%lu\n"
 		  "----------------------------\n\n",
-		  atomic64_read(&t->recv), process_count, atomic64_read(&t->lost),
-		  get_process_lost_count(), get_stack_table_data_miss_count(),
-		  stack_trace_lost, transfer_count,
+		  atomic64_read(&t->recv), process_count,
+		  atomic64_read(&t->lost), get_process_lost_count(),
+		  get_stack_table_data_miss_count(), stack_trace_lost,
+		  transfer_count,
 		  ((double)atomic64_read(&t->recv) / (double)transfer_count),
-		  alloc_b, free_b, alloc_b - free_b, output_count, sample_drop_cnt,
-		  output_err_cnt, iter_max_cnt);
+		  alloc_b, free_b, alloc_b - free_b, output_count,
+		  sample_drop_cnt, output_err_cnt, iter_max_cnt);
 }
 
 static void print_profiler_status(struct bpf_tracer *t, u64 iter_count,
-				  stack_str_hash_t *h,
-				  stack_trace_msg_hash_t *msg_h)
+				  stack_str_hash_t * h,
+				  stack_trace_msg_hash_t * msg_h)
 {
 	u64 alloc_b, free_b;
 	get_mem_stat(&alloc_b, &free_b);
@@ -900,8 +938,7 @@ static bool check_kallsyms_addr_is_zero(void)
  * @callback Profile data processing callback interface
  * @returns 0 on success, < 0 on error
  */
-int start_continuous_profiler(int freq,
-			      tracer_callback_t callback)
+int start_continuous_profiler(int freq, tracer_callback_t callback)
 {
 	char bpf_load_buffer_name[NAME_LEN];
 	void *bpf_bin_buffer;
@@ -933,6 +970,66 @@ int start_continuous_profiler(int freq,
 	// CPUID will not be included in the aggregation of stack trace data.
 	set_profiler_cpu_aggregation(0);
 
+	// Java agent so library generation.
+	if (access(AGENT_LIB_SRC_PATH, F_OK) == 0) {
+		if (unlink(AGENT_LIB_SRC_PATH) != 0) {
+			ebpf_warning(LOG_CP_TAG "rm file %s failed.\n",
+				     AGENT_LIB_SRC_PATH);
+			return (-1);
+		}
+	}
+
+	if (access(AGENT_MUSL_LIB_SRC_PATH, F_OK) == 0) {
+		if (unlink(AGENT_MUSL_LIB_SRC_PATH) != 0) {
+			ebpf_warning(LOG_CP_TAG "rm file %s failed.\n",
+				     AGENT_MUSL_LIB_SRC_PATH);
+			return (-1);
+		}
+	}
+
+	if (gen_file_from_mem((const char *)java_agent_so_gnu,
+			      sizeof(java_agent_so_gnu),
+			      (const char *)AGENT_LIB_SRC_PATH)) {
+		ebpf_warning(LOG_CP_TAG
+			     "Java agent so library(%s) generate failed.\n",
+			     AGENT_LIB_SRC_PATH);
+		return (-1);
+	}
+
+	if (gen_file_from_mem((const char *)java_agent_so_musl,
+			      sizeof(java_agent_so_musl),
+			      (const char *)AGENT_MUSL_LIB_SRC_PATH)) {
+		ebpf_warning(LOG_CP_TAG
+			     "Java agent so library(%s) generate failed.\n",
+			     AGENT_MUSL_LIB_SRC_PATH);
+		return (-1);
+	}
+
+	/* For java attach tool */
+	if (access(JAVA_ATTACH_TOOL_PATH, F_OK) == 0) {
+		if (unlink(JAVA_ATTACH_TOOL_PATH) != 0) {
+			ebpf_warning(LOG_CP_TAG "rm file %s failed.\n",
+				     JAVA_ATTACH_TOOL_PATH);
+			return (-1);
+		}
+	}
+
+	if (gen_file_from_mem((const char *)deepflow_jattach_bin,
+			      sizeof(deepflow_jattach_bin),
+			      (const char *)JAVA_ATTACH_TOOL_PATH)) {
+		ebpf_warning(LOG_CP_TAG
+			     "Java attach tool (%s) generate failed.\n",
+			     JAVA_ATTACH_TOOL_PATH);
+		return (-1);
+	}
+
+	if (chmod(JAVA_ATTACH_TOOL_PATH, 0755) < 0) {
+		ebpf_warning(LOG_CP_TAG
+			     "file '%s' chmod failed.\n",
+			     JAVA_ATTACH_TOOL_PATH);
+		return (-1);
+	}
+
 	snprintf(bpf_load_buffer_name, NAME_LEN, "continuous_profiler");
 	bpf_bin_buffer = (void *)perf_profiler_common_ebpf_data;
 	buffer_sz = sizeof(perf_profiler_common_ebpf_data);
@@ -951,7 +1048,7 @@ int start_continuous_profiler(int freq,
 
 static u64 test_add_count, stack_count;
 static u64 test_hit_count, msg_ptr_zero_count;
-void process_stack_trace_data_for_flame_graph(stack_trace_msg_t *msg)
+void process_stack_trace_data_for_flame_graph(stack_trace_msg_t * msg)
 {
 	stack_count++;
 	if (folded_file == NULL) {
@@ -962,14 +1059,15 @@ void process_stack_trace_data_for_flame_graph(stack_trace_msg_t *msg)
 	}
 
 	/* Ensure that the buffer is long enough to accommodate the stack trace string. */
-	int len = msg->data_len + sizeof(msg->comm) + sizeof(msg->process_name) + 64;
+	int len =
+	    msg->data_len + sizeof(msg->comm) + sizeof(msg->process_name) + 64;
 	char str[len];
 	/* profile regex match ? */
 	if (msg->stime > 0)
-		snprintf(str, len, "%s (%d);%s %u\n", msg->process_name, msg->pid,
-			 msg->data, msg->count);
+		snprintf(str, len, "%s (%d);%s %u\n", msg->process_name,
+			 msg->pid, msg->data, msg->count);
 	else
-		snprintf(str, len, "%s;%s %u\n", msg->process_name, /*msg->pid,*/
+		snprintf(str, len, "%s;%s %u\n", msg->process_name,	/*msg->pid, */
 			 msg->data, msg->count);
 
 	os_puts(folded_file, str, strlen(str), false);
@@ -979,7 +1077,8 @@ void release_flame_graph_hash(void)
 {
 	u64 alloc_b, free_b;
 	get_mem_stat(&alloc_b, &free_b);
-	ebpf_info(LOG_CP_TAG "pre alloc_b:\t%lu bytes free_b:\t%lu bytes use:\t%lu"
+	ebpf_info(LOG_CP_TAG
+		  "pre alloc_b:\t%lu bytes free_b:\t%lu bytes use:\t%lu"
 		  " bytes\n", alloc_b, free_b, alloc_b - free_b);
 	if (folded_file)
 		fclose(folded_file);
@@ -988,16 +1087,21 @@ void release_flame_graph_hash(void)
 #ifdef DF_MEM_DEBUG
 	show_mem_list();
 #endif
-	ebpf_info(LOG_CP_TAG "after alloc_b:\t%lu bytes free_b:\t%lu bytes use:\t%lu"
-		  " bytes\n",alloc_b, free_b, alloc_b - free_b);
+	ebpf_info(LOG_CP_TAG
+		  "after alloc_b:\t%lu bytes free_b:\t%lu bytes use:\t%lu"
+		  " bytes\n", alloc_b, free_b, alloc_b - free_b);
 
-	ebpf_info(LOG_CP_TAG "<<< stack_count %lu add_count %lu hit_count %lu msg_ptr_zero"
-		  "_count %lu push_count %lu >>>\n", stack_count, test_add_count, test_hit_count,
-		  msg_ptr_zero_count, push_count);
+	ebpf_info(LOG_CP_TAG
+		  "<<< stack_count %lu add_count %lu hit_count %lu msg_ptr_zero"
+		  "_count %lu push_count %lu >>>\n", stack_count,
+		  test_add_count, test_hit_count, msg_ptr_zero_count,
+		  push_count);
 
-	ebpf_info(LOG_CP_TAG "Please use the following command to generate a flame graph:"
+	ebpf_info(LOG_CP_TAG
+		  "Please use the following command to generate a flame graph:"
 		  "\n\n\033[33;1mcat ./profiler.folded |./.flamegraph.pl"
-		  " --countname=samples --inverted > profiler-test.svg\033[0m\n");
+		  " --countname=samples --inverted > profiler-from_%s_to_%s.svg\033[0m\n",
+		  flame_graph_start_time, flame_graph_end_time);
 }
 
 /*
@@ -1009,7 +1113,8 @@ void release_flame_graph_hash(void)
 int set_profiler_regex(const char *pattern)
 {
 	if (profiler_tracer == NULL) {
-		ebpf_warning(LOG_CP_TAG "The 'profiler_tracer' has not been created yet."
+		ebpf_warning(LOG_CP_TAG
+			     "The 'profiler_tracer' has not been created yet."
 			     " Please use start_continuous_profiler() to create it first.\n");
 		return (-1);
 	}
@@ -1023,7 +1128,8 @@ int set_profiler_regex(const char *pattern)
 	tracer_reader_lock(profiler_tracer);
 	if (*pattern == '\0') {
 		regex_existed = false;
-		ebpf_warning(LOG_CP_TAG "Set 'profiler_regex' pattern : '', an empty"
+		ebpf_warning(LOG_CP_TAG
+			     "Set 'profiler_regex' pattern : '', an empty"
 			     " regular expression will not generate any stack data."
 			     "Please configure the regular expression for profiler.\n");
 		tracer_reader_unlock(profiler_tracer);
@@ -1037,8 +1143,10 @@ int set_profiler_regex(const char *pattern)
 	int ret = regcomp(&profiler_regex, pattern, REG_EXTENDED);
 	if (ret != 0) {
 		char error_buffer[100];
-		regerror(ret, &profiler_regex, error_buffer, sizeof(error_buffer));
-		ebpf_warning(LOG_CP_TAG "Pattern %s failed to compile the regular "
+		regerror(ret, &profiler_regex, error_buffer,
+			 sizeof(error_buffer));
+		ebpf_warning(LOG_CP_TAG
+			     "Pattern %s failed to compile the regular "
 			     "expression: %s\n", pattern, error_buffer);
 		regex_existed = false;
 		tracer_reader_unlock(profiler_tracer);
@@ -1047,20 +1155,23 @@ int set_profiler_regex(const char *pattern)
 
 	regex_existed = true;
 	tracer_reader_unlock(profiler_tracer);
-	ebpf_info(LOG_CP_TAG "Set 'profiler_regex' successful, pattern : '%s'", pattern);
+	ebpf_info(LOG_CP_TAG "Set 'profiler_regex' successful, pattern : '%s'",
+		  pattern);
 	return (0);
 }
 
 int set_profiler_cpu_aggregation(int flag)
 {
 	if (flag != 0 && flag != 1) {
-		ebpf_info(LOG_CP_TAG "Set 'cpu_aggregation_flag' parameter invalid.\n");
+		ebpf_info(LOG_CP_TAG
+			  "Set 'cpu_aggregation_flag' parameter invalid.\n");
 		return (-1);
 	}
 
-	cpu_aggregation_flag = (u64)flag;
+	cpu_aggregation_flag = (u64) flag;
 
-	ebpf_info(LOG_CP_TAG "Set 'cpu_aggregation_flag' successful, value %d\n", flag);
+	ebpf_info(LOG_CP_TAG
+		  "Set 'cpu_aggregation_flag' successful, value %d\n", flag);
 	return (0);
 }
 
@@ -1074,8 +1185,7 @@ int set_profiler_cpu_aggregation(int flag)
  * @callback Profile data processing callback interface
  * @returns 0 on success, < 0 on error
  */
-int start_continuous_profiler(int freq,
-			      tracer_callback_t callback)
+int start_continuous_profiler(int freq, tracer_callback_t callback)
 {
 	return (-1);
 }

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Yunshan Networks
+ * Copyright (c) 2023 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 #ifndef DF_USER_PERF_PROFILER_H
 #define DF_USER_PERF_PROFILER_H
-#include "bihash_24_8.h"
+#include "../bihash_24_8.h"
 
 /*
  * stack_trace_msg_hash, used to store stack trace messages and
@@ -33,6 +33,8 @@
 #define stack_trace_msg_hash_free	clib_bihash_free_24_8
 #define stack_trace_msg_hash_key_value_pair_cb		clib_bihash_foreach_key_value_pair_cb_24_8
 #define stack_trace_msg_hash_foreach_key_value_pair	clib_bihash_foreach_key_value_pair_24_8
+
+#define JAVA_ATTACH_TOOL_PATH DF_JAVA_ATTACH_CMD
 
 /*
  * stack trace messages for push-hash kvp.

--- a/agent/src/ebpf/user/profile/stringifier.c
+++ b/agent/src/ebpf/user/profile/stringifier.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Yunshan Networks
+ * Copyright (c) 2023 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,21 +41,21 @@
  */
 
 #ifndef AARCH64_MUSL
-#include "config.h"
-#include "common.h"
-#include "mem.h"
-#include "log.h"
-#include "types.h"
-#include "vec.h"
-#include "tracer.h"
+#include "../config.h"
+#include "../common.h"
+#include "../mem.h"
+#include "../log.h"
+#include "../types.h"
+#include "../vec.h"
+#include "../tracer.h"
 #include "perf_profiler.h"
-#include "elf.h"
-#include "load.h"
-#include "../kernel/include/perf_profiler.h"
-#include "perf_reader.h"
-#include "table.h"
-#include "bihash_8_8.h"
-#include "bihash_16_8.h"
+#include "../elf.h"
+#include "../load.h"
+#include "../../kernel/include/perf_profiler.h"
+#include "../perf_reader.h"
+#include "../table.h"
+#include "../bihash_8_8.h"
+#include "../bihash_16_8.h"
 #include "stringifier.h"
 #include <bcc/bcc_syms.h>
 

--- a/agent/src/ebpf/user/profile/stringifier.h
+++ b/agent/src/ebpf/user/profile/stringifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Yunshan Networks
+ * Copyright (c) 2023 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -45,6 +45,8 @@
 #include "bddisasm/disasmtypes.h"
 #endif
 #include "libGoReSym.h"
+#include "profile/java/df_jattach.h"
+#include "profile/attach.h"
 
 static u64 add_symcache_count;
 static u64 free_symcache_count;
@@ -483,7 +485,19 @@ static inline void free_symbolizer_cache_kvp(struct symbolizer_cache_kvp *kv)
 	}
 
 	if (kv->v.proc_info_p) {
-		clib_mem_free((void *)kv->v.proc_info_p);
+		struct symbolizer_proc_info *p;
+		p = (struct symbolizer_proc_info *)kv->v.proc_info_p;
+		if (p->is_java) {
+			/* Delete Java files '/tmp/perf-<pid>.<map|log>' */
+			int pid = (int)kv->k.pid;
+			char path[MAX_PATH_LENGTH];
+			snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
+			clear_target_ns_tmp_file(path);
+			snprintf(path, sizeof(path), "/tmp/perf-%d.log", pid);
+			clear_target_ns_tmp_file(path);
+		}
+
+		clib_mem_free((void *)p);
 		kv->v.proc_info_p = 0;
 	}
 }
@@ -608,8 +622,30 @@ u64 get_pid_stime(pid_t pid)
 	return 0;
 }
 
-void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
-			     char *name)
+static void java_proc_info_config(struct symbolizer_proc_info *p, int pid)
+{
+	if (strcmp(p->comm, "java") == 0)
+		p->is_java = true;
+	else
+		p->is_java = false;
+
+	if ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
+	    PROC_INFO_VERIFY_TIME) {
+		p->verified = true;
+		/*
+		 * Ensure the Java program runs stably for a period
+		 * of time before obtaining the Java address and
+		 * symbol mapping table.
+		 */
+		if (p->is_java)
+			gen_java_symbols_file(pid);
+
+	} else {
+		p->verified = false;
+	}
+}
+
+void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 {
 	ASSERT(pid >= 0 && stime != NULL && netns_id != NULL && name != NULL);
 
@@ -654,13 +690,7 @@ void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
 			return;
 		}
 
-		if ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
-		    PROC_INFO_VERIFY_TIME) {
-			p->verified = true;
-		} else {
-			p->verified = false;
-		}
-
+		java_proc_info_config(p, pid);
 		kv.v.proc_info_p = pointer_to_uword(p);
 		kv.v.cache = 0;
 		if (symbol_caches_hash_add_del
@@ -673,17 +703,40 @@ void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id,
 		} else
 			__sync_fetch_and_add(&h->hash_elems_count, 1);
 	} else {
-		p = (struct symbolizer_proc_info *)kv.v.proc_info_p; 
-		if (!p->verified && ((current_sys_time_secs() - (p->stime / 1000ULL)) >= 
-				     PROC_INFO_VERIFY_TIME)) {
+		p = (struct symbolizer_proc_info *)kv.v.proc_info_p;
+		if (!p->verified
+		    && ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
+			PROC_INFO_VERIFY_TIME)) {
+			/*
+			 * To prevent the possibility of the process name being changed
+			 * shortly after the program's initial startup, as a precaution,
+			 * we will reacquire it after the program has been running stably
+			 * for a period of time to avoid such situations.
+			 */
 			p->stime = (u64) get_process_starttime_and_comm(pid,
 									p->comm,
-									sizeof(p->comm));
+									sizeof
+									(p->comm));
 			p->comm[sizeof(p->comm) - 1] = '\0';
 			if (p->stime == 0) {
-				ebpf_warning("pid %d get_process_starttime_and_comm() error\n",
-					     pid);
+				ebpf_warning
+				    ("pid %d get_process_starttime_and_comm() error\n",
+				     pid);
 			}
+
+			if (strcmp(p->comm, "java") == 0)
+				p->is_java = true;
+			else
+				p->is_java = false;
+
+			/*
+			 * We obtain the symbol table in the Java program after it has been
+			 * running for a while, rather than during the program's startup p-
+			 * rocess, to avoid situations where the symbol table cannot be re-
+			 * trieved.
+			 */
+			if (p->is_java)
+				gen_java_symbols_file(pid);
 
 			p->verified = true;
 		}
@@ -804,13 +857,7 @@ int create_and_init_symbolizer_caches(void)
 				continue;
 			}
 
-			if ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
-			    PROC_INFO_VERIFY_TIME) {
-				p->verified = true;
-			} else {
-				p->verified = false;
-			}
-
+			java_proc_info_config(p, pid);
 			sym.v.proc_info_p = pointer_to_uword(p);
 			sym.v.cache = 0;
 			if (symbol_caches_hash_add_del

--- a/agent/src/ebpf/user/symbol.h
+++ b/agent/src/ebpf/user/symbol.h
@@ -60,6 +60,8 @@ struct symbolizer_proc_info {
 	 * is used to delay confirmation.
 	 */
 	bool verified;
+	/* To mark whether it is a Java process? */
+	bool is_java;
 	/* process name */
 	char comm[TASK_COMM_LEN];
 };

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -582,7 +582,8 @@ impl FlowMap {
                     // 没有找到严格匹配的 FlowNode，插入新 Node
                     let node = self.new_flow_node(config, meta_packet);
                     if let Some(node) = node {
-                        time_set[node.timestamp_key as usize & (self.time_window_size - 1)].insert(pkt_key);
+                        time_set[node.timestamp_key as usize & (self.time_window_size - 1)]
+                            .insert(pkt_key);
                         nodes.push(node);
                         max_depth += 1;
                     }

--- a/agent/src/flow_generator/protocol_logs/fastcgi.rs
+++ b/agent/src/flow_generator/protocol_logs/fastcgi.rs
@@ -138,7 +138,7 @@ impl FastCGIInfo {
     ) -> Result<()> {
         let mut p = param_payload;
         while p.len() > 2 {
-            let Ok((off,key_len,val_len)) = read_param_kv_len(p) else {
+            let Ok((off, key_len, val_len)) = read_param_kv_len(p) else {
                 break;
             };
             p = &p[off..];
@@ -188,8 +188,9 @@ impl FastCGIInfo {
             b"HTTP_USER_AGENT" => self.user_agent = Some(String::from_utf8_lossy(val).to_string()),
             _ => {
                 // value must be valid utf8 from here
-                let (Ok(key), Ok(val)) = (std::str::from_utf8(key), std::str::from_utf8(val)) else {
-                    return Ok(())
+                let (Ok(key), Ok(val)) = (std::str::from_utf8(key), std::str::from_utf8(val))
+                else {
+                    return Ok(());
                 };
                 let lower_key = key.to_lowercase();
                 let key = lower_key.as_str();
@@ -536,7 +537,7 @@ fn read_param_kv_len(param_payload: &[u8]) -> Result<(usize, usize, usize)> {
 fn get_param_val<'a>(param_payload: &'a [u8], key: &str) -> Result<&'a [u8]> {
     let mut p = param_payload;
     while p.len() > 2 {
-        let Ok((off,key_len,val_len)) = read_param_kv_len(p) else {
+        let Ok((off, key_len, val_len)) = read_param_kv_len(p) else {
             break;
         };
         p = &p[off..];

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -462,7 +462,7 @@ impl From<&[u8]> for SofaHdr {
             new_rpc_trace_context: "".to_string(),
         };
         while let Some((key, val)) = read_b32_kv(&mut payload) {
-            let Ok(key_str) = std::str::from_utf8(key) else{
+            let Ok(key_str) = std::str::from_utf8(key) else {
                 return ret;
             };
             match key_str {
@@ -548,10 +548,10 @@ pub fn decode_new_rpc_trace_context_with_type(mut payload: &[u8], id_type: u8) -
 }
 
 fn read_url_param_kv<'a>(payload: &mut &'a [u8]) -> Option<(&'a [u8], &'a [u8])> {
-    let Ok((rest, key)) = payload.split_at_position::<_,()>(|b| b == b'=')else{
+    let Ok((rest, key)) = payload.split_at_position::<_, ()>(|b| b == b'=') else {
         return None;
     };
-    let Ok((rest, val)) = (&rest[1..]).split_at_position::<_,()>(|b| b == b'&')else{
+    let Ok((rest, val)) = (&rest[1..]).split_at_position::<_, ()>(|b| b == b'&') else {
         return None;
     };
     *payload = &rest[1..];

--- a/agent/src/platform/kubernetes/api_watcher.rs
+++ b/agent/src/platform/kubernetes/api_watcher.rs
@@ -278,7 +278,10 @@ impl ApiWatcher {
             if r.disabled {
                 continue;
             }
-            let Some(index) = supported_resources.iter().position(|sr| &sr.name == &r.name) else {
+            let Some(index) = supported_resources
+                .iter()
+                .position(|sr| &sr.name == &r.name)
+            else {
                 warn!("resource {} not supported", r.name);
                 continue;
             };
@@ -309,8 +312,15 @@ impl ApiWatcher {
                 }
                 continue;
             }
-            let Some(index) = sr.group_versions.iter().position(|gv| &gv.group == &r.group && &gv.version == &r.version) else {
-                warn!("resource {} in group {}/{} not supported", r.name, r.group, r.version);
+            let Some(index) = sr
+                .group_versions
+                .iter()
+                .position(|gv| &gv.group == &r.group && &gv.version == &r.version)
+            else {
+                warn!(
+                    "resource {} in group {}/{} not supported",
+                    r.name, r.group, r.version
+                );
                 continue;
             };
             resources.push(Resource {
@@ -337,7 +347,10 @@ impl ApiWatcher {
             .await
             .map_err(|e| Error::KubernetesApiWatcher(format!("{}", e)))?;
         for api_resource in core_resources.resources {
-            let Some(index) = resources.iter().position(|r| &r.name == &api_resource.name && r.group_versions.iter().any(|gv| gv.group == "core")) else {
+            let Some(index) = resources.iter().position(|r| {
+                &r.name == &api_resource.name
+                    && r.group_versions.iter().any(|gv| gv.group == "core")
+            }) else {
                 continue;
             };
             debug!(
@@ -406,13 +419,20 @@ impl ApiWatcher {
 
                         for api_resource in api_resources.unwrap().resources {
                             let resource_name = api_resource.name;
-                            let Some(index) = resources.iter().position(|r| &r.name == &resource_name && r.group_versions.iter().any(|gv| gv.group == &group.name)) else {
+                            let Some(index) = resources.iter().position(|r| {
+                                &r.name == &resource_name
+                                    && r.group_versions.iter().any(|gv| gv.group == &group.name)
+                            }) else {
                                 continue;
                             };
-                            let Some(gv_index) = resources[index].group_versions.iter().position(|gv| gv.group == &group.name && gv.version == &version.version) else {
-                                debug!("skipped {} api in group {} with other version",
-                                    resource_name,
-                                    version.group_version
+                            let Some(gv_index) =
+                                resources[index].group_versions.iter().position(|gv| {
+                                    gv.group == &group.name && gv.version == &version.version
+                                })
+                            else {
+                                debug!(
+                                    "skipped {} api in group {} with other version",
+                                    resource_name, version.group_version
                                 );
                                 continue;
                             };

--- a/agent/src/platform/kubernetes/passive_poller.rs
+++ b/agent/src/platform/kubernetes/passive_poller.rs
@@ -88,7 +88,9 @@ impl PassivePoller {
     fn get_ignored_interface_indice() -> HashSet<u32> {
         let mut ignored = HashSet::new();
 
-        let Ok(addrs) = addr_list() else { return ignored; };
+        let Ok(addrs) = addr_list() else {
+            return ignored;
+        };
         for addr in addrs {
             if addr.scope != RT_SCOPE_LINK {
                 ignored.insert(addr.if_index);

--- a/agent/src/platform/kubernetes/sidecar_poller.rs
+++ b/agent/src/platform/kubernetes/sidecar_poller.rs
@@ -37,7 +37,11 @@ impl SidecarPoller {
             thread::sleep(Duration::from_secs(1));
             process::exit(-1);
         };
-        let Some(link) = links.into_iter().filter(|link| link.mac_addr == ctrl_mac).next() else {
+        let Some(link) = links
+            .into_iter()
+            .filter(|link| link.mac_addr == ctrl_mac)
+            .next()
+        else {
             warn!("cannot find ctrl interface with mac {}", ctrl_mac);
             thread::sleep(Duration::from_secs(1));
             process::exit(-1);

--- a/agent/src/platform/platform_synchronizer/linux_process.rs
+++ b/agent/src/platform/platform_synchronizer/linux_process.rs
@@ -310,7 +310,10 @@ impl ProcRegRewrite {
                     }
 
                     let Some(parent_proc) = pid_process_map.get(&(proc.ppid as u32)) else {
-                        error!("pid {} have no parent proc with ppid: {}", proc.pid,proc.ppid);
+                        error!(
+                            "pid {} have no parent proc with ppid: {}",
+                            proc.pid, proc.ppid
+                        );
                         return false;
                     };
                     if reg.is_match(&parent_proc.process_name.as_str()) {
@@ -595,7 +598,7 @@ fn merge_tag(child_tag: &mut Vec<OsAppTagKV>, parent_tag: &[OsAppTagKV]) {
 
 fn get_container_id(proc: &Process) -> Option<String> {
     let Ok(cgruop) = proc.cgroups() else {
-        return None
+        return None;
     };
 
     let mut path = "".to_string();
@@ -631,7 +634,7 @@ fn get_container_id(proc: &Process) -> Option<String> {
         Some(s.to_string())
     } else {
         // other cri likely have format like `${cri-prefix}-${container id}.scope`
-        let Some((_, sp))  = s.rsplit_once("-") else {
+        let Some((_, sp)) = s.rsplit_once("-") else {
             debug!("containerd cri path: `{:?}` get container id fail", path);
             return None;
         };

--- a/agent/src/platform/platform_synchronizer/linux_socket.rs
+++ b/agent/src/platform/platform_synchronizer/linux_socket.rs
@@ -230,7 +230,7 @@ pub(super) fn get_all_socket(
             }
         };
 
-        let Ok(up_sec) =  proc_data.up_sec(now_sec) else {
+        let Ok(up_sec) = proc_data.up_sec(now_sec) else {
             continue;
         };
 
@@ -474,7 +474,7 @@ fn divide_tcp_entry(
                 continue;
             }
 
-            let Some((pid,fd)) = inode_pid_fd_map.get(&t.inode) else {
+            let Some((pid, fd)) = inode_pid_fd_map.get(&t.inode) else {
                 continue;
             };
 
@@ -483,7 +483,15 @@ fn divide_tcp_entry(
                 not the time that the connection create. unless os_proc_socket_min_lifetime config to 0,
                 the new connection at lease the second times scan can be recognized.
             */
-            let Ok(sock_up_sec) = sym_uptime(now_sec, &PathBuf::from_iter([proc_root.to_string(), pid.to_string(), "fd".to_string(), fd.to_string()])) else {
+            let Ok(sock_up_sec) = sym_uptime(
+                now_sec,
+                &PathBuf::from_iter([
+                    proc_root.to_string(),
+                    pid.to_string(),
+                    "fd".to_string(),
+                    fd.to_string(),
+                ]),
+            ) else {
                 continue;
             };
             if sock_up_sec < sock_min_lifetime_sec {
@@ -491,8 +499,9 @@ fn divide_tcp_entry(
             }
 
             // now only support ipv4
-            let (Some(local_address),Some(remote_address)) = (
-                convert_addr_to_v4(t.local_address),convert_addr_to_v4(t.remote_address)
+            let (Some(local_address), Some(remote_address)) = (
+                convert_addr_to_v4(t.local_address),
+                convert_addr_to_v4(t.remote_address),
             ) else {
                 continue;
             };
@@ -562,9 +571,17 @@ fn divide_udp_entry(
                 the new connection at lease the second times scan can be recognized.
             */
 
-            let Ok(sock_up_sec) = sym_uptime(now_sec, &PathBuf::from_iter([proc_root.to_string(), pid.to_string(), "fd".to_string(), fd.to_string()])) else {
-                    continue;
-                };
+            let Ok(sock_up_sec) = sym_uptime(
+                now_sec,
+                &PathBuf::from_iter([
+                    proc_root.to_string(),
+                    pid.to_string(),
+                    "fd".to_string(),
+                    fd.to_string(),
+                ]),
+            ) else {
+                continue;
+            };
             if sock_up_sec < sock_min_lifetime_sec {
                 continue;
             }
@@ -575,8 +592,9 @@ fn divide_udp_entry(
             }
 
             // now only support ipv4
-            let (Some(local_address),Some(remote_address)) = (
-                convert_addr_to_v4(u.local_address),convert_addr_to_v4(u.remote_address)
+            let (Some(local_address), Some(remote_address)) = (
+                convert_addr_to_v4(u.local_address),
+                convert_addr_to_v4(u.remote_address),
             ) else {
                 continue;
             };

--- a/agent/src/plugin/c_ffi.rs
+++ b/agent/src/plugin/c_ffi.rs
@@ -372,13 +372,13 @@ fn read_attr(attr_bytes: &[u8], mut attr_len: u32) -> Vec<KeyVal> {
     let mut attr = vec![];
     let mut off = 0;
     while off < attr_bytes.len() && attr_len > 0 {
-        let Some(key_idx) = (&attr_bytes[off..]).iter().position(|b| *b==0) else {
+        let Some(key_idx) = (&attr_bytes[off..]).iter().position(|b| *b == 0) else {
             break;
         };
         let key = String::from_utf8_lossy(&attr_bytes[off..off + key_idx]).to_string();
         off += key_idx + 1;
         if off < attr_bytes.len() {
-            let Some(val_idx) = &attr_bytes[off..].iter().position(|b| *b==0) else {
+            let Some(val_idx) = &attr_bytes[off..].iter().position(|b| *b == 0) else {
                 break;
             };
             let val = String::from_utf8_lossy(&attr_bytes[off..off + val_idx]).to_string();

--- a/agent/src/plugin/wasm/abi_import.rs
+++ b/agent/src/plugin/wasm/abi_import.rs
@@ -235,7 +235,7 @@ pub(super) fn vm_read_http_resp_info(
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mem_mut = mem.data_mut(caller.as_context_mut());
 
-    let  VmParseCtx::HttpRespCtx(ref resp_ctx) = ctx else {
+    let VmParseCtx::HttpRespCtx(ref resp_ctx) = ctx else {
         wasm_error!(
             ctx.get_ins_name(),
             IMPORT_FUNC_VM_READ_HTTP_RESP,
@@ -362,7 +362,7 @@ pub(super) fn host_read_str_result(mut caller: Caller<'_, StoreDataType>, b: i32
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mem = mem.data(caller.as_context());
     let data = &mem[b as usize..(b + len) as usize];
-    let Some(str) = read_wasm_str(data,&mut 0) else {
+    let Some(str) = read_wasm_str(data, &mut 0) else {
         let ins_name = caller.data().parse_ctx.as_ref().unwrap().get_ins_name();
         wasm_error!(
             ins_name,


### PR DESCRIPTION
Support symbolization of Java program addresses.

We have utilized the solution from the open-source project [**pixie**](https://github.com/pixie-io/pixie).

For Java processes, the address representations collected by the stack trace sampler have already been converted by the JVM JIT into machine code for the underlying Java application source code. However, symbolization is not straightforward. Symbolizers for non-JIT compiled languages (such as C++ or Golang) work by looking for the debugging symbol sections in natively compiled binary files and libraries. However, this doesn't apply to Java bytecode because the code doesn't have a static mapping to the virtual address space of the application. We interact with the JVM running the target Java application using the Java Virtual Machine Tool Interface (`JVMTI`). Based on the open-source Java [**perf map agent**](https://github.com/jvm-profiling-tools/perf-map-agent) we've written our own JVMTI agent called CompiledMethodLoad to listen to JVMTI callbacks for DynamicCodeGenerated. Whenever the JVM JIT compiles some application source code into native binary code stored in memory, the agent is triggered, and it simply writes the symbols and their corresponding virtual address ranges to a symbol file. We've implemented the automatic attachment of the JVMTI agent to target applications in a Kubernetes cluster.

To automatically attach the JVMTI agent to Java processes running as peers in
Kubernetes, the following issues need to be considered:

- Different JVM implementations (HotSpot and OpenJ9) have different attachment protocols.
- The .so files of the agent need to be visible from within the target application container.
- Unix domain sockets may need to share the same UID and GID as the target process.
- Different libc implementations (Alpine Linux uses musl instead of glibc).

For this, we use the open-source project [**jattach**](https://github.com/jattach/jattach), which inherently handles much of this complexity. The jattach binary natively handles the `HotSpot` and `OpenJ9` attachment protocols, and it deals with most container-related issues. In addition to the functionality provided by jattach, we still needed a few additional features.

For this purpose, we created our own attachment tool, deepflow-jattach. First, we copy our glibc and musl agent libraries into the target container, and then we select which library to use by attempting to map them using dlopen. Once the appropriate agent library is selected, deepflow_jattach simply calls jattach to complete the remaining heavy lifting.


### This PR is for:

- Agent



#### Affected branches
- main
- v6.3
