### PR TITLE
[Agent] obfuscate sql and redis

### DIFF
--- a/agent/crates/public/src/utils/hash.rs
+++ b/agent/crates/public/src/utils/hash.rs
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-pub mod bitmap;
-pub mod hash;
-pub mod net;
-pub mod string;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
-#[cfg(windows)]
-const WIN_ERROR_CODE_STR: &str = "please browse website(https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes) to get more detail";
+pub fn hash_to_u64<T: Hash>(data: &T) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    data.hash(&mut hasher);
+    hasher.finish()
+}

--- a/agent/crates/public/src/utils/string.rs
+++ b/agent/crates/public/src/utils/string.rs
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 pub fn get_string_from_chars(chars: &[u8]) -> String {
     let mut end_index = chars.len();
     for (i, char) in chars.iter().enumerate() {
@@ -32,16 +29,5 @@ pub fn get_string_from_chars(chars: &[u8]) -> String {
     unsafe {
         // safe because it has been checked that every character is ascii
         String::from_utf8_unchecked(result)
-    }
-}
-
-pub fn hash_endpoint(endpoint: &Option<String>) -> u64 {
-    match endpoint {
-        Some(s) => {
-            let mut hasher = DefaultHasher::new();
-            s.hash(&mut hasher);
-            hasher.finish()
-        }
-        None => 0,
     }
 }

--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -45,7 +45,7 @@ use crate::utils::{
 use public::{
     buffer::BatchedBox,
     queue::{DebugSender, Error, Receiver},
-    utils::string::hash_endpoint,
+    utils::hash::hash_to_u64,
 };
 
 const FLOW_ID_LEN: usize = 8;
@@ -559,7 +559,10 @@ impl L7QuadrupleGenerator {
         }
         let l7_stats = l7_stats.unwrap();
 
-        let endpoint_hash = hash_endpoint(&l7_stats.endpoint) as u32;
+        let endpoint_hash = match &l7_stats.endpoint {
+            Some(e) => hash_to_u64(e) as u32,
+            None => 0,
+        };
 
         let app_meter = if config.l7_metrics_enabled {
             Self::generate_app_meter(&l7_stats)

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -443,6 +443,7 @@ pub struct HttpEndpointExtraction {
 #[serde(default, rename_all = "kebab-case")]
 pub struct L7ProtocolAdvancedFeatures {
     pub http_endpoint_extraction: HttpEndpointExtraction,
+    pub obfuscate_enabled_protocols: Vec<String>,
 }
 
 #[derive(Clone, Copy, Default, Debug, Deserialize, PartialEq, Eq)]

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -382,6 +382,8 @@ pub struct FlowConfig {
     pub batched_buffer_size_limit: usize,
 
     pub oracle_parse_conf: OracleParseConfig,
+
+    pub obfuscate_enabled_protocols: L7ProtocolBitmap,
 }
 
 impl From<&RuntimeConfig> for FlowConfig {
@@ -439,6 +441,12 @@ impl From<&RuntimeConfig> for FlowConfig {
             rrt_udp_timeout: conf.yaml_config.rrt_udp_timeout.as_micros() as usize,
             batched_buffer_size_limit: conf.yaml_config.batched_buffer_size_limit,
             oracle_parse_conf: conf.yaml_config.oracle_parse_config,
+            obfuscate_enabled_protocols: L7ProtocolBitmap::from(
+                &conf
+                    .yaml_config
+                    .l7_protocol_advanced_features
+                    .obfuscate_enabled_protocols,
+            ),
         }
     }
 }
@@ -576,6 +584,7 @@ pub struct LogParserConfig {
     pub l7_log_ignore_tap_sides: [bool; TapSide::MAX as usize + 1],
     pub http_endpoint_disabled: bool,
     pub http_endpoint_trie: HttpEndpointTrie,
+    pub obfuscate_enabled_protocols: L7ProtocolBitmap,
 }
 
 impl Default for LogParserConfig {
@@ -587,6 +596,7 @@ impl Default for LogParserConfig {
             l7_log_ignore_tap_sides: [false; TapSide::MAX as usize + 1],
             http_endpoint_disabled: false,
             http_endpoint_trie: HttpEndpointTrie::new(),
+            obfuscate_enabled_protocols: L7ProtocolBitmap::default(),
         }
     }
 }
@@ -1201,6 +1211,12 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
                         .yaml_config
                         .l7_protocol_advanced_features
                         .http_endpoint_extraction,
+                ),
+                obfuscate_enabled_protocols: L7ProtocolBitmap::from(
+                    &conf
+                        .yaml_config
+                        .l7_protocol_advanced_features
+                        .obfuscate_enabled_protocols,
                 ),
             },
             debug: DebugConfig {

--- a/agent/src/flow_generator/protocol_logs/plugin/mod.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         flow::L7PerfStats,
         l7_protocol_log::{L7ParseResult, L7ProtocolParser, L7ProtocolParserInterface, ParseParam},
     },
-    flow_generator::Result,
+    flow_generator::{protocol_logs::sql::ObfuscateCache, Result},
 };
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/agent/src/flow_generator/protocol_logs/sql/mod.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mod.rs
@@ -14,16 +14,41 @@
  * limitations under the License.
  */
 
+use std::{
+    cell::RefCell,
+    iter::{Enumerate, Peekable},
+    rc::Rc,
+    slice::Iter,
+};
+
+use lru::LruCache;
+
 mod mongo;
 mod mysql;
 mod oracle;
 mod postgre_convert;
 mod postgresql;
 mod redis;
+mod redis_obfuscate;
 mod sql_check;
+mod sql_obfuscate;
 
 pub use mongo::{MongoDBInfo, MongoDBLog};
 pub use mysql::{MysqlHeader, MysqlInfo, MysqlLog};
 pub use oracle::{OracleInfo, OracleLog};
 pub use postgresql::{PostgreInfo, PostgresqlLog};
 pub use redis::{decode, RedisInfo, RedisLog};
+
+pub type ObfuscateCache = Rc<RefCell<LruCache<u64, Vec<u8>>>>;
+
+pub const OBFUSCATE_CACHE_SIZE: usize = 8192;
+pub const QUESTION_MARK: u8 = b'?';
+pub const BLANK_SPACE: u8 = b' ';
+
+pub fn forward(iteration: &mut Peekable<Enumerate<Iter<'_, u8>>>, n: usize) {
+    for _ in 0..n {
+        if iteration.next().is_none() {
+            return;
+        }
+    }
+}

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -20,6 +20,8 @@ use serde::Serialize;
 
 use super::super::{consts::*, value_is_default, AppProtoHead, L7ResponseStatus, LogMessageType};
 use super::sql_check::{is_mysql, is_valid_sql, trim_head_comment_and_get_first_word};
+use super::sql_obfuscate::attempt_obfuscation;
+use super::ObfuscateCache;
 
 use crate::common::flow::L7PerfStats;
 use crate::common::l7_protocol_log::L7ParseResult;
@@ -176,8 +178,18 @@ impl MysqlInfo {
         }
     }
 
-    fn request_string(&mut self, payload: &[u8], trace_id: Option<&str>) {
-        self.context = mysql_string(payload);
+    fn request_string(
+        &mut self,
+        payload: &[u8],
+        obfuscate_cache: &Option<ObfuscateCache>,
+        trace_id: Option<&str>,
+    ) {
+        let payload = mysql_string(payload);
+        self.context = attempt_obfuscation(obfuscate_cache, payload)
+            .map_or(String::from_utf8_lossy(payload).to_string(), |m| {
+                String::from_utf8_lossy(&m).to_string()
+            });
+
         if let Some(t) = trace_id {
             self.trace_id = extra_sql_trace_id(self.context.as_str(), t);
         }
@@ -205,7 +217,7 @@ impl From<MysqlInfo> for L7ProtocolSendLog {
             },
 
             row_effect: if f.command == COM_QUERY {
-                trim_head_comment_and_get_first_word(&f.context, 8)
+                trim_head_comment_and_get_first_word(f.context.as_bytes(), 8)
                     .map(|first| {
                         if is_valid_sql(first, &["INSERT", "UPDATE", "DELETE"]) {
                             f.affected_rows as u32
@@ -251,6 +263,7 @@ impl From<MysqlInfo> for L7ProtocolSendLog {
 pub struct MysqlLog {
     pub protocol_version: u8,
     perf_stats: Option<L7PerfStats>,
+    obfuscate_cache: Option<ObfuscateCache>,
 }
 
 impl L7ProtocolParserInterface for MysqlLog {
@@ -308,15 +321,19 @@ impl L7ProtocolParserInterface for MysqlLog {
     fn perf_stats(&mut self) -> Option<L7PerfStats> {
         self.perf_stats.take()
     }
+
+    fn set_obfuscate_cache(&mut self, obfuscate_cache: Option<ObfuscateCache>) {
+        self.obfuscate_cache = obfuscate_cache;
+    }
 }
 
-fn mysql_string(payload: &[u8]) -> String {
+fn mysql_string(payload: &[u8]) -> &[u8] {
     if payload.len() > 2 && payload[0] == 0 && payload[1] == 1 {
         // MYSQL 8.0.26返回字符串前有0x0、0x1，MYSQL 8.0.21版本没有这个问题
         // https://gitlab.yunshan.net/platform/trident/-/merge_requests/2592#note_401425
-        String::from_utf8_lossy(&payload[2..]).into_owned()
+        &payload[2..]
     } else {
-        String::from_utf8_lossy(payload).into_owned()
+        payload
     }
 }
 
@@ -355,7 +372,11 @@ impl MysqlLog {
         match info.command {
             COM_QUIT | COM_FIELD_LIST | COM_STMT_CLOSE | COM_STMT_FETCH => (),
             COM_INIT_DB | COM_QUERY | COM_STMT_PREPARE => {
-                info.request_string(&payload[COMMAND_OFFSET + COMMAND_LEN..], trace_id);
+                info.request_string(
+                    &payload[COMMAND_OFFSET + COMMAND_LEN..],
+                    &self.obfuscate_cache,
+                    trace_id,
+                );
             }
             COM_STMT_EXECUTE => {
                 info.statement_id(&payload[STATEMENT_ID_OFFSET..]);
@@ -459,7 +480,7 @@ impl MysqlLog {
         match protocol_version_or_query_type {
             COM_QUERY | COM_STMT_PREPARE => {
                 let context = mysql_string(&payload[offset + 1..]);
-                return context.is_ascii() && is_mysql(&context);
+                return context.is_ascii() && is_mysql(context);
             }
             _ => {}
         }

--- a/agent/src/flow_generator/protocol_logs/sql/redis_obfuscate.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis_obfuscate.rs
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use public::utils::hash::hash_to_u64;
+
+use super::{forward, ObfuscateCache, BLANK_SPACE, QUESTION_MARK};
+
+const AUTH: &[u8] = "AUTH".as_bytes();
+const APPEND: &[u8] = "APPEND".as_bytes();
+const GETSET: &[u8] = "GETSET".as_bytes();
+const LPUSHX: &[u8] = "LPUSHX".as_bytes();
+const GEORADIUSBYMEMBER: &[u8] = "GEORADIUSBYMEMBER".as_bytes();
+const RPUSHX: &[u8] = "RPUSHX".as_bytes();
+const SETNX: &[u8] = "SETNX".as_bytes();
+const SISMEMBER: &[u8] = "SISMEMBER".as_bytes();
+const ZRANK: &[u8] = "ZRANK".as_bytes();
+const ZREVRANK: &[u8] = "ZREVRANK".as_bytes();
+const ZSCORE: &[u8] = "ZSCORE".as_bytes();
+const SET: &[u8] = "SET".as_bytes();
+const GET: &[u8] = "GET".as_bytes();
+const HSET: &[u8] = "HSET".as_bytes();
+const HSETNX: &[u8] = "HSETNX".as_bytes();
+const LREM: &[u8] = "LREM".as_bytes();
+const LSET: &[u8] = "LSET".as_bytes();
+const SETBIT: &[u8] = "SETBIT".as_bytes();
+const SETEX: &[u8] = "SETEX".as_bytes();
+const PSETEX: &[u8] = "PSETEX".as_bytes();
+const SETRANGE: &[u8] = "SETRANGE".as_bytes();
+const ZINCRBY: &[u8] = "ZINCRBY".as_bytes();
+const SMOVE: &[u8] = "SMOVE".as_bytes();
+const RESTORE: &[u8] = "RESTORE".as_bytes();
+const LINSERT: &[u8] = "LINSERT".as_bytes();
+const GEOHASH: &[u8] = "GEOHASH".as_bytes();
+const GEOPOS: &[u8] = "GEOPOS".as_bytes();
+const GEODIST: &[u8] = "GEODIST".as_bytes();
+const LPUSH: &[u8] = "LPUSH".as_bytes();
+const RPUSH: &[u8] = "RPUSH".as_bytes();
+const SREM: &[u8] = "SREM".as_bytes();
+const ZREM: &[u8] = "ZREM".as_bytes();
+const SADD: &[u8] = "SADD".as_bytes();
+const GEOADD: &[u8] = "GEOADD".as_bytes();
+const HMSET: &[u8] = "HMSET".as_bytes();
+const MSET: &[u8] = "MSET".as_bytes();
+const MSETNX: &[u8] = "MSETNX".as_bytes();
+const CONFIG: &[u8] = "CONFIG".as_bytes();
+const BITFIELD: &[u8] = "BITFIELD".as_bytes();
+const ZADD: &[u8] = "ZADD".as_bytes();
+const NX: &[u8] = "NX".as_bytes();
+const XX: &[u8] = "XX".as_bytes();
+const CH: &[u8] = "CH".as_bytes();
+const INCR: &[u8] = "INCR".as_bytes();
+
+const MAX_COMMAND_LENGTH: usize = 17;
+
+pub fn attempt_obfuscation<'a>(
+    obfuscate_cache: &Option<ObfuscateCache>,
+    input: &[u8],
+    remove_all_args: bool,
+) -> Option<Vec<u8>> {
+    let Some(cache) = obfuscate_cache else {
+        return None;
+    };
+    let key = hash_to_u64(&input);
+    if let Some(s) = cache.borrow_mut().get(&key) {
+        return Some(s.clone());
+    }
+
+    let mut tokenizer = RedisTokenizer::new(input, remove_all_args);
+    let mut output = Vec::with_capacity(input.len());
+    tokenizer.obfuscate(&mut output);
+    let _ = cache.borrow_mut().put(key, output.clone());
+    Some(output)
+}
+
+struct RedisTokenizer<'a> {
+    data: &'a [u8],
+    last_is_cmd: bool,
+    // merge multiple question marks into one, for example, convert 'GEOPOS key member1 member2' to 'GEOPOS key ?'
+    need_masked: bool,
+    arg_index: usize,
+    // start with the number of arguments after the command mask, for example,
+    // 'SET key value', the mask_start_index is 2
+    mask_start_index: usize,
+    // every number of parameters mask,  for example, 'GEOADD key longitude latitude member longitude
+    // latitude member longitude latitude member', every other member needs to be masked, the step is 3
+    mask_step: usize,
+    last_is_config: bool,
+    last_is_bitfield: bool,
+    last_is_zadd: bool,
+    already_masked: bool,
+    remove_all_args: bool,
+}
+
+impl RedisTokenizer<'_> {
+    fn new(data: &[u8], remove_all_args: bool) -> RedisTokenizer {
+        RedisTokenizer {
+            data,
+            last_is_cmd: false,
+            arg_index: 0,
+            need_masked: false,
+            already_masked: false,
+            mask_start_index: 0,
+            mask_step: 0,
+            last_is_config: false,
+            last_is_bitfield: false,
+            last_is_zadd: false,
+            remove_all_args,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.last_is_cmd = false;
+        self.need_masked = false;
+        self.arg_index = 0;
+        self.mask_start_index = 0;
+        self.mask_step = 0;
+        self.last_is_config = false;
+        self.last_is_bitfield = false;
+        self.last_is_zadd = false;
+        self.already_masked = false;
+    }
+
+    fn obfuscate(&mut self, out: &mut Vec<u8>) {
+        let mut start = 0;
+        let mut iteration = self.data.iter().enumerate().peekable();
+        let mut quoted = false;
+        let mut escaped = false;
+        let length = self.data.len();
+
+        while let Some(&(i, ch)) = iteration.peek() {
+            match ch {
+                b' ' => {
+                    if !quoted {
+                        if self.already_masked && self.need_masked {
+                            forward(&mut iteration, 1);
+                            continue;
+                        }
+                        self.mask_sensitive_data(out, &self.data[start..i]);
+                        if !self.last_is_cmd {
+                            self.last_is_cmd = true;
+                        }
+                        // skip space
+                        while let Some(_) =
+                            iteration.next_if(|&(_, c)| *c == b' ' || *c == b'\t' || *c == b'\r')
+                        {
+                        }
+                        start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                    } else {
+                        forward(&mut iteration, 1);
+                    }
+                    continue;
+                }
+                b'\n' => {
+                    self.mask_sensitive_data(out, &self.data[start..i]);
+                    forward(&mut iteration, 1);
+                    start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                    if iteration.len() > 0 {
+                        out.push('\n' as u8);
+                    }
+                    self.reset();
+                    continue;
+                }
+                b'\\' => {
+                    if !escaped {
+                        escaped = true;
+                        forward(&mut iteration, 1);
+                        continue;
+                    }
+                }
+                b'"' => {
+                    if !escaped {
+                        quoted = !quoted;
+                    }
+                }
+                _ => {
+                    if self.already_masked && self.need_masked {
+                        forward(&mut iteration, 1);
+                        continue;
+                    }
+                }
+            }
+            forward(&mut iteration, 1);
+        }
+
+        self.mask_sensitive_data(out, &self.data[start..]);
+    }
+
+    fn mask_sensitive_data(&mut self, out: &mut Vec<u8>, data: &[u8]) {
+        if data.is_empty() {
+            return;
+        }
+
+        let mut is_command = true;
+
+        let command = std::str::from_utf8(data);
+        if data.len() <= MAX_COMMAND_LENGTH && command.is_ok() {
+            match command.unwrap().to_ascii_uppercase().as_bytes() {
+                AUTH => {
+                    self.mask_start_index = 1;
+                    self.need_masked = true;
+                }
+                APPEND | GETSET | LPUSHX | GEORADIUSBYMEMBER | RPUSHX | SETNX | SISMEMBER
+                | ZRANK | ZREVRANK | ZSCORE => {
+                    self.mask_start_index = 2;
+                }
+                SET => {
+                    if self.last_is_config {
+                        self.mask_start_index = 2;
+                    } else if self.last_is_bitfield {
+                        self.mask_start_index = 3;
+                    } else {
+                        self.mask_start_index = 2;
+                    }
+                }
+                HSET | HSETNX | LREM | LSET | SETBIT | SETEX | PSETEX | SETRANGE | ZINCRBY
+                | SMOVE | RESTORE => {
+                    self.mask_start_index = 3;
+                }
+                LINSERT => {
+                    self.mask_start_index = 4;
+                }
+                GEOHASH | GEOPOS | GEODIST | LPUSH | RPUSH | SREM | ZREM | SADD => {
+                    self.need_masked = true;
+                    self.mask_start_index = 2;
+                }
+                GEOADD => {
+                    self.mask_start_index = 4;
+                    self.mask_step = 3;
+                }
+                HMSET => {
+                    self.mask_start_index = 3;
+                    self.mask_step = 2;
+                }
+                MSET | MSETNX => {
+                    self.mask_start_index = 2;
+                    self.mask_step = 2;
+                }
+                CONFIG => {
+                    self.last_is_config = true;
+                }
+                BITFIELD => {
+                    self.last_is_bitfield = true;
+                }
+                ZADD => {
+                    self.last_is_zadd = true;
+                    self.mask_start_index = 3;
+                    self.mask_step = 2;
+                }
+                NX | XX | CH | INCR => {
+                    if self.last_is_zadd {
+                        self.mask_start_index = 2;
+                        self.mask_step = 2;
+                    }
+                }
+                GET => {}
+                _ => {
+                    is_command = false;
+                    self.arg_index += 1;
+                }
+            }
+        } else {
+            is_command = false;
+            self.arg_index += 1;
+        }
+
+        if is_command {
+            if self.remove_all_args {
+                self.mask_start_index = 1;
+                self.need_masked = true;
+            }
+            self.arg_index = 0;
+            if self.last_is_cmd {
+                out.push(BLANK_SPACE as u8);
+            }
+            out.extend_from_slice(data);
+        } else if self.mask_step > 0
+            && self.arg_index >= self.mask_start_index
+            && (self.arg_index - self.mask_start_index) % self.mask_step == 0
+            || self.arg_index == self.mask_start_index
+        {
+            self.already_masked = true;
+            out.push(BLANK_SPACE as u8);
+            out.push(QUESTION_MARK as u8);
+        } else {
+            if !self.already_masked && self.need_masked || !self.need_masked {
+                if self.last_is_cmd {
+                    out.push(BLANK_SPACE as u8);
+                }
+                out.extend_from_slice(data);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, num::NonZeroUsize, rc::Rc};
+
+    use lru::LruCache;
+
+    use super::{super::OBFUSCATE_CACHE_SIZE, *};
+
+    #[test]
+    fn test_redis_obfuscate() {
+        let obfuscate_cache = Some(Rc::new(RefCell::new(LruCache::new(
+            NonZeroUsize::new(OBFUSCATE_CACHE_SIZE).unwrap(),
+        ))));
+
+        let test_cases = [
+                ("GET key ", Some("GET key")),
+                ("AUTH", Some("AUTH")),
+                ("AUTH my-secret-password", Some("AUTH ?")),
+                ("AUTH james my-secret-password", Some("AUTH ?")),
+                ("HELLO 3 AUTH username passwd SETNAME cliname", Some("HELLO 3 AUTH ?")),
+                ("APPEND key value", Some("APPEND key ?")),
+                ("GETSET key value", Some("GETSET key ?")),
+                ("LPUSHX key value", Some("LPUSHX key ?")),
+                ("GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]", Some("GEORADIUSBYMEMBER key ? radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]")),
+                ("RPUSHX key value", Some("RPUSHX key ?")),
+                ("SET key value", Some("SET key ?")),
+                ("SET key value [expiration EX seconds|PX milliseconds] [NX|XX]", Some("SET key ? [expiration EX seconds|PX milliseconds] [NX|XX]")),
+                ("SETNX key value", Some("SETNX key ?")),
+                ("SISMEMBER key member", Some("SISMEMBER key ?")),
+                ("ZRANK key member", Some("ZRANK key ?")),
+                ("ZREVRANK key member", Some("ZREVRANK key ?")),
+                ("ZSCORE key member", Some("ZSCORE key ?")),
+                ("BITFIELD key GET type offset SET type offset value INCRBY type", Some("BITFIELD key GET type offset SET type offset ? INCRBY type")),
+                ("BITFIELD key SET type offset value INCRBY type", Some("BITFIELD key SET type offset ? INCRBY type")),
+                ("BITFIELD key GET type offset INCRBY type", Some("BITFIELD key GET type offset INCRBY type")),
+                ("BITFIELD key SET type offset", Some("BITFIELD key SET type offset")),
+                ("CONFIG SET parameter value", Some("CONFIG SET parameter ?")),
+                ("CONFIG foo bar baz", Some("CONFIG foo bar baz")),
+                ("GEOADD key longitude latitude member longitude latitude member longitude latitude member", Some("GEOADD key longitude latitude ? longitude latitude ? longitude latitude ?")),
+                ("GEOADD key longitude latitude member longitude latitude member", Some("GEOADD key longitude latitude ? longitude latitude ?")),
+                ("GEOADD key longitude latitude member", Some("GEOADD key longitude latitude ?")),
+                ("GEOADD key longitude latitude", Some("GEOADD key longitude latitude")),
+                ("GEOADD key", Some("GEOADD key")),
+                (
+                    "GEOHASH key\nGEOPOS key\n   GEODIST key",
+                    Some("GEOHASH key\nGEOPOS key\n GEODIST key"),
+                ),
+                  ("GEOHASH key member\nGEOPOS key member\nGEODIST key member\n", Some("GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?")),
+                  ("GEOHASH key member member member\nGEOPOS key member member \n  GEODIST key member member member", Some("GEOHASH key ?\nGEOPOS key ?\n GEODIST key ?")),
+                ("GEOPOS key member [member ...]", Some("GEOPOS key ?")),
+                ("SREM key member [member ...]", Some("SREM key ?")),
+                ("ZREM key member [member ...]", Some("ZREM key ?")),
+                ("SADD key member [member ...]", Some("SADD key ?")),
+                ("GEODIST key member1 member2 [unit]", Some("GEODIST key ?")),
+                ("LPUSH key value [value ...]", Some("LPUSH key ?")),
+                ("RPUSH key value [value ...]", Some("RPUSH key ?")),
+                (
+                    "HSET key field value \nHSETNX key field value\nBLAH",
+                    Some("HSET key field ?\nHSETNX key field ?\nBLAH"),
+                ),
+                ("HSET key field value", Some("HSET key field ?")),
+                ("HSETNX key field value", Some("HSETNX key field ?")),
+                ("LREM key count value", Some("LREM key count ?")),
+                ("LSET key index value", Some("LSET key index ?")),
+                ("SETBIT key offset value", Some("SETBIT key offset ?")),
+                ("SETRANGE key offset value", Some("SETRANGE key offset ?")),
+                ("SETEX key seconds value", Some("SETEX key seconds ?")),
+                ("PSETEX key milliseconds value", Some("PSETEX key milliseconds ?")),
+                ("ZINCRBY key increment member", Some("ZINCRBY key increment ?")),
+                (
+                    "SMOVE source destination member",
+                    Some("SMOVE source destination ?"),
+                ),
+                (
+                    "RESTORE key ttl serialized-value [REPLACE]",
+                    Some("RESTORE key ttl ? [REPLACE]"),
+                ),
+                (
+                    "LINSERT key BEFORE pivot value",
+                    Some("LINSERT key BEFORE pivot ?"),
+                ),
+                ("LINSERT key AFTER pivot value", Some("LINSERT key AFTER pivot ?")),
+                (
+                    "HMSET key field value field value",
+                    Some("HMSET key field ? field ?"),
+                ),
+                (
+                    "HMSET key field value \n HMSET key field value\n",
+                    Some("HMSET key field ?\n HMSET key field ?"),
+                ),
+                ("HMSET key field", Some("HMSET key field")),
+                ("MSET key value key value", Some("MSET key ? key ?")),
+                ("MSET\nMSET key value", Some("MSET\nMSET key ?")),
+                ("MSET key value", Some("MSET key ?")),
+                ("MSETNX key value key value", Some("MSETNX key ? key ?")),
+                (
+                    "ZADD key score member score member",
+                    Some("ZADD key score ? score ?"),
+                ),
+                (
+                    "ZADD key NX score member score member",
+                    Some("ZADD key NX score ? score ?"),
+                ),
+                (
+                    "ZADD key NX CH score member score member",
+                    Some("ZADD key NX CH score ? score ?"),
+                ),
+                (
+                    "ZADD key NX CH INCR score member score member",
+                    Some("ZADD key NX CH INCR score ? score ?"),
+                ),
+                (
+                    "ZADD key XX INCR score member score member",
+                    Some("ZADD key XX INCR score ? score ?"),
+                ),
+                ("ZADD key XX INCR score member", Some("ZADD key XX INCR score ?")),
+                ("ZADD key XX INCR score", Some("ZADD key XX INCR score")),
+                ("CONFIG command\nSET k v", Some("CONFIG command\nSET k ?")),
+                ("SET *😊®© ❤️", Some("SET *😊®© ?")),
+                ("SET😊 ❤️*😊®© ❤️", Some("SET😊 ❤️*😊®© ❤️")),
+                ("ZADD key 😊 member score 😊", Some("ZADD key 😊 ? score ?")),
+            ];
+        for (ti, tt) in test_cases.iter().enumerate() {
+            assert_eq!(
+                attempt_obfuscation(&obfuscate_cache, tt.0.as_bytes(), false),
+                tt.1.map(|o| o.as_bytes().to_vec()),
+                "{}",
+                format!("Test case {}", ti)
+            );
+        }
+    }
+
+    #[test]
+    fn test_remove_all_redis_args() {
+        let obfuscate_cache = Some(Rc::new(RefCell::new(LruCache::new(
+            NonZeroUsize::new(OBFUSCATE_CACHE_SIZE).unwrap(),
+        ))));
+
+        let test_cases = [
+            ("", Some("")),
+            ("SET key value", Some("SET ?")),
+            ("GET k", Some("GET ?")),
+            ("FAKECMD key value hash", Some("FAKECMD key value hash")),
+            ("AUTH password", Some("AUTH ?")),
+            ("GET", Some("GET")),
+            ("CONFIG SET key value", Some("CONFIG SET ?")),
+            ("CONFIG GET key", Some("CONFIG GET ?")),
+            ("CONFIG key", Some("CONFIG ?")),
+            ("BITFIELD key SET key value GET key", Some("BITFIELD ?")),
+            ("BITFIELD key INCRBY value", Some("BITFIELD ?")),
+            ("BITFIELD secret key", Some("BITFIELD ?")),
+            ("set key value", Some("set ?")),
+            ("Get key", Some("Get ?")),
+            ("config key", Some("config ?")),
+            ("CONFIG get key", Some("CONFIG get ?")),
+            ("bitfield key SET key value incrby 3", Some("bitfield ?")),
+            ("GET key\nSET key value", Some("GET ?\nSET ?")),
+        ];
+
+        for (ti, tt) in test_cases.iter().enumerate() {
+            assert_eq!(
+                attempt_obfuscation(&obfuscate_cache, tt.0.as_bytes(), true),
+                tt.1.map(|o| o.as_bytes().to_vec()),
+                "{}",
+                format!("Test case {}", ti)
+            );
+        }
+    }
+}

--- a/agent/src/flow_generator/protocol_logs/sql/sql_check.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/sql_check.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use super::forward;
+
 const COMMON_SQL_START: [&'static str; 19] = [
     //crud
     "SELECT",
@@ -40,9 +42,9 @@ const COMMON_SQL_START: [&'static str; 19] = [
     "REVOKE",
 ];
 
-pub(super) fn is_valid_sql(first: &str, keywords: &[&'static str]) -> bool {
+pub(super) fn is_valid_sql(first: &[u8], keywords: &[&'static str]) -> bool {
     for i in COMMON_SQL_START.iter().chain(keywords.iter()) {
-        if first.eq_ignore_ascii_case(i) {
+        if first.eq_ignore_ascii_case(i.as_bytes()) {
             return true;
         }
     }
@@ -83,8 +85,8 @@ const POSTGRESQL_START: [&'static str; 16] = [
     "TRUNCATE",
 ];
 
-pub(super) fn is_postgresql(sql: &String) -> bool {
-    if let Some(first) = trim_head_comment_and_get_first_word(sql.as_str(), 12) {
+pub(super) fn is_postgresql(sql: &[u8]) -> bool {
+    if let Some(first) = trim_head_comment_and_get_first_word(sql, 12) {
         is_valid_sql(first, &POSTGRESQL_START)
     } else {
         false
@@ -131,8 +133,8 @@ const MYSQL_START: [&'static str; 14] = [
     "COMMIT", "ROLLBACK", "DESC",
 ];
 
-pub(super) fn is_mysql(sql: &String) -> bool {
-    if let Some(first) = trim_head_comment_and_get_first_word(sql.as_str(), 8) {
+pub(super) fn is_mysql(sql: &[u8]) -> bool {
+    if let Some(first) = trim_head_comment_and_get_first_word(sql, 8) {
         is_valid_sql(first, &MYSQL_START)
     } else {
         false
@@ -153,36 +155,49 @@ pub(super) fn is_mysql(sql: &String) -> bool {
         reference: https://dev.mysql.com/doc/refman/5.6/en/comments.html
 */
 pub(super) fn trim_head_comment_and_get_first_word(
-    mut sql: &str,
+    sql: &[u8],
     first_word_max_len: usize,
-) -> Option<&str> {
-    sql = sql.trim_start();
-    // if start with /*, strip all comment block before sql string.
-    while sql.starts_with("/*") {
-        if !sql.is_char_boundary(2) {
-            return None;
+) -> Option<&[u8]> {
+    let length = sql.len();
+    let mut iteration = sql.iter().enumerate().peekable();
+    let mut next = 0;
+    while let Some(_) = iteration.peek() {
+        if !(sql[next..].starts_with(b"/*")
+            || sql[next..].starts_with(b" ")
+            || sql[next..].starts_with(b"\n")
+            || sql[next..].starts_with(b"\t")
+            || sql[next..].starts_with(b"\r"))
+        {
+            break;
         }
-        (_, sql) = sql.split_at(2);
-
-        if let Some(idx) = sql.find("*/") {
-            if !sql.is_char_boundary(idx + 2) {
-                return None;
+        // skip space
+        while let Some(_) =
+            iteration.next_if(|&(_, c)| *c == b' ' || *c == b'\n' || *c == b'\t' || *c == b'\r')
+        {
+        }
+        next = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+        if next >= length {
+            break;
+        }
+        if sql[next..].starts_with(b"/*") {
+            // skip comment
+            while let Some(_) = iteration.next_if(|&(j, _)| !sql[j..].starts_with(b"*/")) {}
+            next = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+            if next >= length {
+                break;
+            } else {
+                forward(&mut iteration, 2); // skip the "*/"
+                next = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
             }
-            (_, sql) = sql.split_at(idx + 2);
-            sql = sql.trim_start();
-        } else {
-            return None;
         }
     }
 
-    if let Some(idx) = sql.find(|c: char| !c.is_alphabetic()) {
-        if idx <= first_word_max_len && idx != 0 {
-            let (sub_sql, _) = sql.split_at(idx);
-            return Some(sub_sql);
-        }
-    } else if sql.len() <= first_word_max_len {
-        // if not have word boundary, assume as single word
-        return Some(sql);
+    let start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+    // get the frist word
+    while let Some(_) = iteration.next_if(|&(_, c)| c.is_ascii_alphabetic()) {}
+    let end = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+    if start < end && end - start <= first_word_max_len {
+        return Some(&sql[start..end]);
     }
     None
 }
@@ -196,81 +211,81 @@ mod test_sql_check {
     #[test]
     fn test_trim_head_comment_and_get_first_word() {
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"sEleCt 1", 6).unwrap(),
+            trim_head_comment_and_get_first_word(b"sEleCt 1", 6).unwrap(),
             &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"sEleCt 1", 7).unwrap(),
-            &["SELECT"]
+            trim_head_comment_and_get_first_word(b"sEleCt 1", 7).unwrap(),
+            &["SELECT"],
         ));
-        assert_eq!(trim_head_comment_and_get_first_word(r"sEleCt 1", 5), None);
+        assert_eq!(trim_head_comment_and_get_first_word(b"sEleCt 1", 5), None);
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* i am comment */SelecT 1", 6).unwrap(),
-            &["SELECT"]
+            trim_head_comment_and_get_first_word(b"/* i am comment */SelecT 1", 6).unwrap(),
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* i am comment */ SelecT 1", 6).unwrap(),
-            &["SELECT",]
+            trim_head_comment_and_get_first_word(b"/* i am comment */ SelecT 1", 6).unwrap(),
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
             trim_head_comment_and_get_first_word(
-                r"/* i am comment */ /*i am comment*/ SelecT 1",
+                b"/* i am comment */ /*i am comment*/ SelecT 1",
                 6
             )
             .unwrap(),
-            &["SELECT"]
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* i am comment */ /*i am comment*/SelecT 1", 6)
+            trim_head_comment_and_get_first_word(b"/* i am comment */ /*i am comment*/SelecT 1", 6)
                 .unwrap(),
-            &["SELECT"]
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* i am comment * /*/ SelecT 1", 6).unwrap(),
-            &["SELECT"]
+            trim_head_comment_and_get_first_word(b"/* i am comment * /*/ SelecT 1", 6).unwrap(),
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* i am comment *  /**/  /**  */ SelecT 1", 6)
+            trim_head_comment_and_get_first_word(b"/* i am comment *  /**/  /**  */ SelecT 1", 6)
                 .unwrap(),
-            &["SELECT"]
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* unable to parse */SelecT", 6).unwrap(),
-            &["SELECT"]
+            trim_head_comment_and_get_first_word(b"/* unable to parse */SelecT", 6).unwrap(),
+            &["SELECT"],
         ));
         assert!(is_valid_sql(
-            trim_head_comment_and_get_first_word(r"/* able to parse */SelecT ", 6).unwrap(),
-            &["SELECT"]
+            trim_head_comment_and_get_first_word(b"/* able to parse */SelecT ", 6).unwrap(),
+            &["SELECT"],
         ));
         assert_eq!(
-            trim_head_comment_and_get_first_word(r"/* not a comment * / SelecT 1", 6),
+            trim_head_comment_and_get_first_word(b"/* not a comment * / SelecT 1", 6),
             None
         );
         assert_eq!(
-            trim_head_comment_and_get_first_word(r"/ * not a comment */ SelecT 1", 6),
+            trim_head_comment_and_get_first_word(b"/ * not a comment */ SelecT 1", 6),
             None
         );
         assert!(is_valid_sql(
             trim_head_comment_and_get_first_word(
-                r"/* i am comment /* */ syntax error /* i am comment */ SelecT 1",
+                b"/* i am comment /* */ syntax error /* i am comment */ SelecT 1",
                 6
             )
             .unwrap(),
-            &["SYNTAX"]
+            &["SYNTAX"],
         ));
         assert_eq!(
             trim_head_comment_and_get_first_word(
-                r"/* i am comment /* */ -- syntax error /* i am comment */ SelecT 1",
+                b"/* i am comment /* */ -- syntax error /* i am comment */ SelecT 1",
                 6
             ),
             None
         );
         assert_eq!(
-            trim_head_comment_and_get_first_word(r"/ * not a comment *\/ SelecT 1", 6),
+            trim_head_comment_and_get_first_word(br"/ * not a comment *\/ SelecT 1", 6),
             None
         );
         assert_eq!(
-            trim_head_comment_and_get_first_word(r"/ * not a comment  /*/*  */ SelecT 1", 6),
+            trim_head_comment_and_get_first_word(b"/ * not a comment  /*/*  */ SelecT 1", 6),
             None
         );
     }

--- a/agent/src/flow_generator/protocol_logs/sql/sql_obfuscate.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/sql_obfuscate.rs
@@ -1,0 +1,809 @@
+/*
+ * Copyright (ch) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES Or CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::{
+    cell::OnceCell,
+    collections::HashMap,
+    iter::{Enumerate, Peekable},
+    slice::Iter,
+};
+
+use public::utils::hash::hash_to_u64;
+
+use super::{forward, ObfuscateCache, BLANK_SPACE, QUESTION_MARK};
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum Token {
+    Keyword(Keyword),
+    String(usize), // the end offset
+    Separator(u8),
+    Operator(Operator),
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operator {
+    ColonCast, // ::
+    Ge,        // >=
+    Gt,        // >
+    Le,        // <=
+    Lt,        // <
+    Ne,        // <> or !=
+    Regex,     // ~*
+
+    At,                 // @
+    Backtick,           // `
+    Caret,              // ^
+    Colon,              // :
+    Dash,               // -
+    Dot,                // .
+    Equals,             // =
+    ExclamationMark,    // !
+    LeftCurlyBrace,     // {
+    LeftSquareBracket,  // [
+    Percent,            // %
+    Pipe,               // |
+    Plus,               // +
+    PoundSign,          // #
+    RightCurlyBrace,    // }
+    RightSquareBracket, // ]
+    Slash,              // /
+    Star,               // *
+    Tilde,              // ~
+
+    // PostgreSQL specific Json operators
+    JsonSelect,         // ->
+    JsonSelectText,     // ->>
+    JsonSelectPath,     // #>
+    JsonSelectPathText, // #>>
+    JsonContains,       // @>
+    JsonContainsLeft,   // <@
+    JsonKeyExists,      // ?
+    JsonAnyKeysExist,   // ?|
+    JsonAllKeysExist,   // ?&
+    JsonDelete,         // #-
+}
+
+impl Operator {
+    fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            Operator::ColonCast => b"::",
+            Operator::Ne => b"<>",
+            Operator::Lt => b"<",
+            Operator::Gt => b">",
+            Operator::Le => b"<=",
+            Operator::Ge => b">=",
+            Operator::Regex => b"~*",
+            Operator::Dash => b"-",
+            Operator::ExclamationMark => b"!",
+            Operator::Plus => b"+",
+            Operator::PoundSign => b"#",
+            Operator::Slash => b"/",
+            Operator::Star => b"*",
+            Operator::Equals => b"=",
+            Operator::LeftSquareBracket => b"[",
+            Operator::RightSquareBracket => b"]",
+            Operator::Colon => b":",
+            Operator::Caret => b"^",
+            Operator::Percent => b"%",
+            Operator::Pipe => b"|",
+            Operator::Tilde => b"~",
+            Operator::Backtick => b"`",
+            Operator::At => b"@",
+            Operator::LeftCurlyBrace => b"{",
+            Operator::RightCurlyBrace => b"}",
+            Operator::Dot => b".",
+            Operator::JsonSelect => b"->",
+            Operator::JsonSelectText => b"->>",
+            Operator::JsonSelectPath => b"#>",
+            Operator::JsonSelectPathText => b"#>>",
+            Operator::JsonContains => b"@>",
+            Operator::JsonContainsLeft => b"<@",
+            Operator::JsonKeyExists => b"?",
+            Operator::JsonAnyKeysExist => b"?|",
+            Operator::JsonAllKeysExist => b"?&",
+            Operator::JsonDelete => b"#-",
+        }
+    }
+}
+
+const MAX_KEYWORD_LENGTH: usize = 9;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Keyword {
+    Alter,
+    And,
+    As,
+    Begin,
+    BooleanLiteralFalse,
+    BooleanLiteralTrue,
+    By,
+    Commit,
+    Create,
+    Cross,
+    Delete,
+    Drop,
+    False,
+    From,
+    Full,
+    Grant,
+    In,
+    Inner,
+    Insert,
+    Into,
+    Join,
+    Left,
+    Limit,
+    Matched,
+    Merge,
+    Not,
+    Null,
+    On,
+    Or,
+    Over,
+    Output,
+    Revoke,
+    Right,
+    Savepoint,
+    Select,
+    Set,
+    Show,
+    Then,
+    Truncate,
+    True,
+    Union,
+    Update,
+    Use,
+    Using,
+    Values,
+    Where,
+    When,
+}
+
+impl Keyword {
+    fn as_bytes(&self) -> &'static [u8] {
+        match self {
+            Keyword::Alter => b"ALTER",
+            Keyword::And => b"AND",
+            Keyword::As => b"AS",
+            Keyword::Begin => b"BEGIN",
+            Keyword::BooleanLiteralFalse => b"FALSE",
+            Keyword::BooleanLiteralTrue => b"TRUE",
+            Keyword::By => b"BY",
+            Keyword::Commit => b"COMMIT",
+            Keyword::Create => b"CREATE",
+            Keyword::Cross => b"CROSS",
+            Keyword::Delete => b"DELETE",
+            Keyword::Drop => b"DROP",
+            Keyword::False => b"FALSE",
+            Keyword::From => b"FROM",
+            Keyword::Full => b"FULL",
+            Keyword::Grant => b"GRANT",
+            Keyword::In => b"IN",
+            Keyword::Inner => b"INNER",
+            Keyword::Insert => b"INSERT",
+            Keyword::Into => b"INTO",
+            Keyword::Join => b"JOIN",
+            Keyword::Left => b"LEFT",
+            Keyword::Limit => b"LIMIT",
+            Keyword::Matched => b"MATCHED",
+            Keyword::Merge => b"MERGE",
+            Keyword::Not => b"NOT",
+            Keyword::Null => b"NULL",
+            Keyword::On => b"ON",
+            Keyword::Or => b"OR",
+            Keyword::Over => b"OVER",
+            Keyword::Output => b"OUTPUT",
+            Keyword::Revoke => b"REVOKE",
+            Keyword::Right => b"RIGHT",
+            Keyword::Savepoint => b"SAVEPOINT",
+            Keyword::Select => b"SELECT",
+            Keyword::Set => b"SET",
+            Keyword::Show => b"SHOW",
+            Keyword::Then => b"THEN",
+            Keyword::Truncate => b"TRUNCATE",
+            Keyword::True => b"TRUE",
+            Keyword::Union => b"UNION",
+            Keyword::Update => b"UPDATE",
+            Keyword::Use => b"USE",
+            Keyword::Using => b"USING",
+            Keyword::Values => b"VALUES",
+            Keyword::Where => b"WHERE",
+            Keyword::When => b"WHEN",
+        }
+    }
+}
+thread_local! {
+    static KEYWORDS: OnceCell<HashMap<&'static [u8], Keyword>> = OnceCell::new();
+}
+
+impl TryFrom<&[u8]> for Keyword {
+    type Error = &'static str;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        KEYWORDS.with(|keys| {
+            let map = keys.get_or_init(|| {
+                let mut m = HashMap::new();
+                m.insert(Keyword::Alter.as_bytes(), Keyword::Alter);
+                m.insert(Keyword::And.as_bytes(), Keyword::And);
+                m.insert(Keyword::As.as_bytes(), Keyword::As);
+                m.insert(Keyword::Begin.as_bytes(), Keyword::Begin);
+                m.insert(
+                    Keyword::BooleanLiteralFalse.as_bytes(),
+                    Keyword::BooleanLiteralFalse,
+                );
+                m.insert(
+                    Keyword::BooleanLiteralTrue.as_bytes(),
+                    Keyword::BooleanLiteralTrue,
+                );
+                m.insert(Keyword::By.as_bytes(), Keyword::By);
+                m.insert(Keyword::Commit.as_bytes(), Keyword::Commit);
+                m.insert(Keyword::Create.as_bytes(), Keyword::Create);
+                m.insert(Keyword::Cross.as_bytes(), Keyword::Cross);
+                m.insert(Keyword::Delete.as_bytes(), Keyword::Delete);
+                m.insert(Keyword::Drop.as_bytes(), Keyword::Drop);
+                m.insert(Keyword::False.as_bytes(), Keyword::False);
+                m.insert(Keyword::From.as_bytes(), Keyword::From);
+                m.insert(Keyword::Full.as_bytes(), Keyword::Full);
+                m.insert(Keyword::Grant.as_bytes(), Keyword::Grant);
+                m.insert(Keyword::In.as_bytes(), Keyword::In);
+                m.insert(Keyword::Inner.as_bytes(), Keyword::Inner);
+                m.insert(Keyword::Insert.as_bytes(), Keyword::Insert);
+                m.insert(Keyword::Into.as_bytes(), Keyword::Into);
+                m.insert(Keyword::Join.as_bytes(), Keyword::Join);
+                m.insert(Keyword::Left.as_bytes(), Keyword::Left);
+                m.insert(Keyword::Limit.as_bytes(), Keyword::Limit);
+                m.insert(Keyword::Matched.as_bytes(), Keyword::Matched);
+                m.insert(Keyword::Merge.as_bytes(), Keyword::Merge);
+                m.insert(Keyword::Not.as_bytes(), Keyword::Not);
+                m.insert(Keyword::Null.as_bytes(), Keyword::Null);
+                m.insert(Keyword::On.as_bytes(), Keyword::On);
+                m.insert(Keyword::Or.as_bytes(), Keyword::Or);
+                m.insert(Keyword::Over.as_bytes(), Keyword::Over);
+                m.insert(Keyword::Output.as_bytes(), Keyword::Output);
+                m.insert(Keyword::Revoke.as_bytes(), Keyword::Revoke);
+                m.insert(Keyword::Right.as_bytes(), Keyword::Right);
+                m.insert(Keyword::Savepoint.as_bytes(), Keyword::Savepoint);
+                m.insert(Keyword::Select.as_bytes(), Keyword::Select);
+                m.insert(Keyword::Set.as_bytes(), Keyword::Set);
+                m.insert(Keyword::Show.as_bytes(), Keyword::Show);
+                m.insert(Keyword::Then.as_bytes(), Keyword::Then);
+                m.insert(Keyword::Truncate.as_bytes(), Keyword::Truncate);
+                m.insert(Keyword::True.as_bytes(), Keyword::True);
+                m.insert(Keyword::Union.as_bytes(), Keyword::Union);
+                m.insert(Keyword::Update.as_bytes(), Keyword::Update);
+                m.insert(Keyword::Use.as_bytes(), Keyword::Use);
+                m.insert(Keyword::Using.as_bytes(), Keyword::Using);
+                m.insert(Keyword::Values.as_bytes(), Keyword::Values);
+                m.insert(Keyword::Where.as_bytes(), Keyword::Where);
+                m.insert(Keyword::When.as_bytes(), Keyword::When);
+                m
+            });
+            map.get(value).ok_or("Failed to parse keyword").copied()
+        })
+    }
+}
+
+fn obfuscate(input: &[u8]) -> Vec<u8> {
+    let length = input.len();
+    let mut output = Vec::with_capacity(length);
+    let mut iteration = input.iter().enumerate().peekable();
+    let mut last_token = Token::Unknown;
+    let mut last_keyword_is_set = false;
+    let mut need_obfuscated = false; // if false, the original string can be returned directly without creating a new string
+    let mut need_masked = false; // merge multiple question marks into one, for example, convert 'SELECT * FROM table WHERE id IN (1, 2, 3)' to 'SELECT * FROM table WHERE id IN (?)'
+    let mut already_masked = false;
+    let mut start = 0;
+    while let Some(&(i, ch)) = iteration.peek() {
+        let token = match ch {
+            b'/' => {
+                if input[i..].starts_with(b"//") {
+                    Token::String(scan_single_line_comment(&mut iteration, length))
+                } else if input[i..].starts_with(b"/*") {
+                    Token::String(scan_multiline_comment(&mut iteration, length))
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Slash)
+                }
+            }
+            b'-' => {
+                if input[i..].starts_with(b"->>") {
+                    forward(&mut iteration, 3);
+                    Token::Operator(Operator::JsonSelectText)
+                } else if input[i..].starts_with(b"--") {
+                    Token::String(scan_single_line_comment(&mut iteration, length))
+                } else if input[i..].starts_with(b"->") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonSelect)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Dash)
+                }
+            }
+            b'#' => {
+                if input[i..].starts_with(b"#>>") {
+                    forward(&mut iteration, 3);
+                    Token::Operator(Operator::JsonSelectPathText)
+                } else if input[i..].starts_with(b"#>") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonSelectPath)
+                } else if input[i..].starts_with(b"#-") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonDelete)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::PoundSign)
+                }
+            }
+            b'?' => {
+                if input[i..].starts_with(b"?|") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonAnyKeysExist)
+                } else if input[i..].starts_with(b"?&") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonAllKeysExist)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::JsonKeyExists)
+                }
+            }
+            b':' => {
+                if input[i..].starts_with(b"::") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::ColonCast)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Colon)
+                }
+            }
+            b'~' => {
+                if input[i..].starts_with(b"~*") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::Regex)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Tilde)
+                }
+            }
+            b'"' | b'\'' => Token::String(scan_quoted_string(&mut iteration, length)),
+            b'<' => {
+                if input[i..].starts_with(b"<=") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::Le)
+                } else if input[i..].starts_with(b"<>") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::Ne)
+                } else if input[i..].starts_with(b"<@") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonContainsLeft)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Lt)
+                }
+            }
+            b'!' => {
+                if input[i..].starts_with(b"!~*") {
+                    forward(&mut iteration, 3);
+                    Token::Operator(Operator::Ne)
+                } else if input[i..].starts_with(b"!=") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::Ne)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::ExclamationMark)
+                }
+            }
+            b'@' => {
+                if input[i..].starts_with(b"@>") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::JsonContains)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::At)
+                }
+            }
+            b'>' => {
+                if input[i..].starts_with(b">=") {
+                    forward(&mut iteration, 2);
+                    Token::Operator(Operator::Ge)
+                } else {
+                    forward(&mut iteration, 1);
+                    Token::Operator(Operator::Gt)
+                }
+            }
+            b';' | b',' | b'(' | b')' | b'\n' => {
+                forward(&mut iteration, 1);
+                Token::Separator(*ch)
+            }
+            b'+' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Plus)
+            }
+            b'*' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Star)
+            }
+            b'=' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Equals)
+            }
+            b'[' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::LeftSquareBracket)
+            }
+            b']' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::RightSquareBracket)
+            }
+            b'^' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Caret)
+            }
+            b'%' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Percent)
+            }
+            b'|' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Pipe)
+            }
+            b'`' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Backtick)
+            }
+            b'{' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::LeftCurlyBrace)
+            }
+            b'}' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::RightCurlyBrace)
+            }
+            b'.' => {
+                forward(&mut iteration, 1);
+                Token::Operator(Operator::Dot)
+            }
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'$' => {
+                while let Some(_) = iteration.next_if(|&(_, ch)| {
+                    ch.is_ascii_alphanumeric()
+                        || *ch == b'_'
+                        || *ch == b'.'
+                        || *ch == b'$'
+                        || *ch == b'*'
+                }) {}
+                let end = if let Some(&(i, _)) = iteration.peek() {
+                    i
+                } else {
+                    length
+                };
+
+                if end - start > MAX_KEYWORD_LENGTH {
+                    Token::String(end)
+                } else if let Ok(v) = Keyword::try_from(unsafe {
+                    // SAFETY:
+                    // - input[start..end] have been checked for ascii characters
+                    std::str::from_utf8_unchecked(&input[start..end])
+                        .to_uppercase()
+                        .as_bytes()
+                }) {
+                    Token::Keyword(v)
+                } else {
+                    Token::String(end)
+                }
+            }
+            b' ' => {
+                forward(&mut iteration, 1);
+                start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                continue;
+            }
+            _ => {
+                if need_obfuscated {
+                    output.push(*ch);
+                }
+                forward(&mut iteration, 1);
+                start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                continue;
+            }
+        };
+
+        if matches!(token, Token::Operator(_))
+            || token == Token::Keyword(Keyword::In)
+            || token == Token::Keyword(Keyword::Values)
+        {
+            need_masked = true;
+            if !need_obfuscated {
+                start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                // this token and its previous contents do not need to be confused, directly intercepted
+                output.extend_from_slice(&input[..start]);
+                need_obfuscated = true;
+                last_token = token;
+                continue;
+            }
+        } else if token == Token::Keyword(Keyword::As) {
+            // the As keyword content is not displayed
+            if !need_obfuscated {
+                output.extend_from_slice(&input[..start]);
+                need_obfuscated = true;
+                start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                last_token = token;
+                continue;
+            }
+        }
+        match token {
+            Token::String(end) => {
+                if last_token == Token::Keyword(Keyword::As) {
+                    last_token = token;
+                    continue;
+                }
+                if !matches!(last_token, Token::Unknown)
+                    && !matches!(last_token, Token::Separator(_))
+                {
+                    if need_obfuscated {
+                        output.push(BLANK_SPACE);
+                    }
+                }
+                if need_masked && !already_masked {
+                    already_masked = true;
+                    if need_obfuscated {
+                        output.push(QUESTION_MARK);
+                    }
+                } else if !need_masked {
+                    // if a number appears, the string needs to be obfuscated
+                    if !need_obfuscated && has_digits(&input[start..end]) {
+                        output.extend_from_slice(&input[..start]);
+                        need_obfuscated = true;
+                    }
+                    if need_obfuscated {
+                        output.extend_from_slice(&replace_digits(&input[start..end]));
+                    }
+                }
+            }
+            Token::Separator(s) => {
+                if matches!(last_token, Token::Keyword(_)) && need_obfuscated {
+                    output.push(BLANK_SPACE);
+                }
+                if need_masked
+                    && ((*ch == b')' || *ch == b';') || (last_keyword_is_set && *ch == b','))
+                {
+                    need_masked = false;
+                    already_masked = false;
+                }
+                if (!need_masked || !already_masked) && need_obfuscated {
+                    output.push(s);
+                }
+            }
+            Token::Keyword(ref k) => {
+                if *k == Keyword::As {
+                    last_token = token;
+                    start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+                    continue;
+                } else if *k == Keyword::Set {
+                    last_keyword_is_set = true;
+                } else if *k != Keyword::Values && *k != Keyword::In {
+                    need_masked = false;
+                    already_masked = false;
+                    last_keyword_is_set = false;
+                } else {
+                    last_keyword_is_set = false;
+                }
+
+                if !matches!(last_token, Token::Unknown) && need_obfuscated {
+                    output.push(BLANK_SPACE);
+                }
+                if need_obfuscated {
+                    output.extend_from_slice(k.as_bytes());
+                }
+            }
+            Token::Operator(ref o) => {
+                if need_obfuscated {
+                    if !matches!(last_token, Token::Operator(_))
+                        && !matches!(last_token, Token::Separator(_))
+                    {
+                        output.push(BLANK_SPACE);
+                    }
+                    output.extend_from_slice(o.as_bytes());
+                }
+            }
+            _ => {}
+        }
+        last_token = token;
+        start = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+    }
+    output
+}
+
+fn scan_quoted_string(iteration: &mut Peekable<Enumerate<Iter<'_, u8>>>, length: usize) -> usize {
+    forward(iteration, 1); // consume the '"' or '\''
+    while let Some(_) = iteration.next_if(|&(_, ch)| *ch != b'"' && *ch != b'\'') {}
+    forward(iteration, 1); // consume the '"' or '\''
+    iteration.peek().map(|(idx, _)| *idx).unwrap_or(length)
+}
+
+fn scan_single_line_comment(
+    iteration: &mut Peekable<Enumerate<Iter<'_, u8>>>,
+    length: usize,
+) -> usize {
+    forward(iteration, 2); // consume the "//"
+    while let Some(_) = iteration.next_if(|&(_, ch)| *ch != b'\n') {}
+    let off = iteration.peek().map(|(idx, _)| *idx).unwrap_or(length);
+    forward(iteration, 1); // consume the '\n'
+    off
+}
+
+fn scan_multiline_comment(
+    iteration: &mut Peekable<Enumerate<Iter<'_, u8>>>,
+    length: usize,
+) -> usize {
+    forward(iteration, 2);
+    let mut last_char_is_star = false;
+    while let Some(_) = iteration.next_if(|&(_, ch)| {
+        if *ch == b'*' {
+            last_char_is_star = true;
+        } else {
+            last_char_is_star = false;
+        }
+        !last_char_is_star || *ch != b'/'
+    }) {}
+    forward(iteration, 1); // consume the '/'
+    iteration.peek().map(|(idx, _)| *idx).unwrap_or(length)
+}
+
+pub fn attempt_obfuscation<'a>(
+    obfuscate_cache: &Option<ObfuscateCache>,
+    input: &[u8],
+) -> Option<Vec<u8>> {
+    let Some(cache) = obfuscate_cache else {
+        return None;
+    };
+
+    let key = hash_to_u64(&input);
+    if let Some(s) = cache.borrow_mut().get(&key) {
+        return Some(s.clone());
+    }
+
+    let output = obfuscate(&input);
+    if !output.is_empty() {
+        let _ = cache.borrow_mut().put(key, output.clone());
+        return Some(output);
+    }
+    None
+}
+
+fn has_digits(buffer: &[u8]) -> bool {
+    for ch in buffer {
+        if ch.is_ascii_digit() {
+            return true;
+        }
+    }
+    false
+}
+
+fn replace_digits(buffer: &[u8]) -> Vec<u8> {
+    let mut scanning_digit = false;
+    let mut filtered = Vec::with_capacity(buffer.len());
+    for ch in buffer {
+        if ch.is_ascii_digit() {
+            if scanning_digit {
+                continue;
+            }
+            scanning_digit = true;
+            filtered.push(QUESTION_MARK);
+            continue;
+        }
+        scanning_digit = false;
+        filtered.push(*ch);
+    }
+    filtered
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, num::NonZeroUsize, rc::Rc};
+
+    use lru::LruCache;
+
+    use super::{super::OBFUSCATE_CACHE_SIZE, *};
+
+    #[test]
+    fn test_sql_obfuscate() {
+        let obfuscate_cache = Some(Rc::new(RefCell::new(LruCache::new(
+            NonZeroUsize::new(OBFUSCATE_CACHE_SIZE).unwrap(),
+        ))));
+
+        let test_cases = [
+                (
+                    "SELECT id FROM table;",
+                    None,
+                ),
+                (
+                    "DELETE FROM table WHERE id = 1;",
+                    Some("DELETE FROM table WHERE id = ?;"),
+                ),
+                (
+                    "UPDATE table SET column1 = value1, column2 = value2, column3 = value3 WHERE id = 1;",
+                    Some("UPDATE table SET column? = ?,column? = ?,column? = ? WHERE id = ?;"),
+                ),
+                (
+                    "INSERT INTO table (column1, column2, column3) VALUES (value1, value2, value3);",
+                    Some("INSERT INTO table (column?,column?,column?) VALUES (?);"),
+                ),
+                (
+                    "SELECT * FROM table123😊 WHERE id😊 = 123;",
+                    Some("SELECT * FROM table?😊 WHERE id😊 = ?;"),
+                ),
+                (
+                    "SELECT json_column ->'😊key' FROM ta123ble;",
+                    Some("SELECT json_column -> ? FROM ta?ble;"),
+                ),
+                (
+                    "SELECT * FROM table WHERE name ='Tom' OR name = \"Jerry\";",
+                    Some("SELECT * FROM table WHERE name = ? OR name = ?;"),
+                ),
+                (
+                    "SELECT * FROM table WHERE (age > 18 AND count < 10) OR (age <= 1 AND count >= 10) OR age != 100 OR count <> 100;",
+                    Some("SELECT * FROM table WHERE (age > ? AND count < ?) OR (age <= ? AND count >= ?) OR age <> ? OR count <> ?;"),
+                ),
+                (
+                    "SELECT * FROM table WHERE (id = 123 AND id NOT IN(1,2,3));",
+                    Some("SELECT * FROM table WHERE (id = ? AND id NOT IN (?));"),
+                ),
+                (
+                    "SELECT * FROM table where id = 1;-- some comment, 一些注释",
+                    Some("SELECT * FROM table WHERE id = ?;-- some comment, 一些注释"),
+                ),
+                (
+                    "SELECT * FROM table where id = 1;// some comment, 一些注释",
+                    Some("SELECT * FROM table WHERE id = ?;// some comment, 一些注释"),
+                ),
+                (
+                    r#"/* 这是一个多行注释*/ SELECT count(*) FROM table WHERE id = 100;"#,
+                    Some(r#"/* 这是一个多行注释*/ SELECT count(*) FROM table WHERE id = ?;"#),
+                ),
+                (
+                    "MERGE INTO Employees AS target USING EmployeeUpdates AS source ON (target.EmployeeID = source.EmployeeID) WHEN MATCHED THEN UPDATE SET target.Name = source.Name WHEN NOT MATCHED BY TARGET THEN INSERT (EmployeeID, Name) VALUES (source.EmployeeID, source.Name) WHEN NOT MATCHED BY SOURCE THEN DELETE OUTPUT $action, inserted.*, deleted.*;",
+                    Some("MERGE INTO Employees  USING EmployeeUpdates ON (target.EmployeeID = ?) WHEN MATCHED THEN UPDATE SET target.Name = ? WHEN NOT MATCHED BY TARGET THEN INSERT (EmployeeID,Name) VALUES (?) WHEN NOT MATCHED BY SOURCE THEN DELETE OUTPUT $action,inserted.*,deleted.*;"),
+                ),
+                (
+                    "SELECT CustomerID, CustomerName, City FROM Customers WHERE City = 'New York' UNION SELECT O.CustomerID, C.CustomerName, C.City FROM Orders O JOIN Customers C ON O.CustomerID = C.CustomerID WHERE C.City = 'New York';",
+                    Some("SELECT CustomerID, CustomerName, City FROM Customers WHERE City = ? UNION SELECT O.CustomerID,C.CustomerName,C.City FROM Orders O JOIN Customers C ON O.CustomerID = ? WHERE C.City = ?;"),
+                ),
+                (
+                    "SELECT CustomerID, CustomerName, City FROM Customers WHERE CustomerID IN (SELECT CustomerID FROM Orders WHERE CustomerID IN (SELECT CustomerID FROM Customers WHERE City = 'New York'));",
+                    Some("SELECT CustomerID, CustomerName, City FROM Customers WHERE CustomerID IN ( SELECT CustomerID FROM Orders WHERE CustomerID IN ( SELECT CustomerID FROM Customers WHERE City = ?));"),
+                ),
+                (
+                    "SELECT Orders.OrderID, Customers.CustomerName, Orders.OrderDate FROM Orders INNER JOIN Customers ON Orders.CustomerID = Customers.CustomerID WHERE Customers.Country = 'USA';",
+                    Some("SELECT Orders.OrderID, Customers.CustomerName, Orders.OrderDate FROM Orders INNER JOIN Customers ON Orders.CustomerID = ? WHERE Customers.Country = ?;"),
+                ),
+                (
+                    "SELECT Customers.CustomerName, Orders.OrderDate, (SELECT COUNT(*) FROM OrderDetails WHERE OrderDetails.OrderID = Orders.OrderID) AS TotalItems FROM Customers INNER JOIN Orders ON Customers.CustomerID = Orders.CustomerID WHERE Orders.OrderDate BETWEEN '2022-01-01' AND '2022-12-31';",
+                    Some("SELECT Customers.CustomerName, Orders.OrderDate, (SELECT COUNT(*) FROM OrderDetails WHERE OrderDetails.OrderID = ?) FROM Customers INNER JOIN Orders ON Customers.CustomerID = ? WHERE Orders.OrderDate BETWEEN '?-?-?' AND '?-?-?';"),
+                ),
+                (
+                    "SELECT CustomerName, OrderDate, TotalAmount FROM (SELECT Customers.CustomerName, Orders.OrderDate, SUM(OrderDetails.Quantity * OrderDetails.UnitPrice) OVER (PARTITION BY Customers.CustomerID) AS TotalAmount, ROW_NUMBER() OVER (PARTITION BY Customers.CustomerID ORDER BY Orders.OrderDate DESC) AS RowNum FROM Customers INNER JOIN Orders ON Customers.CustomerID = Orders.CustomerID INNER JOIN OrderDetails ON Orders.OrderID = OrderDetails.OrderID) AS Subquery WHERE RowNum = 1;",
+                    Some("SELECT CustomerName, OrderDate, TotalAmount FROM (SELECT Customers.CustomerName, Orders.OrderDate, SUM(OrderDetails.Quantity * ?) OVER (PARTITION BY Customers.CustomerID),ROW_NUMBER() OVER (PARTITION BY Customers.CustomerID ORDER BY Orders.OrderDate DESC) FROM Customers INNER JOIN Orders ON Customers.CustomerID = ? INNER JOIN OrderDetails ON Orders.OrderID = ?) WHERE RowNum = ?;"),
+                ),
+            ];
+        for (ti, tt) in test_cases.iter().enumerate() {
+            assert_eq!(
+                attempt_obfuscation(&obfuscate_cache, tt.0.as_bytes()),
+                tt.1.map(|o| o.as_bytes().to_vec()),
+                "{}",
+                format!("Test case {}", ti)
+            );
+        }
+    }
+}

--- a/server/controller/model/agent_group_config.go
+++ b/server/controller/model/agent_group_config.go
@@ -222,7 +222,8 @@ type HttpEndpointExtraction struct {
 }
 
 type L7ProtocolAdvancedFeatures struct {
-	HttpEndpointExtraction *HttpEndpointExtraction `yaml:"http-endpoint-extraction,omitempty"`
+	HttpEndpointExtraction    *HttpEndpointExtraction `yaml:"http-endpoint-extraction,omitempty"`
+	ObfuscateEnabledProtocols []string                `yaml:"obfuscate-enabled-protocols,omitempty"`
 }
 
 type OracleConfig struct {

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -1008,6 +1008,15 @@ vtap_group_id: g-xxxxxx
         ## Note: Intercept the first few paragraphs in URL (the content between two / is regarded as one paragraph) as endpoint
         ## Default: 2
         #keep-segments: 2
+  
+    ## List of L7 protocols that need to be obfuscated
+    ## Note: For the sake of data security, the data of the protocol that needs
+    ## to be desensitized is configured here and is not processed by default.
+    #obfuscate-enabled-protocols:
+    #- MySQL
+    #- PostgreSQL
+    #- Redis
+
 
   #oracle-parse-config:
     #is-be: true


### PR DESCRIPTION
### This PR is for:

- Agent

### obfuscate sql and redis
Sensitive data needs to be desensitized for data security. The value in the request_resource of SQL/NoSQL is processed as a mask. For example:
- change "SELECT * FROM table WHERE id = 1;" to  "SELECT * FROM table WHERE id = ?;"
- change "SET key value" to "SET key ?"
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main


