### PR TITLE
[Querier] modify l4_flow_log rtt_client_max&rtt_server_max calc method

### DIFF
--- a/server/querier/engine/clickhouse/metrics/l4_flow_log.go
+++ b/server/querier/engine/clickhouse/metrics/l4_flow_log.go
@@ -128,12 +128,10 @@ var L4_FLOW_LOG_METRICS_REPLACE = map[string]*Metrics{
 	"server_half_close_flow":     NewReplaceMetrics(DB_FIELD_SERVER_HALF_CLOSE_FLOW, ""),
 	"tcp_timeout":                NewReplaceMetrics(DB_FIELD_TCP_TIMEOUT, ""),
 
-	"rtt_client": NewReplaceMetrics("rtt_client_sum/rtt_client_count", "").SetIsAgg(false),
-	"rtt_server": NewReplaceMetrics("rtt_server_sum/rtt_server_count", "").SetIsAgg(false),
-	"srt":        NewReplaceMetrics("srt_sum/srt_count", "").SetIsAgg(false),
-	"art":        NewReplaceMetrics("art_sum/art_count", "").SetIsAgg(false),
-	"cit":        NewReplaceMetrics("cit_sum/cit_count", "").SetIsAgg(false),
-	"rrt":        NewReplaceMetrics("rrt_sum/rrt_count", "").SetIsAgg(false),
+	"srt": NewReplaceMetrics("srt_sum/srt_count", "").SetIsAgg(false),
+	"art": NewReplaceMetrics("art_sum/art_count", "").SetIsAgg(false),
+	"cit": NewReplaceMetrics("cit_sum/cit_count", "").SetIsAgg(false),
+	"rrt": NewReplaceMetrics("rrt_sum/rrt_count", "").SetIsAgg(false),
 
 	"l7_error":              NewReplaceMetrics("l7_client_error+l7_server_error", ""),
 	"l7_error_ratio":        NewReplaceMetrics("l7_error/l7_response", "l7_error/l7_response>=0"),


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


