### PR TITLE
Update ebpf java profile

### DIFF
--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -151,4 +151,10 @@ enum {
  */
 #define PROC_INFO_VERIFY_TIME  60 // 60 seconds
 
+/*
+ * This value is used to determine which type of Java agent's so library to
+ * attach JVM (GNU or musl libc agent.so).
+ */
+#define JAVA_AGENT_LIBS_TEST_FUN_RET_VAL 3302
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -157,4 +157,14 @@ enum {
  */
 #define JAVA_AGENT_LIBS_TEST_FUN_RET_VAL 3302
 
+/*
+ * Java symbol table update delay time.
+ * When an unknown Frame is encountered during the symbolization process of
+ * the Java process, it will be delayed for a fixed time (if the unknown f-
+ * rame is encountered again during this period, it will be ignored) to up-
+ * date the Java symbol table. This is done The purpose is to avoid freque-
+ * nt updates of the java symbol table.
+ */
+#define JAVA_SYMS_TABLE_UPDATE_PERIOD 300 // 300 seconds
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/profile/attach.c
+++ b/agent/src/ebpf/user/profile/attach.c
@@ -31,15 +31,6 @@ void gen_java_symbols_file(int pid)
 		return;
 	}
 
-	char path[128];
-	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.map",
-		 pid, target_ns_pid);
-	/* If the file already exists, no action required. */
-	if (access(path, F_OK) == 0) {
-		ebpf_info("Java symbols file '%s' is existed.\n", path);
-		return;
-	}
-
 	char args[32];
 	snprintf(args, sizeof(args), "%d", pid);
 	exec_command(DF_JAVA_ATTACH_CMD, args);

--- a/agent/src/ebpf/user/profile/attach.c
+++ b/agent/src/ebpf/user/profile/attach.c
@@ -32,31 +32,17 @@ void gen_java_symbols_file(int pid)
 	}
 
 	char path[128];
-	snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
-	/* If it already exists in the deepflow agent namespace, it will delete it. */
-	clear_target_ns_tmp_file(path);
-
-	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.log",
-		 pid, target_ns_pid);
-	if (access(path, F_OK) == 0) {
-		copy_file_from_target_ns(pid, target_ns_pid, "log");
-	}
-
 	snprintf(path, sizeof(path), "/proc/%d/root/tmp/perf-%d.map",
 		 pid, target_ns_pid);
-	/* If the file already exists, it will simply perform the copy operation and
-	 * then exit successfully.*/
+	/* If the file already exists, no action required. */
 	if (access(path, F_OK) == 0) {
-		copy_file_from_target_ns(pid, target_ns_pid, "map");
+		ebpf_info("Java symbols file '%s' is existed.\n", path);
 		return;
 	}
 
 	char args[32];
 	snprintf(args, sizeof(args), "%d", pid);
-
 	exec_command(DF_JAVA_ATTACH_CMD, args);
 
-	copy_file_from_target_ns(pid, target_ns_pid, "map");
-	copy_file_from_target_ns(pid, target_ns_pid, "log");
-	clear_target_ns(pid, target_ns_pid);
+	clear_target_ns_so(pid, target_ns_pid);
 }

--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -30,4 +30,5 @@ typedef uint64_t(*agent_test_t) (void);
 void clear_target_ns_tmp_file(const char *target_path);
 void copy_file_from_target_ns(int pid, int ns_pid, const char *file_type);
 void clear_target_ns(int pid, int target_ns_pid);
+void clear_target_ns_so(int pid, int target_ns_pid);
 #endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -479,8 +479,9 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 		stack_trace_msg_kv_t kv;
 		char name[TASK_COMM_LEN];
 		u64 stime, netns_id;
+		void *info_p = NULL;
 		get_process_info_by_pid(v->tgid, &stime, &netns_id,
-					(char *)name);
+					(char *)name, &info_p);
 		char *process_name = NULL;
 		bool matched = false;
 
@@ -523,7 +524,7 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 
 		char *trace_str =
 		    resolve_and_gen_stack_trace_str(t, v, stack_map_name,
-						    stack_str_hash, matched);
+						    stack_str_hash, matched, info_p);
 		if (trace_str) {
 			/*
 			 * append process/thread name to stack string

--- a/agent/src/ebpf/user/profile/stringifier.h
+++ b/agent/src/ebpf/user/profile/stringifier.h
@@ -44,6 +44,6 @@ char *resolve_and_gen_stack_trace_str(struct bpf_tracer *t,
 				      struct stack_trace_key_t *v,
 				      const char *stack_map_name,
 				      stack_str_hash_t *h,
-				      bool new_cache);
+				      bool new_cache, void *info_p);
 #endif /* AARCH64_MUSL */
 #endif /* DF_USER_STRINGIFIER_H */

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -488,13 +488,12 @@ static inline void free_symbolizer_cache_kvp(struct symbolizer_cache_kvp *kv)
 		struct symbolizer_proc_info *p;
 		p = (struct symbolizer_proc_info *)kv->v.proc_info_p;
 		if (p->is_java) {
-			/* Delete Java files '/tmp/perf-<pid>.<map|log>' */
+			/* Delete target ns Java files */
 			int pid = (int)kv->k.pid;
-			char path[MAX_PATH_LENGTH];
-			snprintf(path, sizeof(path), "/tmp/perf-%d.map", pid);
-			clear_target_ns_tmp_file(path);
-			snprintf(path, sizeof(path), "/tmp/perf-%d.log", pid);
-			clear_target_ns_tmp_file(path);
+			int target_ns_pid = get_nspid(pid);
+			if (target_ns_pid > 0) {
+				clear_target_ns(pid, target_ns_pid);
+			}
 		}
 
 		clib_mem_free((void *)p);
@@ -513,9 +512,27 @@ static inline void symbol_cache_pids_unlock(void)
 	__atomic_clear(cache_del_pids.lock, __ATOMIC_RELEASE);
 }
 
+static inline bool pid_is_already_existed(int pid)
+{
+	/*
+	 * Make sure that there are no duplicate items of 'pid' in
+	 * 'cache del pids.pid caches', so as to avoid program crashes
+	 * caused by repeated release of occupied memory resources.
+	 */
+	struct symbolizer_cache_kvp *kv_tmp;
+	vec_foreach(kv_tmp, cache_del_pids.pid_caches) {
+		if ((int)kv_tmp->k.pid == pid) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /*
  * When a process exits, synchronize and update its corresponding
- * symbol cache.
+ * symbol cache. In addition, updating the Java process symbol t-
+ * able also requires calling this interface.
  *
  * @pid : The process ID (PID) that occurs when a process exits.
  */
@@ -535,17 +552,9 @@ void update_symbol_cache(pid_t pid)
 		int ret = VEC_OK;
 
 		symbol_cache_pids_lock();
-		/*
-		 * Make sure that there are no duplicate items of 'pid' in
-		 * 'cache del pids.pid caches', so as to avoid program crashes
-		 * caused by repeated release of occupied memory resources.
-		 */
-		struct symbolizer_cache_kvp *kv_tmp;
-		vec_foreach(kv_tmp, cache_del_pids.pid_caches) {
-			if (kv_tmp->k.pid == kv.k.pid) {
-				symbol_cache_pids_unlock();
-				return;
-			}
+		if (pid_is_already_existed((int)kv.k.pid)) {
+			symbol_cache_pids_unlock();
+			return;
 		}
 
 		vec_add1(cache_del_pids.pid_caches, kv, ret);
@@ -645,11 +654,20 @@ static void java_proc_info_config(struct symbolizer_proc_info *p, int pid)
 	}
 }
 
-void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
+static struct bcc_symbol_option lazy_opt = {
+	.use_debug_file = false,
+	.check_debug_file_crc = false,
+	.lazy_symbolize = true,
+	.use_symbol_type = ((1 << STT_FUNC) | (1 << STT_GNU_IFUNC)),
+};
+
+void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name,
+			     void **ptr)
 {
 	ASSERT(pid >= 0 && stime != NULL && netns_id != NULL && name != NULL);
 
 	*stime = *netns_id = 0;
+	*ptr = NULL;
 	symbol_caches_hash_t *h = &syms_cache_hash;
 	struct symbolizer_cache_kvp kv;
 
@@ -661,7 +679,7 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 	kv.k.pid = (u64) pid;
 	kv.v.proc_info_p = 0;
 	kv.v.cache = 0;
-	struct symbolizer_proc_info *p;
+	struct symbolizer_proc_info *p = NULL;
 	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
 				      (symbol_caches_hash_kv *) & kv) != 0) {
 		p = clib_mem_alloc_aligned("sym_proc_info",
@@ -674,6 +692,8 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 			return;
 		}
 
+		memset(p, 0, sizeof(*p));
+		p->unknown_syms_found = false;
 		p->netns_id = get_netns_id_from_pid(pid);
 		if (p->netns_id == 0) {
 			clib_mem_free(p);
@@ -704,9 +724,51 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 			__sync_fetch_and_add(&h->hash_elems_count, 1);
 	} else {
 		p = (struct symbolizer_proc_info *)kv.v.proc_info_p;
-		if (!p->verified
-		    && ((current_sys_time_secs() - (p->stime / 1000ULL)) >=
-			PROC_INFO_VERIFY_TIME)) {
+		u64 curr_time = current_sys_time_secs();
+		if (p->verified) {
+			/*
+			 * If an unknown frame appears during the process of symbolizing
+			 * the address of the Java process, we need to re-obtain the sy-
+			 * mbols table of the Java process after a delay.
+			 */
+			if (p->is_java && p->unknown_syms_found
+			    && p->update_syms_table_time == 0) {
+				p->update_syms_table_time =
+				    curr_time + JAVA_SYMS_TABLE_UPDATE_PERIOD;
+			}
+
+			if (p->update_syms_table_time > 0
+			    && curr_time >= p->update_syms_table_time) {
+				/* Update java symbols table, will be executed during
+				 * the next Java symbolication */
+				gen_java_symbols_file(pid);
+				if (kv.v.cache) {
+					bcc_free_symcache((void *)kv.v.cache,
+							  kv.k.pid);
+					kv.v.cache =
+					    pointer_to_uword(bcc_symcache_new
+							     ((int)kv.k.pid,
+							      &lazy_opt));
+					if (symbol_caches_hash_add_del
+					    (h, (symbol_caches_hash_kv *) & kv,
+					     1 /* is_add */ )) {
+						ebpf_warning
+						    ("symbol_caches_hash_add_del() failed.(pid %d)\n",
+						     (int)kv.k.pid);
+					}
+				}
+
+				p->update_syms_table_time = 0;
+				ebpf_info
+				    ("Update java symbols table, (Pid %d)\n",
+				     (int)kv.k.pid);
+			}
+		} else {
+			if (((curr_time - (p->stime / 1000ULL)) <
+			     PROC_INFO_VERIFY_TIME)) {
+				goto fetch_proc_info;
+			}
+
 			/*
 			 * To prevent the possibility of the process name being changed
 			 * shortly after the program's initial startup, as a precaution,
@@ -714,10 +776,10 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 			 * for a period of time to avoid such situations.
 			 */
 			char comm[sizeof(p->comm)];
-			u64 stime =
-				(u64)get_process_starttime_and_comm(pid,
-								    comm,
-								    sizeof(comm));
+			u64 stime = (u64)
+			    get_process_starttime_and_comm(pid,
+							   comm,
+							   sizeof(comm));
 			if (stime == 0) {
 				/* 
 				 * Here, indicate that during the symbolization process,
@@ -748,12 +810,14 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name)
 
 			p->verified = true;
 		}
+
 	}
 
 fetch_proc_info:
 	copy_process_name(&kv, name);
 	*stime = cache_process_stime(&kv);
 	*netns_id = cache_process_netns_id(&kv);
+	*ptr = p;
 }
 
 /*
@@ -770,13 +834,6 @@ fetch_proc_info:
 void *get_symbol_cache(pid_t pid, bool new_cache)
 {
 	ASSERT(pid >= 0);
-
-	static struct bcc_symbol_option lazy_opt = {
-		.use_debug_file = false,
-		.check_debug_file_crc = false,
-		.lazy_symbolize = true,
-		.use_symbol_type = ((1 << STT_FUNC) | (1 << STT_GNU_IFUNC)),
-	};
 
 	if (k_resolver == NULL && pid == 0) {
 		k_resolver = (void *)bcc_symcache_new(-1, &lazy_opt);
@@ -850,6 +907,8 @@ int create_and_init_symbolizer_caches(void)
 				return ETR_NOMEM;
 			}
 
+			memset(p, 0, sizeof(*p));
+			p->unknown_syms_found = false;
 			p->netns_id = get_netns_id_from_pid(pid);
 			if (p->netns_id == 0) {
 				clib_mem_free(p);
@@ -857,7 +916,8 @@ int create_and_init_symbolizer_caches(void)
 			}
 
 			p->stime =
-			    (u64) get_process_starttime_and_comm(pid, p->comm,
+			    (u64) get_process_starttime_and_comm(pid,
+								 p->comm,
 								 sizeof
 								 (p->comm));
 			p->comm[sizeof(p->comm) - 1] = '\0';
@@ -878,8 +938,8 @@ int create_and_init_symbolizer_caches(void)
 			} else {
 				ebpf_debug
 				    ("Process '%s'(pid %d start time %lu) has been"
-				     " brought under management.\n", p->comm,
-				     pid, p->stime);
+				     " brought under management.\n",
+				     p->comm, pid, p->stime);
 				__sync_fetch_and_add(&h->hash_elems_count, 1);
 			}
 		}
@@ -908,7 +968,8 @@ void release_symbol_caches(void)
 	ebpf_info("Release symbol_caches %lu elements\n", h->hash_elems_count);
 
 	symbol_cache_pids_lock();
-	symbol_caches_hash_foreach_key_value_pair(h, free_symbolizer_kvp_cb,
+	symbol_caches_hash_foreach_key_value_pair(h,
+						  free_symbolizer_kvp_cb,
 						  (void *)&elems_count);
 	print_hash_symbol_caches(h);
 	symbol_caches_hash_free(h);

--- a/agent/src/ebpf/user/symbol.h
+++ b/agent/src/ebpf/user/symbol.h
@@ -62,6 +62,11 @@ struct symbolizer_proc_info {
 	bool verified;
 	/* To mark whether it is a Java process? */
 	bool is_java;
+	/* Unknown symbols was found, and it is currently mainly used to
+	 * obtain the match of the Java process.*/
+	bool unknown_syms_found;
+	/* Expiration time (in seconds) for updating the Java symbol table */
+	u64 update_syms_table_time;
 	/* process name */
 	char comm[TASK_COMM_LEN];
 };
@@ -166,7 +171,8 @@ struct symbol_uprobe *resolve_and_gen_uprobe_symbol(const char *bin_file,
 						    const uint64_t addr,
 						    int pid);
 uint64_t get_symbol_addr_from_binary(const char *bin, const char *symname);
-void get_process_info_by_pid(pid_t pid, u64 *stime, u64 *netns_id, char *name);
+void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name,
+			     void **ptr);
 #ifndef AARCH64_MUSL
 void *get_symbol_cache(pid_t pid, bool new_cache);
 int create_and_init_symbolizer_caches(void);


### PR DESCRIPTION
- Keep map files in target namespace 
The java parser will automatically enter the namespace where the target process is located to find `perf-<pid>.map` It is hoped that this file will remain in the target namespace，remove copy work.

- Java symbols table update
When an 'unknown' Frame is encountered during the symbolization process of
the Java process, it will be delayed for a fixed time (if the 'unknown' f-
rame is encountered again during this period, it will be ignored) to upda-
te the Java symbol table.

The update cycle of the Java process symbols table is 300 seconds.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.3
