### PR TITLE
[eBPF] To correct an error in online CPU parsing

### DIFF
--- a/agent/src/ebpf/test/Makefile
+++ b/agent/src/ebpf/test/Makefile
@@ -24,7 +24,7 @@ ARCH ?= $(shell uname -m)
 CC ?= gcc
 CFLAGS ?= -std=gnu99 --static -g -O2 -ffunction-sections -fdata-sections -fPIC -fno-omit-frame-pointer -Wall -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
 
-EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec test_fetch_container_id
+EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec test_fetch_container_id test_parse_range
 ifeq ($(ARCH), x86_64)
 #-lbcc -lstdc++
         LDLIBS += ../libtrace.a -ljattach -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl

--- a/agent/src/ebpf/test/test_parse_range.c
+++ b/agent/src/ebpf/test/test_parse_range.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../user/common.h"
+#include "../user/mem.h"
+#include "../user/log.h"
+#include "../user/types.h"
+
+int main(void)
+{
+	printf("Test func parse_num_range() : ");
+	log_to_stdout = true;
+	bool *online = NULL;
+	int err, n = 0;
+	const char *online_cpus_str = "3, 5, 8-10, 12,15-32";
+	err =
+	    parse_num_range(online_cpus_str, strlen(online_cpus_str), &online,
+			    &n);
+	if (err) {
+		ebpf_warning("failed to get online CPU mask: %d\n", err);
+		return -1;
+	}
+
+	if (n != 33) {
+		goto failed;
+	}
+
+	int i;
+	for (i = 0; i < n; i++) {
+		if (!online[i]) {
+			if (i != 0 && i != 1 && i != 2 && i != 4 && i != 6
+			    && i != 7 && i != 11 && i != 13 && i != 14) {
+				goto failed;
+			}
+		}
+	}
+
+	free(online);
+	printf("[OK]\n");
+	return 0;
+
+failed:
+	free(online);
+	printf("[Failed]\n");
+	return -1;
+}

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -279,6 +279,8 @@ int exec_command(const char *cmd, const char *args);
 u64 current_sys_time_secs(void);
 int fetch_container_id_from_str(char *buff, char *id, int copy_bytes);
 int fetch_container_id(pid_t pid, char *id, int copy_bytes);
+int parse_num_range(const char *config_str, int bytes_count,
+		    bool **mask, int *count);
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */


### PR DESCRIPTION
The content of the file "/sys/devices/system/cpu/online" is generally in the format "0-CPUMAX," for example, "0-23." However, if it appears as "0-2,4-23"(use command "echo 0 > /sys/devices/system/cpu/cpu3/online" turned off CPU3), this situation would result in an error (only parsing "0-2").

This patch is intended to fix this issue.


### This PR is for:

- Agent


#### Affected branches
- main
- v6.3
- v6.2
#### Checklist
- [x] Added unit test to verify the fix.
