### PR TITLE
[Agent] fix wrong l7 protocol in metrics #22426

### DIFF
--- a/agent/src/common/l7_protocol_log.rs
+++ b/agent/src/common/l7_protocol_log.rs
@@ -86,8 +86,8 @@ macro_rules! impl_protocol_parser {
                 match self {
                     Self::Http(p) => {
                         match p.protocol() {
-                            L7Protocol::Http1 => return "HTTP",
-                            L7Protocol::Http2 => return "HTTP2",
+                            L7Protocol::Http1|L7Protocol::Http1TLS => return "HTTP",
+                            L7Protocol::Http2|L7Protocol::Http2TLS => return "HTTP2",
                             _ => unreachable!()
                         }
                     },
@@ -543,7 +543,20 @@ impl From<&Vec<String>> for L7ProtocolBitmap {
         let mut bitmap = L7ProtocolBitmap(0);
         for v in vs.iter() {
             if let Ok(p) = L7ProtocolParser::try_from(v.as_str()) {
-                bitmap.set_enabled(p.protocol());
+                let protocol = p.protocol();
+                match protocol {
+                    L7Protocol::Http1 => {
+                        bitmap.set_enabled(L7Protocol::Http1);
+                        bitmap.set_enabled(L7Protocol::Http1TLS);
+                    }
+                    L7Protocol::Http2 => {
+                        bitmap.set_enabled(L7Protocol::Http2);
+                        bitmap.set_enabled(L7Protocol::Http2TLS);
+                    }
+                    _ => {
+                        bitmap.set_enabled(protocol);
+                    }
+                }
             }
         }
         bitmap


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong l7 protocol in metrics #22426
#### Steps to reproduce the bug
- 
#### Changes to fix the bug

#### Affected branches
- main
- v6.3

#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
