### PR TITLE
[server] fix external datasource update from v6.2 to v6.3 failed

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -1213,12 +1213,22 @@ func (i *Issu) addColumnDatasource(connect *sql.DB, d *DatasourceInfo, isEdgeTab
 			&ColumnAdds{
 				Dbs:         []string{d.db},
 				Tables:      []string{d.name, d.name + "_agg"},
-				ColumnNames: []string{"role"},
+				ColumnNames: []string{"role", "tag_source"},
 				ColumnType:  ckdb.UInt8,
 			},
 		}...)
 
+	} else {
+		columnAddss633 = append(columnAddss633, []*ColumnAdds{
+			&ColumnAdds{
+				Dbs:         []string{d.db},
+				Tables:      []string{d.name, d.name + "_agg"},
+				ColumnNames: []string{"tag_source_0", "tag_source_1"},
+				ColumnType:  ckdb.UInt8,
+			},
+		}...)
 	}
+
 	if isAppTable {
 		if isEdgeTable {
 			columnAddss633 = append(columnAddss633, []*ColumnAdds{

--- a/server/libs/zerodoc/tag.go
+++ b/server/libs/zerodoc/tag.go
@@ -956,7 +956,7 @@ func GenTagColumns(code Code) []*ckdb.Column {
 		columns = append(columns, ckdb.NewColumnWithGroupBy("ip4", ckdb.IPv4).SetComment("IPv4地址"))
 		columns = append(columns, ckdb.NewColumnWithGroupBy("ip6", ckdb.IPv6).SetComment("IPV6地址"))
 		columns = append(columns, ckdb.NewColumnWithGroupBy("is_ipv4", ckdb.UInt8).SetIndex(ckdb.IndexMinmax).SetComment("是否IPV4地址. 0: 否, ip6字段有效, 1: 是, ip4字段有效"))
-		columns = append(columns, ckdb.NewColumn("tag_source", ckdb.UInt8).SetComment("tag来源"))
+		columns = append(columns, ckdb.NewColumnWithGroupBy("tag_source", ckdb.UInt8).SetComment("tag来源"))
 	}
 	if code&IPPath != 0 {
 		columns = append(columns, ckdb.NewColumnWithGroupBy("ip4_0", ckdb.IPv4))
@@ -964,8 +964,8 @@ func GenTagColumns(code Code) []*ckdb.Column {
 		columns = append(columns, ckdb.NewColumnWithGroupBy("ip6_0", ckdb.IPv6))
 		columns = append(columns, ckdb.NewColumnWithGroupBy("ip6_1", ckdb.IPv6))
 		columns = append(columns, ckdb.NewColumnWithGroupBy("is_ipv4", ckdb.UInt8).SetIndex(ckdb.IndexMinmax))
-		columns = append(columns, ckdb.NewColumn("tag_source_0", ckdb.UInt8).SetComment("ip_0对应的tag来源"))
-		columns = append(columns, ckdb.NewColumn("tag_source_1", ckdb.UInt8).SetComment("ip_1对应的tag来源"))
+		columns = append(columns, ckdb.NewColumnWithGroupBy("tag_source_0", ckdb.UInt8).SetComment("ip_0对应的tag来源"))
+		columns = append(columns, ckdb.NewColumnWithGroupBy("tag_source_1", ckdb.UInt8).SetComment("ip_1对应的tag来源"))
 	}
 
 	if code&IsKeyService != 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


