### PR TITLE
[eBPF] Fixed x86 musl compile & Modify the libcc library JAVA path order

### DIFF
--- a/agent/docker/dockerfile-build
+++ b/agent/docker/dockerfile-build
@@ -1,4 +1,4 @@
-FROM ghcr.io/deepflowio/rust-build:1.25 as builder
+FROM ghcr.io/deepflowio/rust-build:1.26 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/docker/dockerfile-build-aarch64
+++ b/agent/docker/dockerfile-build-aarch64
@@ -1,5 +1,5 @@
 # TODO : aarch64 env rust-build update
-FROM ghcr.io/deepflowio/rust-build:1.25-arm64 as builder
+FROM ghcr.io/deepflowio/rust-build:1.26-arm64 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/docker/dockerfile-build-static-link
+++ b/agent/docker/dockerfile-build-static-link
@@ -1,4 +1,4 @@
-FROM ghcr.io/deepflowio/rust-build:1.25 as builder
+FROM ghcr.io/deepflowio/rust-build:1.26 as builder
 COPY .  /deepflow/
 WORKDIR /deepflow/agent
 ARG GITHUB_REF_NAME

--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -178,7 +178,7 @@ tools: $(LIBTRACE)
 
 $(JAVA_TOOL): $(JAVA_AGENT_SO)
 	$(call msg,TOOLS,$@)
-	$(Q)$(CC) $(CFLAGS) -DJAVA_AGENT_ATTACH_TOOL user/profile/java/df_jattach.c user/log.c user/common.c -ljattach -o $@ -ldl -lpthread
+	@$(GNU_CC) $(CFLAGS) -DJAVA_AGENT_ATTACH_TOOL user/profile/java/df_jattach.c user/log.c user/common.c -ljattach -o $@ -ldl
 	@rm -rf user/profile/deepflow_jattach_bin.c
 	@./tools/bintobuffer ./$@ user/profile/deepflow_jattach_bin.c deepflow_jattach_bin
 

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdbool.h>
@@ -1042,7 +1041,7 @@ int fetch_container_id(pid_t pid, char *id, int copy_bytes)
 	return fetch_container_id_from_str(buff, id, copy_bytes);
 }
 
-#ifndef AARCH64_MUSL
+#if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg)
 {
 	int ret;
@@ -1072,4 +1071,4 @@ int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg)
 
 	return ETR_OK;
 }
-#endif
+#endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -22,6 +22,7 @@
 #include <time.h>
 #include <string.h>
 #include <stdlib.h>
+#include <pthread.h>
 #include "types.h"
 #include "clib.h"
 #include "log.h"
@@ -278,7 +279,7 @@ int exec_command(const char *cmd, const char *args);
 u64 current_sys_time_secs(void);
 int fetch_container_id_from_str(char *buff, char *id, int copy_bytes);
 int fetch_container_id(pid_t pid, char *id, int copy_bytes);
-#ifndef AARCH64_MUSL
+#if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
-#endif /* AARCH64_MUSL */
+#endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */
 #endif /* DF_COMMON_H */


### PR DESCRIPTION
 Fixed x86 musl compile 
[Modify the libcc library JAVA path order](https://github.com/deepflowio/deepflow/pull/4597/commits/57155ee71d5dc1fb83a1483dad1bf9853ec692f5)

### This PR is for:

- Agent


#### Affected branches
- main
- v6.3