### PR TITLE
[eBPF] Remove same socket no-tracing logic

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -975,13 +975,9 @@ static __inline void trace_process(struct socket_info_t *socket_info_ptr,
 			if (trace_info_ptr->is_trace_id_zero) {
 				return;
 			}
-			/*
-			 * 追踪在不同socket之间进行，而对于在同一个socket的情况进行忽略。
-			 */
-			if (socket_id != trace_info_ptr->socket_id) {
-				*thread_trace_id =
+
+			*thread_trace_id =
 				    trace_info_ptr->thread_trace_id;
-			}
 
 			if (!trace_map__delete(trace_key)) {
 				__sync_fetch_and_add(&trace_stats->


### PR DESCRIPTION
If the same socket is tracked, multiple tracking trees will appear. In order to avoid this situation, the previous operation was to not track data on the same socket. But the disadvantage of doing this is that some necessary tracking is truncated. Because we currently have a branch pruning function that can avoid multiple trees, here we re-enable the same socket tracking function.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.3
- v6.2
