### PR TITLE
[querier] remove empty tag & value for prometheus metrics

### DIFF
--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -626,17 +626,18 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 				tagMap := make(map[string]string)
 				json.Unmarshal([]byte(promTagJson), &tagMap)
 				pairs = make([]prompb.Label, 0, 1+len(tagMap)+len(allDeepFlowNativeTags))
-				if prefix == prefixTag {
-					// prometheus tag for deepflow metrics
-					for k, v := range tagMap {
+				for k, v := range tagMap {
+					if k == "" || v == "" {
+						continue
+					}
+					if prefix == prefixTag {
+						// prometheus tag for deepflow metrics
 						pairs = append(pairs, prompb.Label{
 							Name:  appendPrometheusPrefix(k),
 							Value: v,
 						})
-					}
-				} else {
-					// no prefix, use prometheus native tag
-					for k, v := range tagMap {
+					} else {
+						// no prefix, use prometheus native tag
 						pairs = append(pairs, prompb.Label{
 							Name:  k,
 							Value: v,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes when query empty labels & empty label values
#### Steps to reproduce the bug
- query normal prometheus series
#### Changes to fix the bug
- <changes here>
- drop empty labels key&value
#### Affected branches
- main
- 6.3
