### PR TITLE
[eBPF] Set the unknown flag after the Java symbol table is updated

### DIFF
--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -758,6 +758,7 @@ void get_process_info_by_pid(pid_t pid, u64 * stime, u64 * netns_id, char *name,
 					}
 				}
 
+				p->unknown_syms_found = false;
 				p->update_syms_table_time = 0;
 				ebpf_info
 				    ("Update java symbols table, (Pid %d)\n",


### PR DESCRIPTION
'unknown_syms_found' must be set to false after the Java symbol table is updated, otherwise the Java process symbol table will be updated periodically. We hope that it will only update the symbol table when it finds that there is an 'unknown' Frame.

### This PR is for:


- Agent



#### Affected branches
- main
- v6.3
