### PR TITLE
[agent] fix mac1 of flow metrics fill wrong #22182

### DIFF
--- a/agent/src/metric/document.rs
+++ b/agent/src/metric/document.rs
@@ -349,7 +349,7 @@ impl From<Tagger> for metric::MiniTag {
                 l3_epc_id: t.l3_epc_id as i32,
                 l3_epc_id1: t.l3_epc_id1 as i32,
                 mac: t.mac.into(),
-                mac1: t.mac.into(),
+                mac1: t.mac1.into(),
                 direction: t.direction as u32,
                 tap_side: TapSide::from(t.direction) as u32,
                 protocol: u8::from(t.protocol) as u32,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Agent


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


