### PR TITLE
[querier] update cache

### DIFF
--- a/server/querier/app/prometheus/cache/cache.go
+++ b/server/querier/app/prometheus/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"math"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,6 +48,7 @@ func (c *CacheItem) Size() uint64 {
 	return unsafeSize(c.data)
 }
 
+// it should called under Lock
 func (c *CacheItem) replace(d *common.Result) bool {
 	new_size := unsafeSize(d)
 	if new_size <= config.Cfg.Prometheus.Cache.CacheItemSize {
@@ -61,8 +63,11 @@ func (c *CacheItem) replace(d *common.Result) bool {
 }
 
 func (c *CacheItem) Hit(start int64, end int64) CacheHit {
+	c.rwLock.RLock()
+	defer c.rwLock.RUnlock()
+
 	// outside cache: cache miss
-	if end < c.startTime || start > c.endTime {
+	if end <= c.startTime || start >= c.endTime {
 		return CacheMiss
 	}
 
@@ -78,12 +83,12 @@ func (c *CacheItem) Hit(start int64, end int64) CacheHit {
 	}
 
 	// deviation: fix up start time, cache hit right
-	if end <= c.endTime && end > c.startTime {
+	if end <= c.endTime && end > c.startTime && start < c.startTime {
 		return CacheHitPart
 	}
 
 	// deviation: fix up end time, cache hit left
-	if start < c.endTime && start >= c.startTime {
+	if start < c.endTime && start >= c.startTime && end > c.endTime {
 		return CacheHitPart
 	}
 	return CacheMiss
@@ -91,6 +96,8 @@ func (c *CacheItem) Hit(start int64, end int64) CacheHit {
 
 func (c *CacheItem) Deviation(start int64, end int64) (int64, int64) {
 	// only cache hit part needs to re-calculate deviation
+	c.rwLock.RLock()
+	defer c.rwLock.RUnlock()
 
 	// both side out of cache, query all
 	if start < c.startTime && end > c.endTime {
@@ -99,8 +106,8 @@ func (c *CacheItem) Deviation(start int64, end int64) (int64, int64) {
 
 	// if the deviation between start & c.start > maxAllowDeviation, directy query all data to replace cache
 	// add left data
-	if end <= c.endTime && end > c.startTime {
-		if math.Abs(float64(c.startTime-start)) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+	if end <= c.endTime && end > c.startTime && start < c.startTime {
+		if math.Abs(float64(c.startTime-start)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
 			return start, end
 		} else {
 			return start, c.startTime
@@ -108,8 +115,8 @@ func (c *CacheItem) Deviation(start int64, end int64) (int64, int64) {
 	}
 
 	// add right data
-	if start < c.endTime && start >= c.startTime {
-		if math.Abs(float64(c.endTime-end)) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
+	if start < c.endTime && start >= c.startTime && end > c.endTime {
+		if math.Abs(float64(c.endTime-end)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
 			return start, end
 		} else {
 			return c.endTime, end
@@ -123,9 +130,11 @@ func (c *CacheItem) Data() *common.Result {
 	return c.data
 }
 
-func (c *CacheItem) Merge(start, end int64, data *common.Result) (*common.Result, bool) {
-	if data == nil || len(data.Values) == 0 {
-		return data, true
+func (c *CacheItem) MergeCache(start, end int64, cache *common.Result, query *common.Result) (*common.Result, bool) {
+	log.Debugf("cache merged, query range: [%d-%d], cache range: [%d-%d]", start, end, c.startTime, c.endTime)
+	if query == nil || len(query.Values) == 0 {
+		log.Debugf("cache data is nil: %v, query data is nil: %v", cache == nil, query == nil)
+		return cache, true
 	}
 
 	// re-calculate cache time, because other session may already update cache
@@ -134,48 +143,84 @@ func (c *CacheItem) Merge(start, end int64, data *common.Result) (*common.Result
 
 	if start >= c.startTime && end <= c.endTime {
 		// not merge
-		log.Debugf("cache not merge, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
-		return c.data, true
+		log.Debugf("cache full hit, will not merge, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
+		return cache, true
 	}
-	// no matter c.replace(data) success or not, we should return data
-	// extern both side
 
+	// why need to extern left/right here: because other session may already update cache item during sql query
+	// so we should re-calculate cache time range here
+	// but the `data` merge into cache not completely equals to `data` back to api call
+
+	// extern both side
 	if start < c.startTime && end > c.endTime {
 		log.Debugf("cache extern both side, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
 		c.startTime = start
 		c.endTime = end
-		return data, c.replace(data)
+		return query, c.replace(query)
 	}
 
+	mergeResult := &common.Result{Columns: query.Columns, Schemas: query.Schemas}
 	// extern left
-	if end <= c.endTime && end > c.startTime {
+	// cached:   [0, N]
+	// replaced: [-X, Y] (0<Y<=N, X<0)
+	if end <= c.endTime && end > c.startTime && start < c.startTime {
 		if math.Abs(float64(c.startTime-start)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
 			log.Debugf("cache replace due to deviation too large, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
 			c.startTime = start
 			c.endTime = end
+			// in deviation case, will query all data [-X,Y], not only extern data [-X,0]
+			// replace cache data with query data
+			mergeResult.Values = query.Values
 		} else {
 			log.Debugf("cache merge extern left, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
 			c.startTime = start
-			data.Values = append(data.Values, c.data.Values...)
+			// in not deviation case, query data [-X,0], merge into [-X,N]
+			// note that `Values` is order by time DESC, so extern `left` should append into right
+			mergeResult.Values = append(cache.Values, query.Values...)
 		}
-		return data, c.replace(data)
+
+		if len(mergeResult.Values) > 0 {
+			fv := mergeResult.Values[0].([]interface{})
+			lv := mergeResult.Values[len(mergeResult.Values)-1].([]interface{})
+			if len(fv) > 0 && len(lv) > 0 {
+				log.Debugf("merge result, data range [%v-%v]", lv[0], fv[0])
+			}
+		}
+
+		return mergeResult, c.replace(mergeResult)
 	}
 
 	// extern right
-	if start < c.endTime && start >= c.startTime {
+	// cached:   [0, N]
+	// replaced: [X,Y] (0<=X<N, Y>N)
+	if start < c.endTime && start >= c.startTime && end > c.endTime {
 		if math.Abs(float64(c.endTime-end)/1000) > config.Cfg.Prometheus.Cache.CacheMaxAllowDeviation {
 			log.Debugf("cache replace due to deviation too large, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
 			c.startTime = start
 			c.endTime = end
+			// in deviation case, will query all data [X,Y], not only extern data [N,Y]
+			// replace cache data with query data
+			mergeResult.Values = query.Values
 		} else {
 			log.Debugf("cache merge extern right, cache: [%d-%d], query: [%d-%d]", c.startTime, c.endTime, start, end)
 			c.endTime = end
-			data.Values = append(c.data.Values, data.Values...)
+			// in not deviation case, query data [N,Y], merge into [0,Y]
+			// note that `Values` is order by time DESC, so extern `right` should append into left
+			mergeResult.Values = append(query.Values, cache.Values...)
 		}
-		return data, c.replace(data)
+
+		if len(mergeResult.Values) > 0 {
+			fv := mergeResult.Values[0].([]interface{})
+			lv := mergeResult.Values[len(mergeResult.Values)-1].([]interface{})
+			if len(fv) > 0 && len(lv) > 0 {
+				log.Debugf("merge result, data range [%v-%v]", lv[0], fv[0])
+			}
+		}
+
+		return mergeResult, c.replace(mergeResult)
 	}
 
-	return data, true
+	return query, true
 }
 
 type RemoteReadQueryCache struct {
@@ -204,26 +249,27 @@ func NewRemoteReadQueryCache() *RemoteReadQueryCache {
 	return s
 }
 
-func (s *RemoteReadQueryCache) AddOrMerge(req *prompb.ReadRequest, data *common.Result, item *CacheItem) *common.Result {
+func (s *RemoteReadQueryCache) AddOrMerge(req *prompb.ReadRequest, item *CacheItem, cache *common.Result, query *common.Result) *common.Result {
 	if req == nil || len(req.Queries) == 0 {
-		return nil
+		return cache
 	}
 	q := req.Queries[0]
 	if q.Hints.Func == "series" {
-		return data
+		return query
 	}
 
 	key, _, start, end := promRequestToCacheKey(q)
-	start, end = timeAlign(start, end)
+	start = timeAlign(start)
 	if item == nil {
 		// cache miss
-		s.cache.Add(key, &CacheItem{startTime: start, endTime: end, data: data, rwLock: &sync.RWMutex{}})
-		return data
+		item = &CacheItem{startTime: start, endTime: end, data: query, rwLock: &sync.RWMutex{}}
+		s.cache.Add(key, item)
+		return query
 	} else {
 		// cache hit, merge data
 		atomic.AddUint64(&s.counter.Stats.CacheMerge, 1)
 		t1 := time.Now()
-		result, ok := item.Merge(start, end, data)
+		result, ok := item.MergeCache(start, end, cache, query)
 		d := time.Since(t1)
 		atomic.AddUint64(&s.counter.Stats.CacheMergeDuration, uint64(d.Seconds()))
 		if !ok {
@@ -255,7 +301,12 @@ func (s *RemoteReadQueryCache) Get(req *prompb.ReadRequest) (*CacheItem, CacheHi
 
 	// for query api, cache query samples
 	key, metric, start, end := promRequestToCacheKey(q)
-	start, end = timeAlign(start, end)
+	if strings.Contains(metric, "__") {
+		// for DeepFlow Native metrics, don't use cache
+		return nil, CacheMiss, metric, start, end
+	}
+
+	start = timeAlign(start)
 	item, ok := s.cache.Get(key)
 	if !ok {
 		atomic.AddUint64(&s.counter.Stats.CacheMiss, 1)

--- a/server/querier/app/prometheus/cache/cache_test.go
+++ b/server/querier/app/prometheus/cache/cache_test.go
@@ -1,0 +1,584 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cfg "github.com/deepflowio/deepflow/server/querier/app/prometheus/config"
+	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/deepflowio/deepflow/server/querier/config"
+	"github.com/prometheus/prometheus/prompb"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	remoteReadCacheTestStorage      *RemoteReadQueryCache
+	uniquePromReqs                  []*prompb.ReadRequest
+	parsePrometheusRequestTestCases []TestCase[parseCacheItemOutput]
+
+	prometheusCacheHitTestCases map[string][]TestCase[cacheHitResultOutput]
+)
+
+type cacheExternDirection int
+
+const (
+	externNone cacheExternDirection = iota
+	externLeft
+	externRight
+	externBoth
+)
+
+type TestCase[T any] struct {
+	input    *prompb.ReadRequest
+	output   *T
+	hasError bool
+}
+
+type parseCacheItemOutput struct {
+	key    string
+	metric string
+	start  int64
+	end    int64
+}
+
+type cacheHitResultOutput struct {
+	hit     CacheHit
+	extern  cacheExternDirection
+	startms int64
+	endms   int64
+}
+
+func TestMain(m *testing.M) {
+	config.Cfg = &config.QuerierConfig{Prometheus: cfg.Prometheus{Cache: cfg.PrometheusCache{
+		Enabled:                true,
+		CacheItemSize:          512,
+		CacheMaxCount:          5,
+		CacheMaxAllowDeviation: 60 * 60, // 60min
+	}}}
+
+	remoteReadCacheTestStorage = NewRemoteReadQueryCache()
+	t := time.Now()
+
+	parsePrometheusRequestTestCases = make([]TestCase[parseCacheItemOutput], 0, 3)
+	parsePrometheusRequestTestCases = append(parsePrometheusRequestTestCases,
+		// __name__
+		TestCase[parseCacheItemOutput]{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"}},
+						Hints: &prompb.ReadHints{
+							StartMs: t.UnixMilli(),
+							EndMs:   t.Add(30 * time.Minute).UnixMilli(),
+							StepMs:  5000,
+						},
+					},
+				},
+			},
+			output: &parseCacheItemOutput{
+				key:    "__name__EQnode_cpu_seconds_total-",
+				metric: "node_cpu_seconds_total",
+				start:  t.UnixMilli(),
+				end:    t.Add(30 * time.Minute).UnixMilli(),
+			},
+		},
+		// __name__job
+		TestCase[parseCacheItemOutput]{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_RE, Name: "job", Value: "prometheus.*"},
+						},
+						Hints: &prompb.ReadHints{
+							StartMs: t.UnixMilli(),
+							EndMs:   t.Add(30 * time.Minute).UnixMilli(),
+							StepMs:  1000,
+						},
+					},
+				},
+			},
+			output: &parseCacheItemOutput{
+				key:    "__name__EQnode_cpu_seconds_total-jobREprometheus.*-",
+				metric: "node_cpu_seconds_total",
+				start:  t.UnixMilli(),
+				end:    t.Add(30 * time.Minute).UnixMilli(),
+			},
+		},
+		// __name__instance
+		TestCase[parseCacheItemOutput]{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_NRE, Name: "instance", Value: "0.0.0.0"},
+						},
+						Hints: &prompb.ReadHints{
+							StartMs: t.UnixMilli(),
+							EndMs:   t.Add(30 * time.Minute).UnixMilli(),
+							StepMs:  5000,
+						},
+					},
+				},
+			},
+			output: &parseCacheItemOutput{
+				key:    "__name__EQnode_cpu_seconds_total-instanceNRE0.0.0.0-",
+				metric: "node_cpu_seconds_total",
+				start:  t.UnixMilli(),
+				end:    t.Add(30 * time.Minute).UnixMilli(),
+			},
+		})
+
+	prometheusCacheHitTestCases = make(map[string][]TestCase[cacheHitResultOutput], 3)
+	// __name__ case: left/right/both
+	prometheusCacheHitTestCases["__name__EQnode_cpu_seconds_total-"] = []TestCase[cacheHitResultOutput]{
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+						},
+						// last: [0, 30]
+						//                merge
+						// new:  [-10, 5] ====> [-10, 30]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(-10 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(5 * time.Minute).UnixMilli()),
+							StepMs:  3000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitPart, extern: externLeft, startms: leftAlign(t.Add(-10 * time.Minute).UnixMilli()), endms: rightAlign(t.Add(5 * time.Minute).UnixMilli())},
+		},
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+						},
+						// last: [0, 30]
+						//               merge
+						// new:  [0, 40] ====> [0, 40]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.UnixMilli()),
+							EndMs:   rightAlign(t.Add(40 * time.Minute).UnixMilli()),
+							StepMs:  5000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitPart, extern: externRight, startms: leftAlign(t.UnixMilli()), endms: rightAlign(t.Add(40 * time.Minute).UnixMilli())},
+		},
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+						},
+						// last: [0, 30]
+						//                 merge
+						// new:  [-40, 45] ====> [-40, 45]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(-40 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(45 * time.Minute).UnixMilli()),
+							StepMs:  5000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitPart, extern: externBoth, startms: leftAlign(t.Add(-40 * time.Minute).UnixMilli()), endms: rightAlign(t.Add(45 * time.Minute).UnixMilli())},
+		},
+	}
+
+	// __name__job case: full / left miss / right miss
+	prometheusCacheHitTestCases["__name__EQnode_cpu_seconds_total-jobREprometheus.*-"] = []TestCase[cacheHitResultOutput]{
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_RE, Name: "job", Value: "prometheus.*"},
+						},
+						// last: [0, 30]
+						//                none
+						// new:  [5, 15] ======> [0, 30]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(5 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(15 * time.Minute).UnixMilli()),
+							StepMs:  300,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitFull, extern: externNone, startms: leftAlign(t.UnixMilli()), endms: rightAlign(t.Add(30 * time.Minute).UnixMilli())},
+		},
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_RE, Name: "job", Value: "prometheus.*"},
+						},
+						// last: [0, 30]
+						//                 replace
+						// new:  [-10, -5] =======> [-10, -5]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(-10 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(-5 * time.Minute).UnixMilli()),
+							StepMs:  1000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheMiss, extern: externNone, startms: leftAlign(t.Add(-10 * time.Minute).UnixMilli()), endms: rightAlign(t.Add(-5 * time.Minute).UnixMilli())},
+		},
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_RE, Name: "job", Value: "prometheus.*"},
+						},
+						// last: [0, 30]
+						//                replace
+						// new:  [35, 40] =======> [35, 40]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(35 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(40 * time.Minute).UnixMilli()),
+							StepMs:  200,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheMiss, extern: externNone, startms: leftAlign(t.Add(35 * time.Minute).UnixMilli()), endms: rightAlign(t.Add(40 * time.Minute).UnixMilli())},
+		},
+	}
+
+	// __name__instanc case: query / backoff
+	prometheusCacheHitTestCases["__name__EQnode_cpu_seconds_total-instanceNRE0.0.0.0-"] = []TestCase[cacheHitResultOutput]{
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_NRE, Name: "instance", Value: "0.0.0.0"},
+						},
+						// last: [0, 30]
+						//               merge
+						// new:  [0, 45] =====> [0, 45]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.UnixMilli()),
+							EndMs:   rightAlign(t.Add(45 * time.Minute).UnixMilli()),
+							StepMs:  300,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitPart, extern: externRight, startms: leftAlign(t.UnixMilli()), endms: rightAlign(t.Add(45 * time.Minute).UnixMilli())},
+		},
+		// backoff
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_NRE, Name: "instance", Value: "0.0.0.0"},
+						},
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.UnixMilli()),
+							EndMs:   rightAlign(t.Add(30 * time.Minute).UnixMilli()),
+							StepMs:  2000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitFull, extern: externNone, startms: leftAlign(t.UnixMilli()), endms: rightAlign(t.Add(30 * time.Minute).UnixMilli())},
+		},
+
+		// query backward
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_NRE, Name: "instance", Value: "0.0.0.0"},
+						},
+						// last: [0, 30]
+						//                 merge
+						// new:  [-15, 30] =====> [-15, 30]
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.Add(-15 * time.Minute).UnixMilli()),
+							EndMs:   rightAlign(t.Add(30 * time.Minute).UnixMilli()),
+							StepMs:  2000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitPart, extern: externLeft, startms: leftAlign(t.Add(-15 * time.Minute).UnixMilli()), endms: rightAlign(t.Add(30 * time.Minute).UnixMilli())},
+		},
+		// backoff
+		{
+			input: &prompb.ReadRequest{
+				Queries: []*prompb.Query{
+					{
+						Matchers: []*prompb.LabelMatcher{
+							{Type: prompb.LabelMatcher_EQ, Name: "__name__", Value: "node_cpu_seconds_total"},
+							{Type: prompb.LabelMatcher_NRE, Name: "instance", Value: "0.0.0.0"},
+						},
+						Hints: &prompb.ReadHints{
+							StartMs: leftAlign(t.UnixMilli()),
+							EndMs:   rightAlign(t.Add(30 * time.Minute).UnixMilli()),
+							StepMs:  2000,
+						},
+					},
+				},
+			},
+			output: &cacheHitResultOutput{hit: CacheHitFull, extern: externNone, startms: leftAlign(t.UnixMilli()), endms: rightAlign(t.Add(30 * time.Minute).UnixMilli())},
+		},
+	}
+
+	// same key, different query range
+	for i := 0; i < len(parsePrometheusRequestTestCases); i++ {
+		uniquePromReqs = append(uniquePromReqs, parsePrometheusRequestTestCases[i].input)
+	}
+
+	m.Run()
+}
+
+func TestPromRequestToCacheKey(t *testing.T) {
+	Convey("TestPromRequestToCacheKey", t, func() {
+		for i := 0; i < len(parsePrometheusRequestTestCases); i++ {
+			key, m, start, end := promRequestToCacheKey(parsePrometheusRequestTestCases[i].input.Queries[0])
+			So(key, ShouldEqual, parsePrometheusRequestTestCases[i].output.key)
+			So(start, ShouldEqual, parsePrometheusRequestTestCases[i].output.start)
+			So(end, ShouldEqual, parsePrometheusRequestTestCases[i].output.end)
+			So(m, ShouldEqual, parsePrometheusRequestTestCases[i].output.metric)
+
+			for j := 0; j < len(parsePrometheusRequestTestCases); j++ {
+				if i == j {
+					continue
+				}
+				innerKey, _, _, _ := promRequestToCacheKey(parsePrometheusRequestTestCases[j].input.Queries[0])
+				So(key, ShouldNotEqual, innerKey)
+			}
+		}
+	})
+}
+
+func buildCacheItem(start, end int64, index int, m string) *common.Result {
+	return &common.Result{
+		Values: []interface{}{
+			[]interface{}{start, end, index, m},
+		},
+	}
+}
+
+func asyncCacheGenerator() chan CacheHit {
+	c := make(chan CacheHit)
+	go func() {
+		for k, v := range uniquePromReqs {
+			item, hit, m, start, end := remoteReadCacheTestStorage.Get(v)
+			var cache *common.Result
+			if item != nil {
+				cache = item.data
+			}
+			c <- hit
+			data := buildCacheItem(start, end, k, m)
+			remoteReadCacheTestStorage.AddOrMerge(v, item, cache, data)
+		}
+
+		close(c)
+	}()
+	return c
+}
+
+func leftAlign(t int64) int64 {
+	return t - t%60000
+}
+
+func rightAlign(t int64) int64 {
+	return t + (60000 - t%60000)
+}
+
+func TestCacheHit(t *testing.T) {
+	Convey("TestCacheHit", t, func() {
+		// cache hit should happend after miss
+		for i := range asyncCacheGenerator() {
+			So(i, ShouldEqual, CacheMiss)
+		}
+
+		for _, v := range uniquePromReqs {
+			item, hit, _, start, end := remoteReadCacheTestStorage.Get(v)
+			start_align := timeAlign(v.Queries[0].Hints.StartMs)
+
+			So(hit, ShouldEqual, CacheHitFull)
+			So(item, ShouldNotBeNil)
+			So(len(item.data.Values), ShouldBeGreaterThan, 0)
+			So(start, ShouldEqual, start_align)
+			So(end, ShouldEqual, v.Queries[0].Hints.EndMs)
+		}
+	})
+}
+
+func TestCacheMiss(t *testing.T) {
+	Convey("TestCacheMiss", t, func() {
+		for i := range asyncCacheGenerator() {
+			So(i, ShouldEqual, CacheMiss)
+		}
+	})
+}
+
+var lock *sync.Mutex = &sync.Mutex{}
+
+func resetCacheItem(key string, ori *CacheItem, s1, e1 int64) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	ori.startTime = s1
+	ori.endTime = e1
+}
+
+func TestCacheIntegration(t *testing.T) {
+	Convey("TestCacheIntegration", t, func() {
+		// first time, should miss
+		for i := range asyncCacheGenerator() {
+			So(i, ShouldEqual, CacheMiss)
+		}
+
+		// second time, should hit
+		for _, v := range uniquePromReqs {
+			item, hit, _, start, end := remoteReadCacheTestStorage.Get(v)
+
+			start_align := timeAlign(v.Queries[0].Hints.StartMs)
+			So(hit, ShouldEqual, CacheHitFull)
+			So(item, ShouldNotBeNil)
+			So(len(item.data.Values), ShouldBeGreaterThan, 0)
+			So(start, ShouldEqual, start_align)
+			So(end, ShouldEqual, v.Queries[0].Hints.EndMs)
+		}
+	})
+	Convey("TestCacheIntegration_goroutine_10", t, func() {
+		// for repeated reqs
+		for i := 0; i < 10; i++ {
+			tn := t
+			go func(ti *testing.T) {
+				iterateTestCases(ti)
+			}(tn)
+		}
+	})
+}
+
+func iterateTestCases(t *testing.T) {
+	for k, v := range prometheusCacheHitTestCases {
+		for i := 0; i < len(v); i++ {
+			t.Logf("TestCase: %s, index: %d", k, i)
+			if strings.Contains(k, "instance") {
+				fmt.Println(k)
+			}
+			item, hit, m, start, end := remoteReadCacheTestStorage.Get(v[i].input)
+			var cache *common.Result
+			if item != nil {
+				cache = item.data
+			}
+			// cache hit judgement
+			So(hit, ShouldEqual, v[i].output.hit)
+			_ = remoteReadCacheTestStorage.AddOrMerge(v[i].input, item, cache, buildCacheItem(start, end, i, m))
+			//So(len(result.Values), ShouldBeGreaterThan, 0)
+			_, _, newM, newStart, newEnd := remoteReadCacheTestStorage.Get(v[i].input)
+			So(m, ShouldEqual, newM)
+			if item != nil {
+				resetCacheItem(k, item, start, end)
+			}
+			output_start_align := timeAlign(v[i].output.startms)
+			switch v[i].output.extern {
+			case externNone:
+				if hit == CacheHitFull {
+					So(newStart, ShouldBeGreaterThanOrEqualTo, output_start_align)
+					So(newEnd, ShouldBeLessThanOrEqualTo, v[i].output.endms)
+				} else if hit == CacheMiss {
+					So(newStart, ShouldEqual, output_start_align)
+					So(newEnd, ShouldEqual, v[i].output.endms)
+				}
+			case externLeft:
+				So(newStart, ShouldEqual, output_start_align)
+			case externRight:
+				So(newEnd, ShouldEqual, v[i].output.endms)
+			case externBoth:
+				So(newStart, ShouldEqual, output_start_align)
+				So(newEnd, ShouldEqual, v[i].output.endms)
+			}
+		}
+	}
+}
+
+func TestConcurrencyCacheGet(t *testing.T) {
+	Convey("TestConcurrency_Prepare", t, func() {
+		for i := range asyncCacheGenerator() {
+			So(i, ShouldEqual, CacheMiss)
+		}
+	})
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(w *sync.WaitGroup) {
+			r, e := rand.Int(rand.Reader, big.NewInt(300))
+			if e != nil {
+				t.Error(e)
+			}
+			iterateCacheReplaseTestCases("__name__EQnode_cpu_seconds_total-", time.Duration(r.Int64()*int64(time.Millisecond)))
+			w.Done()
+		}(wg)
+	}
+	wg.Wait()
+}
+
+func iterateCacheReplaseTestCases(key string, randomWait time.Duration) {
+	for i := 0; i < len(prometheusCacheHitTestCases[key]); i++ {
+		v := prometheusCacheHitTestCases[key][i]
+		item, _, m, _, _ := remoteReadCacheTestStorage.Get(v.input)
+		var cache *common.Result
+		if item != nil {
+			cache = item.Data()
+		}
+		time.Sleep(randomWait)
+		_ = remoteReadCacheTestStorage.AddOrMerge(v.input, item, cache, buildCacheItem(v.output.startms, v.output.endms, i, m))
+		hit := item.Hit(v.output.startms, v.output.endms)
+		if hit != CacheHitFull {
+			panic("cache result is modify by another goroutine")
+		}
+	}
+}

--- a/server/querier/app/prometheus/cache/utils.go
+++ b/server/querier/app/prometheus/cache/utils.go
@@ -35,8 +35,8 @@ const (
 
 // start time & end time align to 0 second
 // e.g.: query 13s-117s, cache 0s-120s
-func timeAlign(startMs int64, endMs int64) (int64, int64) {
-	return startMs - startMs%60000, endMs + (60000 - endMs%60000)
+func timeAlign(startMs int64) int64 {
+	return startMs - startMs%60000
 }
 
 func promRequestToCacheKey(q *prompb.Query) (string, string, int64, int64) {

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -536,6 +536,10 @@ func parseToQuerierSQL(ctx context.Context, db string, table string, metrics []s
 
 // querier result trans to Prom Response
 func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName string, result *common.Result) (resp *prompb.ReadResponse, err error) {
+	if result == nil || len(result.Values) == 0 {
+		return &prompb.ReadResponse{Results: []*prompb.QueryResult{{}}}, nil
+	}
+	log.Debugf("resTransToProm: result length: %d", len(result.Values))
 	tagIndex := -1
 	metricsIndex := -1
 	timeIndex := -1

--- a/server/querier/app/prometheus/service/service.go
+++ b/server/querier/app/prometheus/service/service.go
@@ -31,7 +31,7 @@ import (
 	"github.com/deepflowio/deepflow/server/querier/config"
 )
 
-var log = logging.MustGetLogger("promethues")
+var log = logging.MustGetLogger("prometheus")
 
 type PrometheusService struct {
 	// keep only 1 instance of prometheus engine during server lifetime


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query promql cache bug
#### Steps to reproduce the bug
- using cache during promql query , it returns unstable result sometimes
#### Changes to fix the bug
1. add locker during get cache `starttime` and `endtime` 、`data`
2. fix `time` conditions in cache hit judgement.
3. when `cache hit` happens, whether it is `hit all` or `hit part`, it should get and returning cache data immediately.
4. when append query values into cache, should reverse append orders, remind that cache values are always order by time `desc`.
5. remove end time aligning , which may cause `instant query` can not get realtime data
6. add debug logs for cache get result
7. add unit tests and asynchronous unit tests.
#### Affected branches
- main


