### PR TITLE
[eBPf] Correct the inaccurate stack string length error

### DIFF
--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -673,7 +673,7 @@ static void aggregate_stack_traces(struct bpf_tracer *t,
 				snprintf((char *)&msg->data[0], str_len, "%s",
 					 trace_str);
 
-			msg->data_len = str_len - 1;
+			msg->data_len = strlen(msg->data);
 			clib_mem_free(trace_str);
 			kv.msg_ptr = pointer_to_uword(msg);
 


### PR DESCRIPTION


### This PR is for:


- Agent


#### Affected branches
- main
- 6.3