### PR TITLE
Profiler optimize 

### DIFF
--- a/agent/src/ebpf/kernel/include/perf_profiler.h
+++ b/agent/src/ebpf/kernel/include/perf_profiler.h
@@ -28,19 +28,22 @@
  * The meaning of the "__profiler_state_map" index.
  */
 typedef enum {
-	TRANSFER_CNT_IDX = 0,	/* buffer-a and buffer-b transfer count.*/
+	TRANSFER_CNT_IDX = 0,	/* buffer-a and buffer-b transfer count. */
 	SAMPLE_CNT_A_IDX,	/* sample count A */
 	SAMPLE_CNT_B_IDX,	/* sample count B */
 	SAMPLE_CNT_DROP,	/* sample drop */
 	SAMPLE_ITER_CNT_MAX,	/* Iteration sample number max value */
-	OUTPUT_CNT_IDX,		/* Count the total number of data outputs.*/
-	ERROR_IDX,		/* Count the number of failed push notifications.*/
+	OUTPUT_CNT_IDX,		/* Count the total number of data outputs. */
+	ERROR_IDX,		/* Count the number of failed push notifications. */
+	ENABLE_IDX,		/* Enable profiler sampling flag.
+				   0: disable sampling; 1: enable sampling. */
+
 	PROFILER_CNT
 } profiler_idx;
 
 struct stack_trace_key_t {
-	__u32 pid;	// processID or threadID
-	__u32 tgid;	// processID
+	__u32 pid;		// processID or threadID
+	__u32 tgid;		// processID
 	__u32 cpu;
 	char comm[TASK_COMM_LEN];
 	int kernstack;

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -26,15 +26,6 @@
 #include "common.h"
 #include "kernel.h"
 #include "bpf_endian.h"
-
-#ifndef unlikely
-#define unlikely(x)             __builtin_expect(!!(x), 0)
-#endif
-
-#ifndef likely
-#define likely(x)               __builtin_expect(!!(x), 1)
-#endif
-
 #include <sys/socket.h>
 #include <stddef.h>
 #include <netinet/in.h>

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -1051,6 +1051,19 @@ int fetch_container_id(pid_t pid, char *id, int copy_bytes)
 	return fetch_container_id_from_str(buff, id, copy_bytes);
 }
 
+int generate_random_integer(int max_value)
+{
+	if (max_value <= 0) {
+		ebpf_warning("Error: max_value must be greater than 0.\n");
+		return 0;
+	}
+
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	srand(ts.tv_nsec);
+	return (rand() % max_value);
+}
+
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg)
 {

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -281,6 +281,9 @@ int fetch_container_id_from_str(char *buff, char *id, int copy_bytes);
 int fetch_container_id(pid_t pid, char *id, int copy_bytes);
 int parse_num_range(const char *config_str, int bytes_count,
 		    bool **mask, int *count);
+int parse_num_range_disorder(const char *config_str,
+			     int bytes_count, bool ** mask);
+int generate_random_integer(int max_value);
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -247,4 +247,21 @@ enum {
  */
 #define STACKMAP_CLEANUP_THRESHOLD 50
 
+/*
+ * When the deepflow-agent is started, to avoid the sudden generation of Java symbol
+ * tables:
+ * - Delay the generation of symbol tables by 'java-symbol-file-refresh-defer-interval'
+ *   seconds.
+ * - Introduce an additional random value for each process's delay, on top of
+ *   the configuration specified above, to prevent the abrupt generation of symbol file
+ *   for a large number of processes.
+ *
+ * For non-Java programs, symbol loading will also be randomly delayed
+ * (time range: 0 to PROFILER_DEFER_RANDOM_MAX).
+ *
+ * The random value has a maximum limit specified above(measured in seconds). 
+ */
+
+#define PROFILER_DEFER_RANDOM_MAX 60 // 60 seconds
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -224,4 +224,27 @@ enum {
  */
 #define JAVA_POD_EXTRA_SPACE_MMA 307200 // 300Ki
 
+/*
+ * The perf profiler utilizes a perf buffer (per CPUs) for transporting stack data,
+ * which may lead to out-of-order behavior in a multi-core environment, as illustrated
+ * below:
+ *
+ * User-received  eBPF (Kernel) Data  Description
+ * Order          recv-time (ns)	     
+ * ---------------------------------------------------------
+ * 0	       1043099273143475	   First stack data with stack ID 'A'
+ * 1	       1043099276726460    Successfully removed 'A' from the stack map
+ * 2	       1043099169934151	   Second stack data with stack ID also 'A'
+ *                                 (failed lookup in stack map for 'A')
+ * 3	       1043099314811542	   Attempted duplicate removal of 'A' from the
+ *                                 stack map, failed
+ * ---------------------------------------------------------
+ *
+ * We have introduced a threshold to delay the removal of 'A' from the stack map to
+ * avoid the aforementioned out-of-order scenario. After each iteration, stack map
+ * cleanup is performed only if the number of entries in the stack map exceeds this
+ * threshold.
+ */
+#define STACKMAP_CLEANUP_THRESHOLD 50
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/profile/java/df_jattach.c
+++ b/agent/src/ebpf/user/profile/java/df_jattach.c
@@ -392,6 +392,38 @@ static inline void switch_to_root_ns(int root_fd)
 	df_exit_ns(root_fd);
 }
 
+static inline i64 get_symbol_file_size(int pid, int ns_pid, bool is_target)
+{
+	char path[PERF_PATH_SZ];
+	if (is_target)
+		snprintf(path, sizeof(path), DF_AGENT_PATH_FMT ".map",
+			 pid, ns_pid);
+	else
+		snprintf(path, sizeof(path),
+			 DF_AGENT_LOCAL_PATH_FMT ".map", pid);
+
+	if (access(path, F_OK)) {
+		return -1;
+	}
+
+	struct stat st;
+	if (stat(path, &st) == 0) {
+		return (i64) st.st_size;
+	}
+
+	return -1;
+}
+
+i64 get_target_symbol_file_sz(int pid, int ns_pid)
+{
+	return get_symbol_file_size(pid, ns_pid, true);
+}
+
+i64 get_local_symbol_file_sz(int pid, int ns_pid)
+{
+	return get_symbol_file_size(pid, ns_pid, false);
+}
+
 int copy_file_from_target_ns(int pid, int ns_pid, const char *file_type)
 {
 	char target_path[PERF_PATH_SZ];

--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -27,4 +27,5 @@ void clear_local_perf_files(int pid);
 bool is_same_mntns(int target_pid);
 i64 get_target_symbol_file_sz(int pid, int ns_pid);
 i64 get_local_symbol_file_sz(int pid, int ns_pid);
+void __unused clear_old_target_perf_files(int pid);
 #endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -25,5 +25,6 @@ void clear_target_ns(int pid, int target_ns_pid);
 void clear_target_ns_so(int pid, int target_ns_pid);
 void clear_local_perf_files(int pid);
 bool is_same_mntns(int target_pid);
-void __unused clear_old_target_perf_files(int pid);
+i64 get_target_symbol_file_sz(int pid, int ns_pid);
+i64 get_local_symbol_file_sz(int pid, int ns_pid);
 #endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.c
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.c
@@ -81,7 +81,7 @@ void add_java_syms_update_task(struct symbolizer_proc_info *p_info)
 	task->p = p_info;
 
 	pthread_mutex_lock(&list_lock);
-	p_info->use += 1;
+	AO_INC(&p_info->use);
 	list_add_tail(&task->list, &java_syms_update_tasks_head);
 	pthread_mutex_unlock(&list_lock);
 }

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.c
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.c
@@ -66,7 +66,7 @@ void gen_java_symbols_file(int pid, bool * need_update)
 							"log")) {
 				ebpf_warning("Copy pid %d files failed\n", pid);
 			} else {
-				ebpf_debug
+				ebpf_info
 				    ("java need update cache pid %d target file"
 				     " size %ld local file size %ld\n",
 				     pid, target_sz, local_sz);

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.h
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.h
@@ -24,7 +24,7 @@ struct java_syms_update_task {
 	struct symbolizer_proc_info *p;
 };
 
-void gen_java_symbols_file(int pid);
+void gen_java_symbols_file(int pid, bool *need_update);
 void clean_local_java_symbols_files(int pid);
 void add_java_syms_update_task(struct symbolizer_proc_info *p_info);
 void java_syms_update_main(void *arg);

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -953,7 +953,7 @@ static void cp_reader_work(void *arg)
 			     get_socket_tracer_state() != TRACER_RUNNING)) {
 			if (g_enable_perf_sample)
 				set_enable_perf_sample(t, 0);
-			exec_proc_info_cache_update();
+			exec_symbol_cache_update();
 			sleep(1);
 			continue;
 		}

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -24,6 +24,7 @@
 #include <sys/stat.h>
 #include <bcc/perf_reader.h>
 #include "../config.h"
+#include "../utils.h"
 #include "../common.h"
 #include "../mem.h"
 #include "../log.h"
@@ -156,6 +157,13 @@ static pthread_mutex_t cpdbg_mutex;
 static bool cpdbg_enable;
 static uint32_t cpdbg_start_time;
 static uint32_t cpdbg_timeout;
+
+/* Record all stack IDs in each iteration for quick retrieval. */
+struct stack_ids_bitmap stack_ids;
+/* This vector table is used to remove a stack from the stack map. */
+static int *clear_stack_ids;
+
+static volatile u64 g_enable_perf_sample;
 
 static u64 get_process_lost_count(void)
 {
@@ -478,6 +486,22 @@ static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t * h,
 	}
 }
 
+static inline void add_stack_id_to_bitmap(int stack_id)
+{
+	if (stack_id < 0)
+		return;
+
+	if (!is_set_bitmap(stack_ids.bitmap, stack_id)) {
+		set_bitmap(stack_ids.bitmap, stack_id);
+		int ret = VEC_OK;
+		vec_add1(clear_stack_ids, stack_id, ret);
+		if (ret != VEC_OK) {
+			ebpf_warning("vec add failed\n");
+		}
+		stack_ids.count++;
+	}
+}
+
 static void aggregate_stack_traces(struct bpf_tracer *t,
 				   const char *stack_map_name,
 				   stack_str_hash_t * stack_str_hash,
@@ -518,6 +542,9 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 
 		if (v->userstack == -EEXIST)
 			stack_trace_lost++;
+
+		add_stack_id_to_bitmap(v->kernstack);
+		add_stack_id_to_bitmap(v->userstack);
 
 		/* Total iteration count for this iteration. */
 		(*count)++;
@@ -625,6 +652,21 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 	vec_free(raw_stack_data);
 }
 
+static void set_enable_perf_sample(struct bpf_tracer *t, u64 enable_flag)
+{
+	if (bpf_table_set_value(t, MAP_PROFILER_STATE_MAP,
+				ENABLE_IDX, &enable_flag) == false) {
+		ebpf_warning("profiler state map update error."
+			     "(%s enable_flag %lu) - %s\n",
+			     MAP_PROFILER_STATE_MAP,
+			     enable_flag, strerror(errno));
+	}
+
+	g_enable_perf_sample = enable_flag;
+
+	ebpf_info("%s() success, enable_flag:%d\n", __func__, enable_flag);
+}
+
 static void process_bpf_stacktraces(struct bpf_tracer *t,
 				    struct bpf_perf_reader *r_a,
 				    struct bpf_perf_reader *r_b)
@@ -696,6 +738,8 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 		}
 	}
 
+	stack_ids.count = 0;
+
 	if (nfds > 0) {
 
 	      check_again:
@@ -736,6 +780,28 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 	}
 
 release_iter:
+
+	if (stack_ids.count != vec_len(clear_stack_ids)) {
+		ebpf_warning
+		    ("stack_ids.count(%lu) != vec_len(clear_stack_ids)(%d)",
+		     stack_ids.count, vec_len(clear_stack_ids));
+	}
+
+	int *sid;
+	vec_foreach(sid, clear_stack_ids) {
+		int id = *sid;
+		if (!bpf_table_delete_key(t, stack_map_name, (u64) id)) {
+			ebpf_warning
+			    ("stack_map_name %s, delete failed, stack-ID %d, flag 0x%X\n",
+			     stack_map_name, id,
+			     is_set_bitmap(stack_ids.bitmap, id));
+		}
+
+		clear_bitmap(stack_ids.bitmap, id);
+	}
+
+	vec_free(clear_stack_ids);
+
 	/* Now that we've consumed the data, reset the sample count in BPF. */
 	sample_cnt_val = 0;
 	bpf_table_set_value(t, MAP_PROFILER_STATE_MAP,
@@ -764,8 +830,12 @@ static void cp_reader_work(void *arg)
 	reader_b = &t->readers[1];
 
 	for (;;) {
-		if (unlikely(profiler_stop == 1))
+		if (unlikely(profiler_stop == 1)) {
+			if (g_enable_perf_sample)
+				set_enable_perf_sample(t, 0);
+
 			goto exit;
+		}
 
 		/* 
 		 * Waiting for the regular expression to be configured
@@ -779,10 +849,15 @@ static void cp_reader_work(void *arg)
 		 */
 		if (unlikely(!regex_existed ||
 			     get_socket_tracer_state() != TRACER_RUNNING)) {
-			exec_symbol_cache_update();
+			if (g_enable_perf_sample)
+				set_enable_perf_sample(t, 0);
+			exec_proc_info_cache_update();
 			sleep(1);
 			continue;
 		}
+
+		if (unlikely(!g_enable_perf_sample))
+			set_enable_perf_sample(t, 1);
 
 		tracer_reader_lock(t);
 		process_bpf_stacktraces(t, reader_a, reader_b);
@@ -825,6 +900,9 @@ static int create_profiler(struct bpf_tracer *tracer)
 	/* load ebpf perf profiler */
 	if (tracer_bpf_load(tracer))
 		return ETR_LOAD;
+
+	set_enable_perf_sample(tracer, 0);
+
 	/*
 	 * create reader for read eBPF-profiler data.
 	 * To implement eBPF perf-profiler double buffering output,
@@ -865,8 +943,7 @@ static int create_profiler(struct bpf_tracer *tracer)
 
 	ret = create_work_thread("java_update",
 				 &java_syms_update_thread,
-				 (void *)java_syms_update_work,
-				 (void *)tracer);
+				 (void *)java_syms_update_work, (void *)tracer);
 
 	if (ret) {
 		goto error;
@@ -1338,6 +1415,11 @@ int set_profiler_cpu_aggregation(int flag)
 	ebpf_info(LOG_CP_TAG
 		  "Set 'cpu_aggregation_flag' successful, value %d\n", flag);
 	return (0);
+}
+
+struct bpf_tracer *get_profiler_tracer(void)
+{
+	return profiler_tracer;
 }
 
 #else /* defined AARCH64_MUSL */

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -159,9 +159,12 @@ static uint32_t cpdbg_start_time;
 static uint32_t cpdbg_timeout;
 
 /* Record all stack IDs in each iteration for quick retrieval. */
-struct stack_ids_bitmap stack_ids;
+struct stack_ids_bitmap stack_ids_a;
+struct stack_ids_bitmap stack_ids_b;
 /* This vector table is used to remove a stack from the stack map. */
-static int *clear_stack_ids;
+static int *clear_stack_ids_a;
+static int *clear_stack_ids_b;
+static u64 stackmap_clear_failed_count;
 
 static volatile u64 g_enable_perf_sample;
 
@@ -486,19 +489,31 @@ static void push_and_release_stack_trace_msg(stack_trace_msg_hash_t * h,
 	}
 }
 
-static inline void add_stack_id_to_bitmap(int stack_id)
+static inline void add_stack_id_to_bitmap(int stack_id, bool is_a)
 {
 	if (stack_id < 0)
 		return;
 
-	if (!is_set_bitmap(stack_ids.bitmap, stack_id)) {
-		set_bitmap(stack_ids.bitmap, stack_id);
+	struct stack_ids_bitmap *ids;
+	if (is_a)
+		ids = &stack_ids_a;
+	else
+		ids = &stack_ids_b;
+
+	if (!is_set_bitmap(ids->bitmap, stack_id)) {
+		set_bitmap(ids->bitmap, stack_id);
 		int ret = VEC_OK;
-		vec_add1(clear_stack_ids, stack_id, ret);
+
+		if (is_a)
+			vec_add1(clear_stack_ids_a, stack_id, ret);
+		else
+			vec_add1(clear_stack_ids_b, stack_id, ret);
+
 		if (ret != VEC_OK) {
 			ebpf_warning("vec add failed\n");
 		}
-		stack_ids.count++;
+
+		ids->count++;
 	}
 }
 
@@ -506,7 +521,7 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 				   const char *stack_map_name,
 				   stack_str_hash_t * stack_str_hash,
 				   stack_trace_msg_hash_t * msg_hash,
-				   u32 * count)
+				   u32 * count, bool use_a_map)
 {
 	struct stack_trace_key_t *v;
 	vec_foreach(v, raw_stack_data) {
@@ -543,8 +558,8 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 		if (v->userstack == -EEXIST)
 			stack_trace_lost++;
 
-		add_stack_id_to_bitmap(v->kernstack);
-		add_stack_id_to_bitmap(v->userstack);
+		add_stack_id_to_bitmap(v->kernstack, use_a_map);
+		add_stack_id_to_bitmap(v->userstack, use_a_map);
 
 		/* Total iteration count for this iteration. */
 		(*count)++;
@@ -667,6 +682,60 @@ static void set_enable_perf_sample(struct bpf_tracer *t, u64 enable_flag)
 	ebpf_info("%s() success, enable_flag:%d\n", __func__, enable_flag);
 }
 
+static void cleanup_stackmap(struct bpf_tracer *t,
+			     const char *stack_map_name, bool is_a)
+{
+	struct stack_ids_bitmap *ids;
+	int *clear_stack_ids;
+
+	if (is_a) {
+		ids = &stack_ids_a;
+		clear_stack_ids = clear_stack_ids_a;
+	} else {
+		ids = &stack_ids_b;
+		clear_stack_ids = clear_stack_ids_b;
+	}
+
+	if (ids->count != vec_len(clear_stack_ids)) {
+		ebpf_warning
+		    ("stack_ids.count(%lu) != vec_len(clear_stack_ids)(%d)",
+		     ids->count, vec_len(clear_stack_ids));
+	}
+
+	/*
+	 * The perf profiler utilizes a perf buffer (per CPUs) for transporting stack data,
+	 * which may lead to out-of-order behavior in a multi-core environment.
+	 * We have employed a threshold to delay the cleanup of the stack map, reducing the
+	 * occurrence of premature clearing of stack entries caused by the disorder in stack
+	 * data.
+	 *
+	 * Examine the detailed explanation of 'STACKMAP_CLEANUP_THRESHOLD' in
+	 * 'agent/src/ebpf/user/config.h'.
+	 */
+	if (ids->count >= STACKMAP_CLEANUP_THRESHOLD) {
+		int *sid;
+		vec_foreach(sid, clear_stack_ids) {
+			int id = *sid;
+			if (!bpf_table_delete_key(t, stack_map_name, (u64) id)) {
+				/*
+				 * It may be due to the disorder in the perf buffer transmission,
+				 * leading to the repetitive deletion of the same stack ID.
+				 */
+				stackmap_clear_failed_count++;
+			}
+
+			clear_bitmap(ids->bitmap, id);
+		}
+
+		if (is_a)
+			vec_free(clear_stack_ids_a);
+		else
+			vec_free(clear_stack_ids_b);
+
+		ids->count = 0;
+	}
+}
+
 static void process_bpf_stacktraces(struct bpf_tracer *t,
 				    struct bpf_perf_reader *r_a,
 				    struct bpf_perf_reader *r_b)
@@ -738,8 +807,6 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 		}
 	}
 
-	stack_ids.count = 0;
-
 	if (nfds > 0) {
 
 	      check_again:
@@ -757,10 +824,10 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 		 * data aggregation will be blocked if there is no data.
 		 */
 		aggregate_stack_traces(t, stack_map_name, &g_stack_str_hash,
-				       &g_msg_hash, &count);
+				       &g_msg_hash, &count, using_map_set_a);
 
 		/*
-		 * To ensure that all data in the perf ring-buffer is processed
+		 * To ensure that all data in the perf ring-buffer is procenssed
 		 * in this iteration, as this iteration will clean up all the
 		 * data recorded in the stackmap, any residual data in the perf
 		 * ring-buffer will be carried over to the next iteration for
@@ -781,26 +848,7 @@ static void process_bpf_stacktraces(struct bpf_tracer *t,
 
 release_iter:
 
-	if (stack_ids.count != vec_len(clear_stack_ids)) {
-		ebpf_warning
-		    ("stack_ids.count(%lu) != vec_len(clear_stack_ids)(%d)",
-		     stack_ids.count, vec_len(clear_stack_ids));
-	}
-
-	int *sid;
-	vec_foreach(sid, clear_stack_ids) {
-		int id = *sid;
-		if (!bpf_table_delete_key(t, stack_map_name, (u64) id)) {
-			ebpf_warning
-			    ("stack_map_name %s, delete failed, stack-ID %d, flag 0x%X\n",
-			     stack_map_name, id,
-			     is_set_bitmap(stack_ids.bitmap, id));
-		}
-
-		clear_bitmap(stack_ids.bitmap, id);
-	}
-
-	vec_free(clear_stack_ids);
+	cleanup_stackmap(t, stack_map_name, using_map_set_a);
 
 	/* Now that we've consumed the data, reset the sample count in BPF. */
 	sample_cnt_val = 0;
@@ -1025,6 +1073,7 @@ static void print_cp_tracer_status(struct bpf_tracer *t)
 	ebpf_info("\n\n----------------------------\nrecv envent:\t%lu\n"
 		  "process-cnt:\t%lu\nkern_lost:\t%lu process_lost_count:\t%lu "
 		  "stack_table_data_miss:\t%lu\n"
+		  "stackmap_clear_failed_count\t%lu\n"
 		  "stack_trace_lost:\t%lu\ntransfer_count:\t%lu "
 		  "iter_count_avg:\t%.2lf\nalloc_b:\t%lu bytes "
 		  "free_b:\t%lu bytes use:\t%lu bytes\n"
@@ -1036,8 +1085,8 @@ static void print_cp_tracer_status(struct bpf_tracer *t)
 		  "----------------------------\n\n",
 		  atomic64_read(&t->recv), process_count,
 		  atomic64_read(&t->lost), get_process_lost_count(),
-		  get_stack_table_data_miss_count(), stack_trace_lost,
-		  transfer_count,
+		  get_stack_table_data_miss_count(),
+		  stackmap_clear_failed_count, stack_trace_lost, transfer_count,
 		  ((double)atomic64_read(&t->recv) / (double)transfer_count),
 		  alloc_b, free_b, alloc_b - free_b, output_count,
 		  sample_drop_cnt, output_err_cnt, iter_max_cnt);
@@ -1051,11 +1100,13 @@ static void print_profiler_status(struct bpf_tracer *t, u64 iter_count,
 	get_mem_stat(&alloc_b, &free_b);
 	ebpf_debug("\n\n----------------------------\nrecv envent:\t%lu\n"
 		   "kern_lost:\t%lu\nstack_trace_lost:\t%lu\n"
+		   "stackmap_clear_failed_count\t%lu\n"
 		   "ransfer_count:\t%lu iter_count:\t%lu\nall"
 		   "oc_b:\t%lu bytes free_b:\t%lu bytes use:\t%lu bytes\n"
 		   "stack_str_hash.hit_count %lu\nstack_trace_msg_hash hit %lu\n",
 		   atomic64_read(&t->recv), atomic64_read(&t->lost),
-		   stack_trace_lost, transfer_count, iter_count,
+		   stack_trace_lost, stackmap_clear_failed_count,
+		   transfer_count, iter_count,
 		   alloc_b, free_b, alloc_b - free_b,
 		   h->hit_hash_count, msg_h->hit_hash_count);
 }

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -155,4 +155,6 @@ void process_stack_trace_data_for_flame_graph(stack_trace_msg_t *val);
 void release_flame_graph_hash(void);
 int set_profiler_regex(const char *pattern);
 int set_profiler_cpu_aggregation(int flag);
+struct bpf_tracer *get_profiler_tracer(void);
+void set_enable_perf_sample(struct bpf_tracer *t, u64 enable_flag);
 #endif /* DF_USER_PERF_PROFILER_H */

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -73,8 +73,8 @@ typedef struct {
 		/* Matching and combining for process/thread name. */
 		struct {
 			u8 comm[TASK_COMM_LEN];
-			u64 u_stack_id: 26,
-			    k_stack_id: 26,
+			u64 pid: 26,
+			    reserved: 26,
 			    cpu: 12;
 		} c_k;
 	};

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -17,6 +17,7 @@
 #ifndef DF_USER_PERF_PROFILER_H
 #define DF_USER_PERF_PROFILER_H
 #include "../bihash_24_8.h"
+#include "../../kernel/include/perf_profiler.h"
 
 /*
  * stack_trace_msg_hash, used to store stack trace messages and
@@ -140,6 +141,11 @@ typedef struct {
 	u64 data_ptr;
 	u8 data[0];
 } stack_trace_msg_t;
+
+struct stack_ids_bitmap {
+	u64 count;
+	u8 bitmap[STACK_MAP_ENTRIES / 8];
+} __attribute__((packed));
 
 int stop_continuous_profiler(void);
 int start_continuous_profiler(int freq, int java_syms_space_limit,

--- a/agent/src/ebpf/user/profile/stringifier.c
+++ b/agent/src/ebpf/user/profile/stringifier.c
@@ -188,7 +188,8 @@ static char *symbol_name_fetch(pid_t pid, struct bcc_symbol *sym)
 	return ptr;
 }
 
-static char *resolve_addr(pid_t pid, u64 address, bool is_create, void *info_p)
+static char *resolve_addr(struct bpf_tracer *t, pid_t pid, u64 address,
+			  bool is_create, void *info_p)
 {
 	ASSERT(pid >= 0);
 
@@ -202,20 +203,6 @@ static char *resolve_addr(pid_t pid, u64 address, bool is_create, void *info_p)
 
 	int ret = symcache_resolve(pid, resolver, address, &sym);
 	if (ret == 0) {
-		if (info_p && pid > 0) {
-			struct symbolizer_proc_info *p = info_p;
-			if (p->new_java_syms_file) {
-				/*
-				 * TODO @jiping
-				 * If you delete the local file perf-PID.map immediately,
-				 * it will leave many symbolic links in /tmp/perf-PID.map.
-				 * We need a better method to delete these map files. Currently,
-				 * they are first saved in the local directory '/tmp'.
-				 */
-				//clean_local_java_symbols_files(pid);
-				p->new_java_syms_file = false;
-			}
-		}
 		ptr = symbol_name_fetch(pid, &sym);
 		if (ptr) {
 			char *p = ptr;
@@ -268,7 +255,8 @@ finish:
 }
 
 static int get_stack_ips(struct bpf_tracer *t,
-			 const char *stack_map_name, int stack_id, u64 * ips)
+			 const char *stack_map_name, int stack_id, u64 * ips,
+			 u64 ts)
 {
 	ASSERT(stack_id >= 0);
 
@@ -285,7 +273,7 @@ static char *build_stack_trace_string(struct bpf_tracer *t,
 				      int stack_id,
 				      stack_str_hash_t * h,
 				      bool new_cache,
-				      int *ret_val, void *info_p)
+				      int *ret_val, void *info_p, u64 ts)
 {
 	ASSERT(pid >= 0 && stack_id >= 0);
 
@@ -301,7 +289,7 @@ static char *build_stack_trace_string(struct bpf_tracer *t,
 	u64 ips[PERF_MAX_STACK_DEPTH];
 	memset(ips, 0, sizeof(ips));
 	int ret;
-	if ((ret = get_stack_ips(t, stack_map_name, stack_id, ips))) {
+	if ((ret = get_stack_ips(t, stack_map_name, stack_id, ips, ts))) {
 		stack_table_data_miss++;
 		*ret_val = ret;
 		return NULL;
@@ -319,7 +307,7 @@ static char *build_stack_trace_string(struct bpf_tracer *t,
 		if (ips[i] == 0 || ips[i] == sentinel_addr)
 			continue;
 
-		str = resolve_addr(pid, ips[i], new_cache, info_p);
+		str = resolve_addr(t, pid, ips[i], new_cache, info_p);
 		if (str) {
 			symbol_array[i] = pointer_to_uword(str);
 			folded_size += strlen(str);
@@ -365,7 +353,7 @@ static char *folded_stack_trace_string(struct bpf_tracer *t,
 				       pid_t pid,
 				       const char *stack_map_name,
 				       stack_str_hash_t * h,
-				       bool new_cache, void *info_p)
+				       bool new_cache, void *info_p, u64 ts)
 {
 	ASSERT(pid >= 0 && stack_id >= 0);
 
@@ -384,7 +372,7 @@ static char *folded_stack_trace_string(struct bpf_tracer *t,
 	char *str = NULL;
 	int ret_val = 0;
 	str = build_stack_trace_string(t, stack_map_name, pid, stack_id,
-				       h, new_cache, &ret_val, info_p);
+				       h, new_cache, &ret_val, info_p, ts);
 
 	if (ret_val == ETR_NOTEXIST)
 		return NULL;
@@ -457,14 +445,16 @@ char *resolve_and_gen_stack_trace_str(struct bpf_tracer *t,
 	if (v->kernstack >= 0) {
 		k_trace_str = folded_stack_trace_string(t, v->kernstack,
 							0, stack_map_name,
-							h, new_cache, info_p);
+							h, new_cache, info_p,
+							v->timestamp);
 	}
 
 	if (v->userstack >= 0) {
 		u_trace_str = folded_stack_trace_string(t, v->userstack,
 							v->tgid,
 							stack_map_name,
-							h, new_cache, info_p);
+							h, new_cache, info_p,
+							v->timestamp);
 	}
 
 	/* 

--- a/agent/src/ebpf/user/profile/stringifier.c
+++ b/agent/src/ebpf/user/profile/stringifier.c
@@ -389,18 +389,6 @@ static char *folded_stack_trace_string(struct bpf_tracer *t,
 	if (ret_val == ETR_NOTEXIST)
 		return NULL;
 
-	/*
-	 * The stringifier clears stack-ids out of the stack traces table
-	 * when it first encounters them. If a stack-id is reused by a
-	 * different stack-trace-key, the stringifier returns its memoized
-	 * stack trace string.
-	 */
-	if (!bpf_table_delete_key(t, stack_map_name, (u64) stack_id)) {
-		ebpf_warning
-		    ("stack_map_name %s, delete failed, stack-ID %d\n",
-		     stack_map_name, stack_id);
-	}
-
 	if (str == NULL)
 		return NULL;
 

--- a/agent/src/ebpf/user/profile/stringifier.h
+++ b/agent/src/ebpf/user/profile/stringifier.h
@@ -44,6 +44,7 @@ char *resolve_and_gen_stack_trace_str(struct bpf_tracer *t,
 				      struct stack_trace_key_t *v,
 				      const char *stack_map_name,
 				      stack_str_hash_t *h,
-				      bool new_cache, void *info_p);
+				      bool new_cache,
+				      char *process_name, void *info_p);
 #endif /* AARCH64_MUSL */
 #endif /* DF_USER_STRINGIFIER_H */

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -178,11 +178,6 @@ struct bpf_socktrace_params {
 	struct bpf_offset_param_array offset_array;
 };
 
-struct clear_list_elem {
-	struct list_head list;
-	const char p[0];
-};
-
 /*
  * This structure is used for registration of additional events. 
  */

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -819,7 +819,7 @@ static void *symbols_cache_update(symbol_caches_hash_t * h,
 		bcc_free_symcache((void *)kv->v.cache, kv->k.pid);
 		kv->v.cache = 0;
 	} else {
-		ebpf_debug("cache update PID %d NAME %s\n", kv->k.pid, p->comm);
+		ebpf_info("cache update PID %d NAME %s\n", kv->k.pid, p->comm);
 		add_symcache_count++;
 	}
 
@@ -1008,17 +1008,8 @@ static int __unused free_symbolizer_kvp_cb(symbol_caches_hash_kv * kv,
 void release_symbol_caches(void)
 {
 	/* Update symbol_cache hash from cache_del_pids. */
-	exec_proc_info_cache_update();
+	exec_symbol_cache_update();
 
-	/*
-	 * Due to socket data being queried by this hash, there is no synchronization
-	 * protection here. release_symbol_caches() is called only for testing purposes,
-	 * so ensure smooth testing, let's temporarily remove the code for releasing
-	 * hash resources.
-	 * TODO(@jiping), add a synchronization lock for protection.
-	 */
-
-#if 0
 	/* user symbol caches release */
 	u64 elems_count = 0;
 	symbol_caches_hash_t *h = &syms_cache_hash;

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -792,6 +792,40 @@ fetch_proc_info:
 	*ptr = p;
 }
 
+static void *symbols_cache_update(symbol_caches_hash_t * h,
+				  struct symbolizer_cache_kvp *kv,
+				  struct symbolizer_proc_info *p)
+{
+	if (kv->v.cache)
+		bcc_free_symcache((void *)kv->v.cache, kv->k.pid);
+
+	kv->v.cache =
+	    pointer_to_uword(bcc_symcache_new((int)kv->k.pid, &lazy_opt));
+
+	if (kv->v.cache <= 0) {
+		kv->v.cache = 0;
+		goto failed;
+	}
+
+	if (symbol_caches_hash_add_del(h, (symbol_caches_hash_kv *)
+				       kv, 1 /* is_add */ )) {
+		ebpf_warning
+		    ("symbol_caches_hash_add_del() failed.(pid %d)\n",
+		     (int)kv->k.pid);
+		bcc_free_symcache((void *)kv->v.cache, kv->k.pid);
+		kv->v.cache = 0;
+	} else {
+		add_symcache_count++;
+	}
+
+failed:
+	p->unknown_syms_found = false;
+	p->update_syms_table_time = 0;
+	p->new_java_syms_file = false;
+	p->add_task_list = false;
+	return (void *)kv->v.cache;
+}
+
 /*
  * Cache for obtaining symbol information of the binary
  * executable corresponding to a PID, and rebuilding it
@@ -812,6 +846,9 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 		sys_btime_msecs = get_sys_btime_msecs();
 	}
 
+	if (!new_cache)
+		return NULL;
+
 	if (pid == 0)
 		return k_resolver;
 
@@ -823,9 +860,6 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 	kv.v.cache = 0;
 	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
 				      (symbol_caches_hash_kv *) & kv) == 0) {
-		if (!new_cache)
-			return NULL;
-
 		p = (struct symbolizer_proc_info *)kv.v.proc_info_p;
 		u64 curr_time = current_sys_time_secs();
 		if (p->verified) {
@@ -834,52 +868,51 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 			 * the address of the Java process, we need to re-obtain the sy-
 			 * mbols table of the Java process after a delay.
 			 */
-			if (p->is_java && p->unknown_syms_found
+			if ((p->unknown_syms_found
+			     || (void *)kv.v.cache == NULL)
 			    && p->update_syms_table_time == 0) {
-				p->update_syms_table_time =
-				    curr_time + get_java_syms_fetch_delay();
+				if (p->is_java) {
+					p->update_syms_table_time =
+					    curr_time +
+					    get_java_syms_fetch_delay();
+				}
+
+				/*
+				 * When the deepflow-agent is started, to avoid the sudden
+				 * generation of Java symbol tables, additional random value
+				 * for each java process's delay.
+				 */
+				if (kv.v.cache == 0)
+					p->update_syms_table_time +=
+					    generate_random_integer
+					    (PROFILER_DEFER_RANDOM_MAX);
 			}
 
 			if (p->update_syms_table_time > 0
 			    && curr_time >= p->update_syms_table_time) {
-				/* Update java symbols table, will be executed during
-				 * the next Java symbolication */
+				if (p->is_java) {
+					/* Update java symbols table, will be executed during
+					 * the next Java symbolication */
 
-				/* Has the symbol file for Java been generated ? */
-				if (AO_GET(&p->new_java_syms_file)) {
-					if (kv.v.cache) {
-						bcc_free_symcache((void *)kv.v.
-								  cache,
-								  kv.k.pid);
-						kv.v.cache =
-						    pointer_to_uword
-						    (bcc_symcache_new
-						     ((int)kv.k.pid,
-						      &lazy_opt));
-						if (symbol_caches_hash_add_del
-						    (h,
-						     (symbol_caches_hash_kv *) &
-						     kv, 1 /* is_add */ )) {
-							ebpf_warning
-							    ("symbol_caches_hash_add_del() failed.(pid %d)\n",
-							     (int)kv.k.pid);
+					/* Has the symbol file for Java been generated ? */
+					if (AO_GET(&p->new_java_syms_file)) {
+						return symbols_cache_update(h,
+									    &kv,
+									    p);
+					} else {
+						if (!p->add_task_list) {
+							add_java_syms_update_task
+							    (p);
+							p->add_task_list = true;
 						}
 					}
-
-					p->unknown_syms_found = false;
-					p->update_syms_table_time = 0;
-					p->new_java_syms_file = false;
-					p->add_task_list = false;
 				} else {
-					if (!p->add_task_list) {
-						add_java_syms_update_task(p);
-						p->add_task_list = true;
-					}
+					return symbols_cache_update(h, &kv, p);
 				}
 			}
 
-			if (p->is_java && (void *)kv.v.cache == NULL) {
-				gen_java_symbols_file(pid);
+			if (kv.v.cache == 0) {
+				return NULL;
 			}
 		} else {
 			/* Ensure that newly launched JAVA processes are detected. */
@@ -888,21 +921,6 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 
 		if (kv.v.cache)
 			return (void *)kv.v.cache;
-
-		kv.v.cache = pointer_to_uword(bcc_symcache_new(pid, &lazy_opt));
-		if (kv.v.cache > 0)
-			add_symcache_count++;
-
-		if (symbol_caches_hash_add_del
-		    (h, (symbol_caches_hash_kv *) & kv, 1 /* is_add */ )) {
-			ebpf_warning
-			    ("symbol_caches_hash_add_del() failed.(pid %d)\n",
-			     pid);
-			free_symbolizer_cache_kvp(&kv);
-			return NULL;
-		}
-
-		return (void *)kv.v.cache;
 	}
 
 	return NULL;
@@ -971,7 +989,8 @@ int create_and_init_symbolizer_caches(void)
 	return ETR_OK;
 }
 
-static int free_symbolizer_kvp_cb(symbol_caches_hash_kv * kv, void *ctx)
+static int __unused free_symbolizer_kvp_cb(symbol_caches_hash_kv * kv,
+					   void *ctx)
 {
 	struct symbolizer_cache_kvp *sym = (struct symbolizer_cache_kvp *)kv;
 	free_symbolizer_cache_kvp(sym);
@@ -982,8 +1001,17 @@ static int free_symbolizer_kvp_cb(symbol_caches_hash_kv * kv, void *ctx)
 void release_symbol_caches(void)
 {
 	/* Update symbol_cache hash from cache_del_pids. */
-	exec_symbol_cache_update();
+	exec_proc_info_cache_update();
 
+	/*
+	 * Due to socket data being queried by this hash, there is no synchronization
+	 * protection here. release_symbol_caches() is called only for testing purposes,
+	 * so ensure smooth testing, let's temporarily remove the code for releasing
+	 * hash resources.
+	 * TODO(@jiping), add a synchronization lock for protection.
+	 */
+
+#if 0
 	/* user symbol caches release */
 	u64 elems_count = 0;
 	symbol_caches_hash_t *h = &syms_cache_hash;

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -826,6 +826,24 @@ failed:
 	return (void *)kv->v.cache;
 }
 
+static inline void java_expired_update(symbol_caches_hash_t * h,
+				       struct symbolizer_cache_kvp *kv,
+				       struct symbolizer_proc_info *p)
+{
+	/* Update java symbols table, will be executed during
+	 * the next Java symbolication */
+
+	/* Has the symbol file for Java been generated ? */
+	if (AO_GET(&p->new_java_syms_file)) {
+		symbols_cache_update(h, kv, p);
+	} else {
+		if (!p->add_task_list) {
+			add_java_syms_update_task(p);
+			p->add_task_list = true;
+		}
+	}
+}
+
 /*
  * Cache for obtaining symbol information of the binary
  * executable corresponding to a PID, and rebuilding it
@@ -891,28 +909,11 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 			if (p->update_syms_table_time > 0
 			    && curr_time >= p->update_syms_table_time) {
 				if (p->is_java) {
-					/* Update java symbols table, will be executed during
-					 * the next Java symbolication */
-
-					/* Has the symbol file for Java been generated ? */
-					if (AO_GET(&p->new_java_syms_file)) {
-						return symbols_cache_update(h,
-									    &kv,
-									    p);
-					} else {
-						if (!p->add_task_list) {
-							add_java_syms_update_task
-							    (p);
-							p->add_task_list = true;
-						}
-					}
+					java_expired_update(h, &kv, p);
+					return (void *)kv.v.cache;
 				} else {
 					return symbols_cache_update(h, &kv, p);
 				}
-			}
-
-			if (kv.v.cache == 0) {
-				return NULL;
 			}
 		} else {
 			/* Ensure that newly launched JAVA processes are detected. */

--- a/agent/src/ebpf/user/symbol.h
+++ b/agent/src/ebpf/user/symbol.h
@@ -67,6 +67,8 @@ struct symbolizer_proc_info {
 	bool add_task_list;
 	/* Have a new perf map file ? */
 	bool new_java_syms_file;
+	/* Java symbol cache needs updating? */
+	bool cache_need_update;
 	/* Unknown symbols was found, and it is currently mainly used to
 	 * obtain the match of the Java process.*/
 	bool unknown_syms_found;

--- a/agent/src/ebpf/user/table.c
+++ b/agent/src/ebpf/user/table.c
@@ -99,9 +99,9 @@ bool bpf_table_delete_key(struct bpf_tracer *tracer,
 	int map_fd = map->fd;
 
 	if (bpf_delete_elem(map_fd, (void *)&key)) {
-		ebpf_warning("bpf_map_delete_elem, err tb_name:%s, key : %"
-			     PRIu64 ", err_message:%s\n", tb_name,
-			     key, strerror(errno));
+		ebpf_debug("bpf_map_delete_elem, err tb_name:%s, key : %"
+			   PRIu64 ", err_message:%s\n", tb_name,
+			   key, strerror(errno));
 		return false;
 	}
 

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -469,6 +469,40 @@ static inline void tracer_reader_unlock(struct bpf_tracer *t)
 	__atomic_clear(t->lock, __ATOMIC_RELEASE);
 }
 
+struct clear_list_elem {
+	struct list_head list;
+	const char p[0];
+};
+
+static bool inline insert_list(void *elt, uint32_t len, struct list_head *h)
+{
+	struct clear_list_elem *cle;
+	cle = calloc(sizeof(*cle) + len, 1);
+	if (cle == NULL) {
+		ebpf_warning("calloc() failed.\n");
+		return false;
+	}
+	memcpy((void *)cle->p, (void *)elt, len);
+	list_add_tail(&cle->list, h);
+	return true;
+}
+
+static int inline __reclaim_map(int map_fd, struct list_head *h)
+{
+	int count = 0;
+	struct list_head *p, *n;
+	struct clear_list_elem *cle;
+	list_for_each_safe(p, n, h) {
+		cle = container_of(p, struct clear_list_elem, list);
+		if (!bpf_delete_elem(map_fd, (void *)cle->p))
+			count++;
+		list_head_del(&cle->list);
+		free(cle);
+	}
+
+	return count;
+}
+
 #define CACHE_LINE_BYTES 64
 
 int set_allow_port_bitmap(void *bitmap);

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -135,6 +135,19 @@ do {                                                        			\
 	} 									\
 } while(0)
 
+#define probes_set_exit_symbol(t, fn)						\
+do {                                                        			\
+	char *func = (char*)calloc(PROBE_NAME_SZ, 1);             		\
+	if (func != NULL) {                                       		\
+		curr_idx = index++;                  		            	\
+		t->ksymbols[curr_idx].isret = true;                 	    	\
+		snprintf(func, PROBE_NAME_SZ, "kretprobe/%s", fn);           	\
+		t->ksymbols[curr_idx].func = func;                        	\
+	} else {								\
+		ebpf_error("no memory, probe (kretprobe/%s) set failed", fn); 	\
+	} 									\
+} while(0)
+
 #define probes_set_symbol(t, fn)						\
 do {                            						\
 	char *func = (char*)calloc(PROBE_NAME_SZ, 1);      			\

--- a/agent/src/ebpf/user/utils.h
+++ b/agent/src/ebpf/user/utils.h
@@ -19,17 +19,23 @@
  * SPDX-License-Identifier: GPL-2.0
  */
 
-#ifndef DF_UTILS_H
-#define DF_UTILS_H
+#ifndef DF_USER_UTILS_H
+#define DF_USER_UTILS_H
 
-#include <arpa/inet.h>
-#include "../../user/utils.h"
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a)    (sizeof(a) / sizeof(a[0]))
+#endif
 
-#undef __inline
-#define __inline inline __attribute__((__always_inline__))
+#ifndef unlikely
+#define unlikely(x)             __builtin_expect(!!(x), 0)
+#endif
 
-#define BPF_LEN_CAP(x, cap) (x < cap ? (x & (cap - 1)) : cap)
+#ifndef likely
+#define likely(x)               __builtin_expect(!!(x), 1)
+#endif
 
-#include "bpf_endian.h"
+#define is_set_bitmap(bitmap, idx) (bitmap[(idx) / 8] & (1 << ((idx) % 8)))
+#define set_bitmap(bitmap, idx)	(bitmap[(idx) / 8] |= 1 << ((idx) % 8))
+#define clear_bitmap(bitmap, idx) (bitmap[(idx) / 8] &= (~(1 << ((idx) % 8))))
 
-#endif /* DF_UTILS_H */
+#endif /* DF_USER_UTILS_H */


### PR DESCRIPTION
[[eBPF] Add enable flag for profiler & modify stackmap cleanup logic](https://github.com/deepflowio/deepflow/pull/4751/commits/cbbc29411f58f80549f9486e4d68326a60866193)

Add a startup switch to the profiler to ensure that all preparations are completed before enabling the eBPF profiler to start working. This prevents premature eBPF data collection, as the user-space program may not be ready, avoiding the occupation of numerous stack map entries.

The cleanup of the stack map is consolidated and performed after each iteration to avoid instances where certain entries might be overlooked during the cleanup process.

[[eBPF] Prevent data loss caused by the disorder of stack data](https://github.com/deepflowio/deepflow/pull/4751/commits/0b6464b2f83c798f6102153789d3f890ec54a8b2) 

The perf profiler utilizes a perf buffer (per CPUs) for transporting stack data,
which may lead to out-of-order behavior in a multi-core environment, as illustrated
below:
 ```
 User-received  eBPF (Kernel) Data  Description
 Order          recv-time (ns)
 ---------------------------------------------------------
 0           1043099273143475    First stack data with stack ID 'A'
 1           1043099276726460    Successfully removed 'A' from the stack map
 2           1043099169934151    Second stack data with stack ID also 'A'
                                 (failed lookup in stack map for 'A')
 3           1043099314811542    Attempted duplicate removal of 'A' from the
                                 stack map, failed
 ---------------------------------------------------------
 ```
We have introduced a threshold to delay the removal of 'A' from the stack map to
avoid the aforementioned out-of-order scenario. After each iteration, stack map
cleanup is performed only if the number of entries in the stack map exceeds this
threshold.

[[eBPF] Cleaning the stackmap in the event of stack data loss](https://github.com/deepflowio/deepflow/pull/4751/commits/9ccde460cca761c7b817ff3d1a16ec7817a06993) 

If data loss occurs due to the user-space receiver program
being too busy and not promptly fetching data from the perf
buffer, it is necessary to clean the stack map once to prevent
excessive remnants of stack data from affecting the acquisition
of new stack data (i.e., eBPF using the bpf_get_stackid()
interface will return -EEXIST).

[[eBPF] Symbols loading with random delay](https://github.com/deepflowio/deepflow/pull/4751/commits/e3f071fcf9abc66be1a3db79eafdfa5b28669563) 

When the deepflow-agent is started, to avoid the sudden generation of Java symbol
tables:
- Delay the generation of symbol tables by 'java-symbol-file-refresh-defer-interval'
  seconds.
- Introduce an additional random value for each process's delay, on top of
  the configuration specified above, to prevent the abrupt generation of symbol file
  for a large number of processes.

For non-Java programs, symbol loading will also be randomly delayed
(time range: 0 to PROFILER_DEFER_RANDOM_MAX).

The random value('PROFILER_DEFER_RANDOM_MAX') has a maximum limit specified
above (measured in seconds).

'PROFILER_DEFER_RANDOM_MAX' default 60 seconds

[[eBPF] Upload a node-level function stack for each node](https://github.com/deepflowio/deepflow/pull/4751/commits/0b5f58a0d43cd67e87957b663b7f86dced9d24eb) 

On top of the existing function call stack, additionally upload a special two-layer function stack:
```
PID: 0
Process Name: Total
Function Stack:
First Layer: Process Name
Second Layer: Thread Name
```

[[eBPF] Determine whether to update cache based on size of Java symbol…](https://github.com/deepflowio/deepflow/pull/4751/commits/4d656ae138062150fcfc5ca939c8ef0ec0c460e2) 

When updating the Java symbol file, only update the Java symbol cache if
the size of the new Java symbol file is greater than the size of the
previous file; otherwise, do not update the cache.
### This PR is for:

- Agent



#### Affected branches
- main
- v6.3

