### PR TITLE
[eBPF] Remove cleanup of java symbol files for old versions

### DIFF
--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -25,5 +25,4 @@ void clear_target_ns(int pid, int target_ns_pid);
 void clear_target_ns_so(int pid, int target_ns_pid);
 void clear_local_perf_files(int pid);
 bool is_same_mntns(int target_pid);
-void __unused clear_old_target_perf_files(int pid);
 #endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -925,10 +925,6 @@ int create_and_init_symbolizer_caches(void)
 				continue;
 			}
 
-			if (p->is_java) {
-				clear_old_target_perf_files(pid);
-			}
-
 			sym.v.proc_info_p = pointer_to_uword(p);
 			sym.v.cache = 0;
 			if (symbol_caches_hash_add_del


### PR DESCRIPTION
Remove cleanup of java symbol files for old versions

### This PR is for:

- Agent



#### Affected branches
- main

