### PR TITLE
[Agent] Only same wan cidr will be alarmed

### DIFF
--- a/agent/src/policy/labeler.rs
+++ b/agent/src/policy/labeler.rs
@@ -270,10 +270,14 @@ impl Labeler {
             let key = EpcNetIpKey::new(&item.ip.network(), item.ip.prefix_len(), epc_id);
 
             if let Some(old) = epc_table.insert(key, item.clone()) {
-                warn!(
-                    "Found the same cidr, please check {:?} and {:?}.",
-                    item, old
-                );
+                if (item.cidr_type == CidrType::Wan && item.epc_id != old.epc_id)
+                    || item.is_vip != old.is_vip
+                {
+                    warn!(
+                        "Found the same cidr, please check {:?} and {:?}.",
+                        item, old
+                    );
+                }
             }
             masklen_table
                 .entry(epc_id)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

### Only same wan cidr will be alarmed
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main
- 6.3

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


