### PR TITLE
[ingester] prevent reset ck connection cause panic

### DIFF
--- a/server/ingester/config/config.go
+++ b/server/ingester/config/config.go
@@ -248,6 +248,7 @@ func (c *Config) Validate() error {
 			log.Warningf("get clickhouse endpoints(%s) failed, err: %s", c.CKDB.Host, err)
 			continue
 		}
+		c.CKDB.ActualAddrs = c.CKDB.ActualAddrs[:0]
 		for _, endpoint := range endpoints {
 			// if it is an IPv6 address, it needs to be enclosed in []
 			if strings.Contains(endpoint.Host, ":") {

--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -254,9 +254,9 @@ func (w *CKWriter) queueProcess(queueID int) {
 
 func (w *CKWriter) ResetConnection(connID int) error {
 	var err error
+	// FIXME: do reset actually
 	if !IsNil(w.conns[connID]) {
-		w.conns[connID].Close()
-		w.conns[connID] = nil
+		return nil
 	}
 	w.conns[connID], err = clickhouse.Open(&clickhouse.Options{
 		Addr: []string{w.addrs[connID]},


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


