### PR TITLE
[eBPF] Fix TCP DNS prev count v6.2

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -887,12 +887,13 @@ static __inline enum message_type infer_dns_message(const char *buf,
 		return MSG_UNKNOWN;
 	}
 
+	bool update_tcp_dns_prev_count = false;
 	struct dns_header *dns = (struct dns_header *)buf;
 	if (conn_info->tuple.l4_protocol == IPPROTO_TCP) {
 		if (__bpf_ntohs(dns->id) + 2 == count) {
 			dns = (void *)dns + 2;
 		} else {
-			conn_info->prev_count = 2;
+			update_tcp_dns_prev_count = true;
 		}
 	}
 
@@ -932,7 +933,12 @@ static __inline enum message_type infer_dns_message(const char *buf,
 			break;
 		}
 	}
-
+	// coreDNS will first send the length in two bytes. If it recognizes
+	// that it is TCP DNS and does not have a length field, it will modify
+	// the offset to correct the TCP sequence number.
+	if (update_tcp_dns_prev_count) {
+		conn_info->prev_count = 2;
+	}
 	return (qr == 0) ? MSG_REQUEST : MSG_RESPONSE;
 }
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes HTTP packet reported by eBPF has two leading '\0'

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
