### PR TITLE
[querier] fixed up start for large interval query

### DIFF
--- a/server/querier/app/prometheus/promql-deepflow-metrics-tests.yaml
+++ b/server/querier/app/prometheus/promql-deepflow-metrics-tests.yaml
@@ -10,7 +10,7 @@ test_target_config:
   query_url: http://deepflow-server.deepflow:20416/prom
 
 query_time_parameters:
-  end_time: 1683442312
+  end_time: 1694672773
   range_in_seconds: 14
 
 test_cases:
@@ -39,8 +39,10 @@ test_cases:
     should_fail: true
   - query: '{{.simpleAggrOp}}(nonexistent_metric_name)'
     variant_args: ['simpleAggrOp']
+    should_fail: true
   - query: '{{.simpleAggrOp}} by() (nonexistent_metric_name)'
     variant_args: ['simpleAggrOp']
+    should_fail: true
   - query: 'sum by(auto_instance) (flow_metrics__vtap_app_port__request__1m)'
   - query: 'avg by(auto_instance) (flow_metrics__vtap_app_port__request__1m)'
   - query: 'min by(auto_instance) (flow_metrics__vtap_app_port__request__1m)'
@@ -73,7 +75,6 @@ test_cases:
     should_fail: true
   - query: '{{.topBottomOp}} by(auto_instance) (2, flow_metrics__vtap_app_port__request__1m)'
     variant_args: ['topBottomOp']
-    should_fail: true
   - query: '{{.topBottomOp}} without(auto_instance) (2, flow_metrics__vtap_app_port__request__1m)'
     variant_args: ['topBottomOp']
     should_fail: true
@@ -119,6 +120,7 @@ test_cases:
     variant_args: ['simpleMathFunc']
   - query: '{{.extrapolatedRateFunc}}(nonexistent_metric[5m])'
     variant_args: ['extrapolatedRateFunc']
+    should_fail: true
   - query: '{{.extrapolatedRateFunc}}(sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"})[{{.range}}:1m])'
     variant_args: ['extrapolatedRateFunc', 'range']
   - query: 'deriv(sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"})[{{.range}}:1m])'
@@ -175,6 +177,7 @@ test_cases:
   - query: 'histogram_quantile({{.quantile}}, rate(sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"})[1m:1m]))'
     variant_args: ['quantile']
   - query: 'histogram_quantile(0.9, nonexistent_metric)'
+    should_fail: true
   - # Missing "le" label.
     query: 'histogram_quantile(0.9, sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"}))'
   # - # Missing "le" label only in some series of the same grouping.
@@ -184,6 +187,7 @@ test_cases:
   - query: 'count_values("value", sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"}))'
   - query: 'absent(sum by(auto_instance, auto_service) (flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"}))'
   - query: 'absent(nonexistent_metric_name)'
+    should_fail: true
 
   # Subqueries.
   - query: 'max_over_time((time() - max(flow_metrics__vtap_app_port__request__1m{auto_service="deepflow-server"}) by(auto_instance, auto_service) < 1000)[5m:10s] offset 5m)'

--- a/server/querier/app/prometheus/promql-prom-metrics-tests.yaml
+++ b/server/querier/app/prometheus/promql-prom-metrics-tests.yaml
@@ -39,6 +39,7 @@ test_cases:
   - query: '{__name__=~".*"}'
     should_fail: true
   - query: "nonexistent_metric_name"
+    should_fail: true
   - query: 'node_cpu_seconds_total offset {{.offset}}'
     variant_args: ['offset']
   - query: 'node_cpu_seconds_total offset -{{.offset}}'
@@ -49,6 +50,7 @@ test_cases:
     variant_args: ['simpleAggrOp']
   - query: '{{.simpleAggrOp}}(nonexistent_metric_name)'
     variant_args: ['simpleAggrOp']
+    should_fail: true
   - query: '{{.simpleAggrOp}} by() (node_cpu_seconds_total)'
     variant_args: ['simpleAggrOp']
   - query: '{{.simpleAggrOp}} by(instance) (node_cpu_seconds_total)'
@@ -153,6 +155,7 @@ test_cases:
     variant_args: ['simpleMathFunc']
   - query: '{{.extrapolatedRateFunc}}(nonexistent_metric[5m])'
     variant_args: ['extrapolatedRateFunc']
+    should_fail: true
   - query: '{{.extrapolatedRateFunc}}(node_cpu_seconds_total{mode="system", cpu="0"}[{{.range}}])'
     variant_args: ['extrapolatedRateFunc', 'range']
   - query: 'deriv(node_cpu_seconds_total{mode="system", cpu="0"}[{{.range}}])'
@@ -161,38 +164,37 @@ test_cases:
     variant_args: ['range']
   - query: 'time()'
     # label_replace does a full-string match and replace.
-  - query: 'label_replace(demo_num_cpus, "job", "destination-value-$1", "instance", "10.34.0.237:(.*)")'
+  - query: 'label_replace(kube_node_info, "job", "destination-value-$1", "instance", "10.34.0.237:(.*)")'
     # label_replace does not do a sub-string match.
-  - query: 'label_replace(demo_num_cpus, "job", "destination-value-$1", "instance", "host:(.*)")'
+  - query: 'label_replace(kube_node_info, "job", "destination-value-$1", "instance", "host:(.*)")'
     # label_replace works with multiple capture groups.
-  - query: 'label_replace(demo_num_cpus, "job", "$1-$2", "instance", "local(.*):(.*)")'
+  - query: 'label_replace(kube_node_info, "job", "$1-$2", "instance", "local(.*):(.*)")'
     # label_replace does not overwrite the destination label if the source label does not exist.
-  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "nonexistent-src", "source-value-(.*)")'
+  - query: 'label_replace(kube_node_info, "job", "value-$1", "nonexistent-src", "source-value-(.*)")'
     # label_replace overwrites the destination label if the source label is empty, but matched.
-  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "nonexistent-src", "(.*)")'
+  - query: 'label_replace(kube_node_info, "job", "value-$1", "nonexistent-src", "(.*)")'
     # label_replace does not overwrite the destination label if the source label is not matched.
-  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "instance", "non-matching-regex")'
+  - query: 'label_replace(kube_node_info, "job", "value-$1", "instance", "non-matching-regex")'
     # label_replace drops labels that are set to empty values.
-  - query: 'label_replace(demo_num_cpus, "job", "", "dst", ".*")'
+  - query: 'label_replace(kube_node_info, "job", "", "dst", ".*")'
     # label_replace fails when the regex is invalid.
-  - query: 'label_replace(demo_num_cpus, "job", "value-$1", "src", "(.*")'
+  - query: 'label_replace(kube_node_info, "job", "value-$1", "src", "(.*")'
     should_fail: true
     # label_replace fails when the destination label name is not a valid Prometheus label name.
-  - query: 'label_replace(demo_num_cpus, "~invalid", "", "src", "(.*)")'
+  - query: 'label_replace(kube_node_info, "~invalid", "", "src", "(.*)")'
     should_fail: true
     # label_replace fails when there would be duplicated identical output label sets.
-  - query: 'label_replace(demo_num_cpus, "instance", "", "", "")'
-    should_fail: true
-  - query: 'label_join(demo_num_cpus, "new_label", "-", "instance", "job")'
-  - query: 'label_join(demo_num_cpus, "job", "-", "instance", "job")'
-  - query: 'label_join(demo_num_cpus, "job", "-", "instance")'
-  - query: 'label_join(demo_num_cpus, "~invalid", "-", "instance")'
+  - query: 'label_replace(kube_node_info, "instance", "", "", "")'
+  - query: 'label_join(kube_node_info, "new_label", "-", "instance", "job")'
+  - query: 'label_join(kube_node_info, "job", "-", "instance", "job")'
+  - query: 'label_join(kube_node_info, "job", "-", "instance")'
+  - query: 'label_join(kube_node_info, "~invalid", "-", "instance")'
     should_fail: true
   - query: '{{.dateFunc}}()'
     variant_args: ['dateFunc']
-  - query: '{{.dateFunc}}(demo_batch_last_success_timestamp_seconds offset {{.offset}})'
+  - query: '{{.dateFunc}}(kube_node_info offset {{.offset}})'
     variant_args: ['dateFunc', 'offset']
-  - query: '{{.instantRateFunc}}(demo_cpu_usage_seconds_total[{{.range}}])'
+  - query: '{{.instantRateFunc}}(node_cpu_seconds_total[{{.range}}])'
     variant_args: ['instantRateFunc', 'range']
   - query: '{{.clampFunc}}(node_cpu_seconds_total{mode="system", cpu="0"}, 2)'
     variant_args: ['clampFunc']
@@ -206,18 +208,20 @@ test_cases:
     variant_args: ['range']
   - query: 'vector(1.23)'
   - query: 'vector(time())'
-  - query: 'histogram_quantile({{.quantile}}, rate(demo_api_request_duration_seconds_bucket[1m]))'
+  - query: 'histogram_quantile({{.quantile}}, rate(apiserver_request_duration_seconds_bucket[1m]))'
     variant_args: ['quantile']
   - query: 'histogram_quantile(0.9, nonexistent_metric)'
+    should_fail: true
   - # Missing "le" label.
     query: 'histogram_quantile(0.9, node_cpu_seconds_total{mode="system", cpu="0"})'
   # - # Missing "le" label only in some series of the same grouping.
-  #  query: 'histogram_quantile(0.9, {__name__=~"demo_api_request_duration_seconds_.+"})'
+  #  query: 'histogram_quantile(0.9, {__name__=~"apiserver_request_duration_seconds_bucket.+"})'
   - query: 'holt_winters(node_cpu_seconds_total{mode="system", cpu="0"}[10m], {{.smoothingFactor}}, {{.trendFactor}})'
     variant_args: ['smoothingFactor', 'trendFactor']
-  - query: 'count_values("value", demo_api_request_duration_seconds_bucket)'
+  - query: 'count_values("value", apiserver_request_duration_seconds_bucket)'
   - query: 'absent(node_cpu_seconds_total{mode="system", cpu="0"})'
   - query: 'absent(nonexistent_metric_name)'
+    should_fail: true
 
   # Subqueries.
   - query: 'max_over_time((time() - max(node_cpu_seconds_total{mode="system", cpu="0"}) < 1000)[5m:10s] offset 5m)'

--- a/server/querier/app/prometheus/service/promql.go
+++ b/server/querier/app/prometheus/service/promql.go
@@ -75,11 +75,13 @@ const _SUCCESS = "success"
 type prometheusExecutor struct {
 	extraLabelCache *lru.Cache[string, string]
 	ticker          *time.Ticker
+	lookbackDelta   time.Duration
 }
 
-func NewPrometheusExecutor() *prometheusExecutor {
+func NewPrometheusExecutor(delta time.Duration) *prometheusExecutor {
 	executor := &prometheusExecutor{
 		extraLabelCache: lru.NewCache[string, string](config.Cfg.Prometheus.ExternalTagCacheSize),
+		lookbackDelta:   delta,
 	}
 	go executor.triggerLoadExternalTag()
 	return executor
@@ -188,6 +190,22 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
 	reader.addExternalTagToCache = p.addExtraLabelConvertion
 	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
+	// in range query, it will scan data from [startTime-lookbackDelta] to endTime
+	// then drop points if timestamp of first point is greater than startTime
+	// so, when start%step > lookbackdelta, points may lost during scan
+	// should fix up time query range for large query steps
+	if start.Local().Unix()%int64(step.Seconds()) > int64(p.lookbackDelta.Seconds()) {
+		start = time.Unix(start.Local().Unix()-start.Local().Unix()%int64(step.Seconds()), 0)
+	}
+	if end.Local().Unix()%int64(step.Seconds()) > int64(p.lookbackDelta.Seconds()) {
+		end = time.Unix(end.Local().Unix()-end.Local().Unix()%int64(step.Seconds())+int64(step.Seconds()), 0)
+	}
+	if int(step.Seconds())%86400 == 0 {
+		year_start, month_start, day_start := start.Date()
+		year_end, month_end, day_end := end.Date()
+		start = time.Date(year_start, month_start, day_start, 0, 0, 0, 0, start.Location())
+		end = time.Date(year_end, month_end, day_end, 0, 0, 0, 0, end.Location())
+	}
 	qry, err := engine.NewRangeQuery(queriable, nil, args.Promql, start, end, step)
 	if qry == nil || err != nil {
 		log.Error(err)

--- a/server/querier/app/prometheus/service/promql_test.go
+++ b/server/querier/app/prometheus/service/promql_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -60,7 +61,7 @@ func TestParseMatchersParam(t *testing.T) {
 }
 
 func TestParsePromQL(t *testing.T) {
-	executor := NewPrometheusExecutor()
+	executor := NewPrometheusExecutor(5 * time.Minute)
 	Convey("TestCase_ParsePromQL_Success_1", t, func() {
 		res, err := executor.parsePromQL("max(kube_pod_info{job=\"kube-state-metrics\"} * on(node, cluster) group_left(role) kube_node_role{job=\"kube-state-metrics\", role=\"master\"} or on(pod, namespace, cluster) kube_pod_info{job=\"kube-state-metrics\"}) by (node, namespace, host_ip, role, pod, cluster)")
 		So(err, ShouldBeNil)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes range query with large interval 
#### Steps to reproduce the bug
- do range query with large query ( like 30m/1h/1d/7d...)
#### Changes to fix the bug
- when query with large step, extend query start/end to the nearest data point which can find start/end data 
- it's mostly for DeepFlow native metrics
#### Affected branches
- main