### PR TITLE
[eBPF] Enhance the inspection for probes of the uprobe type

### DIFF
--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -77,6 +77,15 @@ struct protocol_message_t {
 	enum message_type type;
 };
 
+enum process_data_extra_source {
+	DATA_SOURCE_SYSCALL,
+	DATA_SOURCE_GO_TLS_UPROBE,
+	DATA_SOURCE_GO_HTTP2_UPROBE,
+	DATA_SOURCE_OPENSSL_UPROBE,
+	DATA_SOURCE_IO_EVENT,
+	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
+};
+
 #ifndef TASK_COMM_LEN
 #define TASK_COMM_LEN 16
 #endif

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -181,15 +181,6 @@ struct conn_info_t {
 	__u16 dns_q_type;
 };
 
-enum process_data_extra_source {
-	DATA_SOURCE_SYSCALL,
-	DATA_SOURCE_GO_TLS_UPROBE,
-	DATA_SOURCE_GO_HTTP2_UPROBE,
-	DATA_SOURCE_OPENSSL_UPROBE,
-	DATA_SOURCE_IO_EVENT,
-	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
-};
-
 struct process_data_extra {
 	bool vecs : 1;
 	bool is_go_process : 1;

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -322,6 +322,20 @@ static __inline int infer_iovecs_copy(struct infer_data_s *infer_buf,
 	return bytes_copy;
 }
 
+static __inline struct member_fields_offset *
+retrieve_ready_kern_offset(void)
+{
+	__u32 k0 = 0;
+	struct member_fields_offset *offset = members_offset__lookup(&k0);
+	if (!offset)
+		return NULL;
+
+	if (unlikely(!offset->ready))
+		return NULL;
+
+	return offset;
+}
+
 #include "uprobe_base_bpf.c"
 #include "include/protocol_inference.h"
 #define EVENT_BURST_NUM            16

--- a/agent/src/ebpf/kernel/uprobe_base_bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base_bpf.c
@@ -382,6 +382,10 @@ _Pragma("error \"Must specify a BPF target arch\"");
 SEC("uprobe/runtime.execute")
 int runtime_execute(struct pt_regs *ctx)
 {
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
+
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = pid_tgid >> 32;
 
@@ -418,6 +422,10 @@ int runtime_execute(struct pt_regs *ctx)
 SEC("uprobe/enter_runtime.newproc1")
 int enter_runtime_newproc1(struct pt_regs *ctx)
 {
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
+
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = pid_tgid >> 32;
 
@@ -478,6 +486,10 @@ int enter_runtime_newproc1(struct pt_regs *ctx)
 SEC("uprobe/exit_runtime.newproc1")
 int exit_runtime_newproc1(struct pt_regs *ctx)
 {
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
+
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = pid_tgid >> 32;
 
@@ -532,6 +544,10 @@ int exit_runtime_newproc1(struct pt_regs *ctx)
 SEC("tracepoint/sched/sched_process_exit")
 int bpf_func_sched_process_exit(struct sched_comm_exit_ctx *ctx)
 {
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
+
 	pid_t pid, tid;
 	__u64 id;
 
@@ -559,8 +575,11 @@ int bpf_func_sched_process_exit(struct sched_comm_exit_ctx *ctx)
 SEC("tracepoint/sched/sched_process_fork")
 int bpf_func_sched_process_fork(struct sched_comm_fork_ctx *ctx)
 {
-	struct process_event_t data;
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
 
+	struct process_event_t data;
 	data.meta.event_type = EVENT_TYPE_PROC_EXEC;
 	data.pid = ctx->child_pid;
 	bpf_get_current_comm(data.name, sizeof(data.name));

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -646,9 +646,16 @@ static void reader_raw_cb(void *t, void *raw, int raw_size)
 
 	int i, start = 0;
 	struct __socket_data *sd;
-
-	// 确定分发到哪个队列上，通过第一个socket_data来确定
 	sd = (struct __socket_data *)&buf->data[start];
+
+	/* check uprobe data(GO HTTP2) message type */
+	if (sd->source == DATA_SOURCE_GO_HTTP2_UPROBE ||
+			sd->source == DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE) {
+		if (sd->msg_type == MSG_UNKNOWN)
+			return;
+	}
+
+	/* Determine which queue to distribute to based on the first socket_data. */
 	q_idx =
 	    dispatch_queue_index(sd->socket_id, tracer->dispatch_workers_nr);
 	q = &tracer->queues[q_idx];


### PR DESCRIPTION
Make the following adjustments for UPROBE probes:

- Conduct an immediate check for the successful adaptation to the kernel; data collection must not proceed until the kernel is ready.
- Perform a type check (msg_type) on the data received in user space; discard it immediately if invalid.


### This PR is for:

- Agent


#### Affected branches
- main
- v6.3
