### PR TITLE
[Agent] fixes libpcap does not distinguish between Linux and Windows

### DIFF
--- a/agent/plugins/special_recv_engine/src/lib.rs
+++ b/agent/plugins/special_recv_engine/src/lib.rs
@@ -19,7 +19,6 @@
 use std::sync::Arc;
 
 use public::counter;
-#[cfg(target_os = "linux")]
 use public::debug::QueueDebugger;
 use public::error::Result;
 use public::packet;
@@ -36,13 +35,7 @@ impl counter::RefCountable for LibpcapCounter {
 pub struct Libpcap;
 
 impl Libpcap {
-    #[cfg(target_os = "linux")]
     pub fn new(_: Vec<(&str, isize)>, _: usize, _: usize, _: &QueueDebugger) -> Result<Self> {
-        unimplemented!();
-    }
-
-    #[cfg(target_os = "windows")]
-    pub fn new(_: Vec<(&str, isize)>, _: usize, _: usize) -> Result<Self> {
         unimplemented!();
     }
 

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -255,7 +255,6 @@ impl BaseDispatcher {
                 .iter()
                 .map(|src_iface| (src_iface.name.as_str(), src_iface.if_index as isize))
                 .collect();
-            #[cfg(target_os = "linux")]
             let libpcap = Libpcap::new(
                 src_ifaces.clone(),
                 options.packet_blocks,
@@ -263,9 +262,6 @@ impl BaseDispatcher {
                 &self.queue_debugger,
             )
             .map_err(|e| Error::Libpcap(e.to_string()))?;
-            #[cfg(target_os = "windows")]
-            let libpcap = Libpcap::new(src_ifaces.clone(), options.packet_blocks, options.snap_len)
-                .map_err(|e| Error::Libpcap(e.to_string()))?;
             info!(
                 "libpcap init with {:?} block {} snap {}",
                 src_ifaces, options.packet_blocks, options.snap_len

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -1088,7 +1088,6 @@ impl DispatcherBuilder {
                     "Libpcap init with: {:?} {} {}",
                     &src_ifaces, options.packet_blocks, options.snap_len
                 );
-                #[cfg(target_os = "linux")]
                 let libpcap = Libpcap::new(
                     src_ifaces,
                     options.packet_blocks,
@@ -1096,9 +1095,6 @@ impl DispatcherBuilder {
                     queue_debugger,
                 )
                 .map_err(|e| error::Error::Libpcap(e.to_string()))?;
-                #[cfg(target_os = "windows")]
-                let libpcap = Libpcap::new(src_ifaces, options.packet_blocks, options.snap_len)
-                    .map_err(|e| error::Error::Libpcap(e.to_string()))?;
                 Ok(RecvEngine::Libpcap(Some(libpcap)))
             }
             #[cfg(target_os = "linux")]


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes libpcap does not distinguish between Linux and Windows
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     