### PR TITLE
[querier] remove extend end time

### DIFF
--- a/server/querier/app/prometheus/service/promql.go
+++ b/server/querier/app/prometheus/service/promql.go
@@ -197,14 +197,9 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 	if start.Local().Unix()%int64(step.Seconds()) > int64(p.lookbackDelta.Seconds()) {
 		start = time.Unix(start.Local().Unix()-start.Local().Unix()%int64(step.Seconds()), 0)
 	}
-	if end.Local().Unix()%int64(step.Seconds()) > int64(p.lookbackDelta.Seconds()) {
-		end = time.Unix(end.Local().Unix()-end.Local().Unix()%int64(step.Seconds())+int64(step.Seconds()), 0)
-	}
 	if int(step.Seconds())%86400 == 0 {
 		year_start, month_start, day_start := start.Date()
-		year_end, month_end, day_end := end.Date()
 		start = time.Date(year_start, month_start, day_start, 0, 0, 0, 0, start.Location())
-		end = time.Date(year_end, month_end, day_end, 0, 0, 0, 0, end.Location())
 	}
 	qry, err := engine.NewRangeQuery(queriable, nil, args.Promql, start, end, step)
 	if qry == nil || err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query end time fixup
#### Steps to reproduce the bug
- when use a query like `sum(metric) or vector(0)`，prometheus engine would add `0` for each query timestamp. then it will return an unexpected timestamp when extend end time.
#### Changes to fix the bug
- for query end time, not extend, only extend start time for `start%step>loockbackdelta` query.
#### Affected branches
- main
- v6.3

