### PR TITLE
[server] fix parse config(export-only-with-traceid) error

### DIFF
--- a/server/ingester/flow_log/exporters/config/otlp_config.go
+++ b/server/ingester/flow_log/exporters/config/otlp_config.go
@@ -91,7 +91,7 @@ func (cfg *OtlpExporterConfig) Validate(overridableCfg OverridableCfg) error {
 		cfg.ExportDataTypes = overridableCfg.ExportDataTypes
 	}
 
-	if cfg.ExportOnlyWithTraceID != nil {
+	if cfg.ExportOnlyWithTraceID == nil {
 		cfg.ExportOnlyWithTraceID = overridableCfg.ExportOnlyWithTraceID
 	}
 	return nil


### PR DESCRIPTION
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug

 When I configured only to export span data with traceid, the top-level configuration(export-only-with-traceid) did not take effect, that is, the child configuration did not inherit the parent configuration.

#### Changes to fix the bug

- fix if statement

#### Affected branches
- main
#### Checklist
- [x] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.


