### PR TITLE
[querier] enabled time parse before cache

### DIFF
--- a/server/querier/prometheus/cache/cache.go
+++ b/server/querier/prometheus/cache/cache.go
@@ -290,19 +290,19 @@ func (s *RemoteReadQueryCache) Get(req *prompb.ReadRequest) (*CacheItem, CacheHi
 		return nil, CacheMiss, "", 0, 0
 	}
 	q := req.Queries[0]
+	start, end := GetPromRequestQueryTime(q)
 	if q.Hints.Func == "series" {
 		// for series api, don't use cache
 		// not count cache miss here
-		return nil, CacheMiss, "", q.Hints.StartMs, q.Hints.EndMs
+		return nil, CacheMiss, "", start, end
 	}
 
 	if !config.Cfg.Prometheus.Cache.Enabled {
-		return nil, CacheMiss, "", q.Hints.StartMs, q.Hints.EndMs
+		return nil, CacheMiss, "", start, end
 	}
 
 	// for query api, cache query samples
 	key, metric := promRequestToCacheKey(q)
-	start, end := GetPromRequestQueryTime(q)
 	if strings.Contains(metric, "__") {
 		// for DeepFlow Native metrics, don't use cache
 		return nil, CacheMiss, metric, start, end


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query time parse
#### Steps to reproduce the bug
- use promql query & without cache
#### Changes to fix the bug
- parse time at the first
#### Affected branches
- v6.2
