### PR TITLE
[querier] update v62 cache

### DIFF
--- a/server/querier/prometheus/cache/utils.go
+++ b/server/querier/prometheus/cache/utils.go
@@ -35,8 +35,8 @@ const (
 
 // start time & end time align to 0 second
 // e.g.: query 13s-117s, cache 0s-120s
-func timeAlign(startMs int64, endMs int64) (int64, int64) {
-	return startMs - startMs%60000, endMs + (60000 - endMs%60000)
+func timeAlign(startMs int64) int64 {
+	return startMs - startMs%60000
 }
 
 func promRequestToCacheKey(q *prompb.Query) (string, string, int64, int64) {

--- a/server/querier/prometheus/converters.go
+++ b/server/querier/prometheus/converters.go
@@ -426,6 +426,10 @@ func PromReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest, startTim
 
 // querier result trans to Prom Response
 func RespTransToProm(ctx context.Context, result *common.Result) (resp *prompb.ReadResponse, err error) {
+	if result == nil || len(result.Values) == 0 {
+		return &prompb.ReadResponse{Results: []*prompb.QueryResult{{}}}, nil
+	}
+	log.Debugf("resTransToProm: result length: %d", len(result.Values))
 	tagIndex := -1
 	metricsIndex := -1
 	timeIndex := -1


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query promql cache bug
#### Steps to reproduce the bug
- using cache during promql query , it returns unstable result sometimes
#### Changes to fix the bug
1. add locker during get cache `starttime` and `endtime` 、`data`
2. fix `time` conditions in cache hit judgement.
3. when `cache hit` happens, whether it is `hit all` or `hit part`, it should get and returning cache data immediately.
4. when append query values into cache, should reverse append orders, remind that cache values are always order by time `desc`.
5. remove end time aligning , which may cause `instant query` can not get realtime data
6. add debug logs for cache get result
7. add unit tests and asynchronous unit tests.
#### Affected branches
- v6.2