### PR TITLE
[Agent] fixes http2 go uprobe wrong direction #22443

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -48,6 +48,7 @@ use super::{
 
 use crate::{
     common::{
+        ebpf::EbpfType,
         endpoint::{
             EndpointData, EndpointDataPov, EndpointInfo, EPC_FROM_DEEPFLOW, EPC_FROM_INTERNET,
         },
@@ -983,8 +984,12 @@ impl FlowMap {
 
     fn init_flow(&mut self, config: &Config, meta_packet: &mut MetaPacket) -> Box<FlowNode> {
         let flow_config = config.flow;
-
-        meta_packet.lookup_key.direction = PacketDirection::ClientToServer;
+        match meta_packet.ebpf_type {
+            EbpfType::GoHttp2Uprobe | EbpfType::GoHttp2UprobeData => {}
+            _ => {
+                meta_packet.lookup_key.direction = PacketDirection::ClientToServer;
+            }
+        }
 
         let mut tagged_flow = TaggedFlow::default();
         let lookup_key = &meta_packet.lookup_key;

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -451,9 +451,18 @@ impl L7ProtocolParserInterface for HttpLog {
                     return false;
                 };
                 match param.ebpf_type {
-                    EbpfType::GoHttp2Uprobe => self
-                        .parse_http2_go_uprobe(&config.l7_log_dynamic, payload, param, &mut info)
-                        .is_ok(),
+                    EbpfType::GoHttp2Uprobe | EbpfType::GoHttp2UprobeData => {
+                        if param.direction == PacketDirection::ServerToClient {
+                            return false;
+                        }
+                        self.parse_http2_go_uprobe(
+                            &config.l7_log_dynamic,
+                            payload,
+                            param,
+                            &mut info,
+                        )
+                        .is_ok()
+                    }
                     _ => self.parse_http_v2(payload, param, &mut info).is_ok(),
                 }
             }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes http2 go uprobe wrong direction #22443
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
