### PR TITLE
[Agent] fix http2 parser

### DIFF
--- a/agent/crates/public/src/utils/net/h2pack/parser.rs
+++ b/agent/crates/public/src/utils/net/h2pack/parser.rs
@@ -42,8 +42,8 @@ bitflags! {
     }
 }
 
-pub struct Parser<'a> {
-    decoder: Decoder<'a>,
+pub struct Parser {
+    decoder: Decoder<'static>,
 }
 
 fn parse_int(buf: &[u8], prefix: u8) -> Result<(usize, usize), ParseError> {
@@ -90,8 +90,8 @@ fn parse_int(buf: &[u8], prefix: u8) -> Result<(usize, usize), ParseError> {
     Err(ParseError::NotEnoughOctets)
 }
 
-impl Parser<'_> {
-    pub fn new() -> Parser<'static> {
+impl Parser {
+    pub fn new() -> Parser {
         Parser {
             decoder: Decoder::new(),
         }

--- a/agent/src/flow_generator/protocol_logs/dns.rs
+++ b/agent/src/flow_generator/protocol_logs/dns.rs
@@ -154,7 +154,7 @@ impl From<DnsInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct DnsLog {
     perf_stats: Option<L7PerfStats>,
 }

--- a/agent/src/flow_generator/protocol_logs/fastcgi.rs
+++ b/agent/src/flow_generator/protocol_logs/fastcgi.rs
@@ -305,7 +305,7 @@ impl FastCGIRecord {
     }
 }
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Default)]
 pub struct FastCGILog {
     perf_stats: Option<L7PerfStats>,
 }

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -243,9 +243,8 @@ impl From<KafkaInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Serialize, Default)]
+#[derive(Default)]
 pub struct KafkaLog {
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
@@ -208,7 +208,7 @@ impl From<MqttInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct MqttLog {
     msg_type: LogMessageType,
     status: L7ResponseStatus,

--- a/agent/src/flow_generator/protocol_logs/plugin/custom_wrap.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/custom_wrap.rs
@@ -15,13 +15,12 @@
  */
 
 use public::l7_protocol::L7Protocol;
-use serde::Serialize;
 
 use crate::common::l7_protocol_log::{L7ParseResult, L7ProtocolParserInterface};
 
 use super::{all_plugin_log_parser, CustomLog};
 
-#[derive(Default, Debug, Serialize)]
+#[derive(Default)]
 pub struct CustomWrapLog {
     pub(super) parser: Option<CustomLog>,
 }

--- a/agent/src/flow_generator/protocol_logs/plugin/mod.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/mod.rs
@@ -16,7 +16,6 @@
 
 use enum_dispatch::enum_dispatch;
 use public::l7_protocol::{CustomProtocol, L7Protocol, L7ProtocolEnum};
-use serde::Serialize;
 use wasm::WasmLog;
 
 use crate::{
@@ -36,7 +35,6 @@ pub mod custom_wrap;
 pub mod shared_obj;
 pub mod wasm;
 
-#[derive(Debug, Serialize)]
 #[enum_dispatch(L7ProtocolParserInterface)]
 pub enum CustomLog {
     WasmLog(WasmLog),

--- a/agent/src/flow_generator/protocol_logs/plugin/shared_obj.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/shared_obj.rs
@@ -21,7 +21,6 @@ use std::{
 
 use log::error;
 use public::l7_protocol::{CustomProtocol, L7Protocol};
-use serde::Serialize;
 
 use crate::{
     common::{
@@ -45,11 +44,10 @@ use crate::{
 
 const RESULT_LEN: i32 = 8;
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct SoLog {
     proto_num: Option<u8>,
     proto_str: String,
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/plugin/wasm.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/wasm.rs
@@ -15,7 +15,6 @@
  */
 
 use public::l7_protocol::{CustomProtocol, L7Protocol};
-use serde::Serialize;
 
 use crate::{
     common::{
@@ -26,11 +25,10 @@ use crate::{
     flow_generator::{protocol_logs::L7ResponseStatus, Error, Result},
 };
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct WasmLog {
     proto_num: Option<u8>,
     proto_str: String,
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -225,9 +225,8 @@ impl From<DubboInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct DubboLog {
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -274,9 +274,8 @@ impl From<SofaRpcInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct SofaRpcLog {
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/sql/mongo.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mongo.rs
@@ -157,10 +157,9 @@ impl From<MongoDBInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct MongoDBLog {
     info: MongoDBInfo,
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -247,10 +247,9 @@ impl From<MysqlInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct MysqlLog {
     pub protocol_version: u8,
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -160,9 +160,8 @@ impl From<PostgreInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct PostgresqlLog {
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/sql/redis.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis.rs
@@ -164,11 +164,9 @@ impl From<RedisInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct RedisLog {
-    #[serde(skip)]
     has_request: bool,
-    #[serde(skip)]
     perf_stats: Option<L7PerfStats>,
 }
 

--- a/agent/src/flow_generator/protocol_logs/tls.rs
+++ b/agent/src/flow_generator/protocol_logs/tls.rs
@@ -427,7 +427,7 @@ impl From<TlsInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Default)]
 pub struct TlsLog {
     change_cipher_spec_count: u8,
     perf_stats: Option<L7PerfStats>,


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes http2 parser
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Instead of creating a parser for parsing each packet, create a parser for each flow
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
