### PR TITLE
[ingester] resource_gl1_type support pod group type

### DIFF
--- a/server/ingester/common/common.go
+++ b/server/ingester/common/common.go
@@ -144,8 +144,7 @@ const (
 	PodType     = 10
 	PodNodeType = 14
 
-	PodGroupType = 101
-	ServiceType  = 102
+	ServiceType = 102
 )
 
 func GetResourceGl0(podID, podNodeID, l3DeviceID uint32, l3DeviceType uint8, l3EpcID int32) (uint32, uint8) {
@@ -162,9 +161,9 @@ func GetResourceGl0(podID, podNodeID, l3DeviceID uint32, l3DeviceType uint8, l3E
 	return 0, IpType
 }
 
-func GetResourceGl1(podGroupID, podNodeID, l3DeviceID uint32, l3DeviceType uint8, l3EpcID int32) (uint32, uint8) {
+func GetResourceGl1(podGroupID, podNodeID, l3DeviceID uint32, l3DeviceType, podGroupType uint8, l3EpcID int32) (uint32, uint8) {
 	if podGroupID > 0 {
-		return podGroupID, PodGroupType
+		return podGroupID, podGroupType
 	} else if podNodeID > 0 {
 		return podNodeID, PodNodeType
 	} else if l3DeviceID > 0 {
@@ -175,11 +174,11 @@ func GetResourceGl1(podGroupID, podNodeID, l3DeviceID uint32, l3DeviceType uint8
 	return 0, IpType
 }
 
-func GetResourceGl2(serviceID, podGroupID, podNodeID, l3DeviceID uint32, l3DeviceType uint8, l3EpcID int32) (uint32, uint8) {
+func GetResourceGl2(serviceID, podGroupID, podNodeID, l3DeviceID uint32, l3DeviceType, podGroupType uint8, l3EpcID int32) (uint32, uint8) {
 	if serviceID > 0 {
 		return serviceID, ServiceType
 	}
-	return GetResourceGl1(podGroupID, podNodeID, l3DeviceID, l3DeviceType, l3EpcID)
+	return GetResourceGl1(podGroupID, podNodeID, l3DeviceID, l3DeviceType, podGroupType, l3EpcID)
 }
 
 func IsPodServiceIP(deviceType zerodoc.DeviceType, podId, podNodeId uint32) bool {

--- a/server/ingester/event/decoder/decoder.go
+++ b/server/ingester/event/decoder/decoder.go
@@ -163,7 +163,6 @@ func (d *Decoder) handleResourceEvent(event *eventapi.ResourceEvent) {
 		eventStore.PodGroupID = event.PodGroupID
 		eventStore.L3DeviceType = uint8(event.L3DeviceType)
 		eventStore.L3DeviceID = event.L3DeviceID
-
 	}
 	if event.InstanceType == uint32(trident.DeviceType_DEVICE_TYPE_POD_SERVICE) {
 		eventStore.ServiceID = event.InstanceID

--- a/server/ingester/event/decoder/grpc_resource_info.go
+++ b/server/ingester/event/decoder/grpc_resource_info.go
@@ -59,6 +59,7 @@ type ResourceInfo struct {
 	PodNodeID    uint32
 	PodNSID      uint32
 	PodGroupID   uint32
+	PodGroupType uint8 // no need to store
 	PodID        uint32
 	PodClusterID uint32
 	AZID         uint32
@@ -179,6 +180,7 @@ func updateResourceInfos(reourceInfos map[uint64]*ResourceInfo, podInfos, podNod
 		PodNodeID:    podNodeID,
 		PodNSID:      intf.GetPodNsId(),
 		PodGroupID:   intf.GetPodGroupId(),
+		PodGroupType: uint8(intf.GetPodGroupType()),
 		PodID:        podID,
 		PodClusterID: intf.GetPodClusterId(),
 		AZID:         intf.GetAzId(),
@@ -190,6 +192,7 @@ func updateResourceInfos(reourceInfos map[uint64]*ResourceInfo, podInfos, podNod
 	nodeInfo.PodID = 0
 	nodeInfo.PodNSID = 0
 	nodeInfo.PodGroupID = 0
+	nodeInfo.PodGroupType = 0
 	nodeInfo.PodClusterID = 0
 	podNodeInfos[podNodeID] = &nodeInfo
 
@@ -198,6 +201,7 @@ func updateResourceInfos(reourceInfos map[uint64]*ResourceInfo, podInfos, podNod
 	hostInfo.PodID = 0
 	hostInfo.PodNSID = 0
 	hostInfo.PodGroupID = 0
+	nodeInfo.PodGroupType = 0
 	hostInfo.PodClusterID = 0
 	hostInfos[hostID] = &hostInfo
 }

--- a/server/ingester/ext_metrics/decoder/decoder.go
+++ b/server/ingester/ext_metrics/decoder/decoder.go
@@ -352,6 +352,7 @@ func (d *Decoder) fillExtMetricsBase(m *dbwriter.ExtMetrics, vtapID uint16, podN
 		t.AZID = uint16(info.AZID)
 		t.HostID = uint16(info.HostID)
 		t.PodGroupID = info.PodGroupID
+		podGroupType := uint8(info.PodGroupType)
 		t.PodNSID = uint16(info.PodNSID)
 		t.PodNodeID = info.PodNodeID
 		t.SubnetID = uint16(info.SubnetID)
@@ -368,8 +369,8 @@ func (d *Decoder) fillExtMetricsBase(m *dbwriter.ExtMetrics, vtapID uint16, podN
 			t.ServiceID = d.platformData.QueryService(t.PodID, t.PodNodeID, uint32(t.PodClusterID), t.PodGroupID, t.L3EpcID, t.IsIPv6 == 1, t.IP, t.IP6, 0, 0)
 		}
 		t.ResourceGl0ID, t.ResourceGl0Type = common.GetResourceGl0(t.PodID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
-		t.ResourceGl1ID, t.ResourceGl1Type = common.GetResourceGl1(t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
-		t.ResourceGl2ID, t.ResourceGl2Type = common.GetResourceGl2(t.ServiceID, t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
+		t.ResourceGl1ID, t.ResourceGl1Type = common.GetResourceGl1(t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), podGroupType, t.L3EpcID)
+		t.ResourceGl2ID, t.ResourceGl2Type = common.GetResourceGl2(t.ServiceID, t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), podGroupType, t.L3EpcID)
 	}
 }
 

--- a/server/ingester/roze/unmarshaller/handle_document.go
+++ b/server/ingester/roze/unmarshaller/handle_document.go
@@ -90,6 +90,7 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 		} else {
 			info, info1 = platformData.QueryIPV4InfosPair(t.L3EpcID, t.IP, t.L3EpcID1, t.IP1)
 		}
+		podGroupType := uint8(0)
 		if info1 != nil {
 			t.RegionID1 = uint16(info1.RegionID)
 			t.HostID1 = uint16(info1.HostID)
@@ -100,6 +101,7 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 			t.PodNSID1 = uint16(info1.PodNSID)
 			t.AZID1 = uint16(info1.AZID)
 			t.PodGroupID1 = info1.PodGroupID
+			podGroupType = info1.PodGroupType
 			t.PodID1 = info1.PodID
 			t.PodClusterID1 = uint16(info1.PodClusterID)
 			if common.IsPodServiceIP(t.L3DeviceType1, t.PodID1, t.PodNodeID1) {
@@ -127,8 +129,8 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 			}
 		}
 		t.ResourceGl0ID1, t.ResourceGl0Type1 = common.GetResourceGl0(t.PodID1, t.PodNodeID1, t.L3DeviceID1, uint8(t.L3DeviceType1), t.L3EpcID1)
-		t.ResourceGl1ID1, t.ResourceGl1Type1 = common.GetResourceGl1(t.PodGroupID1, t.PodNodeID1, t.L3DeviceID1, uint8(t.L3DeviceType1), t.L3EpcID1)
-		t.ResourceGl2ID1, t.ResourceGl2Type1 = common.GetResourceGl2(t.ServiceID1, t.PodGroupID1, t.PodNodeID1, t.L3DeviceID1, uint8(t.L3DeviceType1), t.L3EpcID1)
+		t.ResourceGl1ID1, t.ResourceGl1Type1 = common.GetResourceGl1(t.PodGroupID1, t.PodNodeID1, t.L3DeviceID1, uint8(t.L3DeviceType1), podGroupType, t.L3EpcID1)
+		t.ResourceGl2ID1, t.ResourceGl2Type1 = common.GetResourceGl2(t.ServiceID1, t.PodGroupID1, t.PodNodeID1, t.L3DeviceID1, uint8(t.L3DeviceType1), podGroupType, t.L3EpcID1)
 	} else {
 		t.Code |= MainAddCode
 		if t.L3EpcID == datatype.EPC_FROM_INTERNET {
@@ -147,6 +149,7 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 		}
 	}
 
+	podGroupType := uint8(0)
 	if info != nil {
 		t.RegionID = uint16(info.RegionID)
 		t.HostID = uint16(info.HostID)
@@ -157,6 +160,7 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 		t.PodNSID = uint16(info.PodNSID)
 		t.AZID = uint16(info.AZID)
 		t.PodGroupID = info.PodGroupID
+		podGroupType = info.PodGroupType
 		t.PodID = info.PodID
 		t.PodClusterID = uint16(info.PodClusterID)
 		if common.IsPodServiceIP(t.L3DeviceType, t.PodID, t.PodNodeID) {
@@ -197,8 +201,8 @@ func DocumentExpand(doc *app.Document, platformData *grpc.PlatformInfoTable) err
 			}
 		}
 		t.ResourceGl0ID, t.ResourceGl0Type = common.GetResourceGl0(t.PodID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
-		t.ResourceGl1ID, t.ResourceGl1Type = common.GetResourceGl1(t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
-		t.ResourceGl2ID, t.ResourceGl2Type = common.GetResourceGl2(t.ServiceID, t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), t.L3EpcID)
+		t.ResourceGl1ID, t.ResourceGl1Type = common.GetResourceGl1(t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), podGroupType, t.L3EpcID)
+		t.ResourceGl2ID, t.ResourceGl2Type = common.GetResourceGl2(t.ServiceID, t.PodGroupID, t.PodNodeID, t.L3DeviceID, uint8(t.L3DeviceType), podGroupType, t.L3EpcID)
 	}
 
 	return nil

--- a/server/ingester/stream/jsonify/data.go
+++ b/server/ingester/stream/jsonify/data.go
@@ -336,6 +336,8 @@ type KnowledgeGraph struct {
 	PodNSID1      uint16 `json:"pod_ns_id_1"`
 	PodGroupID0   uint32 `json:"pod_group_id_0"`
 	PodGroupID1   uint32 `json:"pod_group_id_1"`
+	PodGroupType0 uint8  `json:"pod_group_type_0"` // no need to store
+	PodGroupType1 uint8  `json:"pod_group_type_1"` // no need to store
 	PodID0        uint32 `json:"pod_id_0"`
 	PodID1        uint32 `json:"pod_id_1"`
 	PodClusterID0 uint16 `json:"pod_cluster_id_0"`
@@ -1050,6 +1052,7 @@ func (k *KnowledgeGraph) fill(
 		k.PodNodeID0 = info0.PodNodeID
 		k.PodNSID0 = uint16(info0.PodNSID)
 		k.PodGroupID0 = info0.PodGroupID
+		k.PodGroupType0 = info0.PodGroupType
 		k.PodID0 = info0.PodID
 		k.PodClusterID0 = uint16(info0.PodClusterID)
 		k.SubnetID0 = uint16(info0.SubnetID)
@@ -1063,6 +1066,7 @@ func (k *KnowledgeGraph) fill(
 		k.PodNodeID1 = info1.PodNodeID
 		k.PodNSID1 = uint16(info1.PodNSID)
 		k.PodGroupID1 = info1.PodGroupID
+		k.PodGroupType1 = info1.PodGroupType
 		k.PodID1 = info1.PodID
 		k.PodClusterID1 = uint16(info1.PodClusterID)
 		k.SubnetID1 = uint16(info1.SubnetID)
@@ -1084,12 +1088,12 @@ func (k *KnowledgeGraph) fill(
 	}
 
 	k.ResourceGl0ID0, k.ResourceGl0Type0 = common.GetResourceGl0(k.PodID0, k.PodNodeID0, k.L3DeviceID0, k.L3DeviceType0, k.L3EpcID0)
-	k.ResourceGl1ID0, k.ResourceGl1Type0 = common.GetResourceGl1(k.PodGroupID0, k.PodNodeID0, k.L3DeviceID0, k.L3DeviceType0, k.L3EpcID0)
-	k.ResourceGl2ID0, k.ResourceGl2Type0 = common.GetResourceGl2(k.ServiceID0, k.PodGroupID0, k.PodNodeID0, k.L3DeviceID0, k.L3DeviceType0, k.L3EpcID0)
+	k.ResourceGl1ID0, k.ResourceGl1Type0 = common.GetResourceGl1(k.PodGroupID0, k.PodNodeID0, k.L3DeviceID0, k.L3DeviceType0, k.PodGroupType0, k.L3EpcID0)
+	k.ResourceGl2ID0, k.ResourceGl2Type0 = common.GetResourceGl2(k.ServiceID0, k.PodGroupID0, k.PodNodeID0, k.L3DeviceID0, k.L3DeviceType0, k.PodGroupType0, k.L3EpcID0)
 
 	k.ResourceGl0ID1, k.ResourceGl0Type1 = common.GetResourceGl0(k.PodID1, k.PodNodeID1, k.L3DeviceID1, k.L3DeviceType1, k.L3EpcID1)
-	k.ResourceGl1ID1, k.ResourceGl1Type1 = common.GetResourceGl1(k.PodGroupID1, k.PodNodeID1, k.L3DeviceID1, k.L3DeviceType1, k.L3EpcID1)
-	k.ResourceGl2ID1, k.ResourceGl2Type1 = common.GetResourceGl2(k.ServiceID1, k.PodGroupID1, k.PodNodeID1, k.L3DeviceID1, k.L3DeviceType1, k.L3EpcID1)
+	k.ResourceGl1ID1, k.ResourceGl1Type1 = common.GetResourceGl1(k.PodGroupID1, k.PodNodeID1, k.L3DeviceID1, k.L3DeviceType1, k.PodGroupType1, k.L3EpcID1)
+	k.ResourceGl2ID1, k.ResourceGl2Type1 = common.GetResourceGl2(k.ServiceID1, k.PodGroupID1, k.PodNodeID1, k.L3DeviceID1, k.L3DeviceType1, k.PodGroupType1, k.L3EpcID1)
 }
 
 func (k *KnowledgeGraph) FillL4(f *pb.Flow, isIPv6 bool, platformData *grpc.PlatformInfoTable) {

--- a/server/libs/eventapi/resource_event.go
+++ b/server/libs/eventapi/resource_event.go
@@ -51,6 +51,7 @@ type ResourceEvent struct {
 	PodNodeID    uint32
 	PodServiceID uint32
 	PodGroupID   uint32
+	PodGroupType uint8
 	PodID        uint32
 }
 

--- a/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl1_type.ch
+++ b/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl1_type.ch
@@ -11,4 +11,10 @@
 15      , 负载均衡器
 16      , NAT 网关
 101     , 工作负载
+130     , Deployment
+131     , StatefulSet
+132     , ReplicationController
+133     , DaemonSet
+134     , ReplicaSetController
+135     , CloneSet
 255     , IP

--- a/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl1_type.en
+++ b/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl1_type.en
@@ -11,4 +11,10 @@
 15      , Load Balancer
 16      , NAT Gateway
 101     , K8s Workload
+130     , Deployment
+131     , StatefulSet
+132     , ReplicationController
+133     , DaemonSet
+134     , ReplicaSetController
+135     , CloneSet
 255     , IP

--- a/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl2_type.ch
+++ b/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl2_type.ch
@@ -12,4 +12,10 @@
 16      , NAT 网关
 101     , 工作负载
 102     , 服务
+130     , Deployment
+131     , StatefulSet
+132     , ReplicationController
+133     , DaemonSet
+134     , ReplicaSetController
+135     , CloneSet
 255     , IP

--- a/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl2_type.en
+++ b/server/querier/db_descriptions/clickhouse/tag/enum/resource_gl2_type.en
@@ -12,4 +12,10 @@
 16      , NAT Gateway
 101     , K8s Workload
 102     , Service
+130     , Deployment
+131     , StatefulSet
+132     , ReplicationController
+133     , DaemonSet
+134     , ReplicaSetController
+135     , CloneSet
 255     , IP


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


