### PR TITLE
[controller] set pod node network type is equal to lan in sub_domain

### DIFF
--- a/server/controller/cloud/sub_domain.go
+++ b/server/controller/cloud/sub_domain.go
@@ -540,13 +540,17 @@ func (c *Cloud) getSubDomainVInterfaces(
 	// 检查容器节点接口是否需要更新子网信息，并补充subDomainLcuuid
 	for _, vinterface := range resource.PodNodeVInterfaces {
 		networkLcuuid := vinterface.NetworkLcuuid
+		networkType := vinterface.Type
 		if updateNetworkLcuuid, ok := updatedVInterfaceLcuuidToNetworkLcuuid[vinterface.Lcuuid]; ok {
 			networkLcuuid = updateNetworkLcuuid
+		} else {
+			// for addtional route interface, set type = LAN
+			networkType = common.VIF_TYPE_LAN
 		}
 		retVInterfaces = append(retVInterfaces, model.VInterface{
 			Lcuuid:          vinterface.Lcuuid,
 			Name:            vinterface.Name,
-			Type:            vinterface.Type,
+			Type:            networkType,
 			Mac:             vinterface.Mac,
 			NetnsID:         vinterface.NetnsID,
 			VTapID:          vinterface.VTapID,
@@ -611,13 +615,27 @@ func (c *Cloud) getSubDomainNetworks(
 
 	// 遍历Networks，更新az和subDomain信息
 	for _, network := range []model.Network{
-		resource.PodNetwork, resource.PodServiceNetwork, resource.PodNodeNetwork,
+		resource.PodNetwork, resource.PodServiceNetwork,
 	} {
 		retNetworks = append(retNetworks, model.Network{
 			Lcuuid:          network.Lcuuid,
 			Name:            network.Name,
 			Label:           network.Label,
 			NetType:         network.NetType,
+			VPCLcuuid:       network.VPCLcuuid,
+			AZLcuuid:        azLcuuid,
+			RegionLcuuid:    network.RegionLcuuid,
+			SubDomainLcuuid: subDomainLcuuid,
+		})
+	}
+
+	// set podNodeNetwork netType = LAN
+	for _, network := range []model.Network{resource.PodNodeNetwork} {
+		retNetworks = append(retNetworks, model.Network{
+			Lcuuid:          network.Lcuuid,
+			Name:            network.Name,
+			Label:           network.Label,
+			NetType:         common.NETWORK_TYPE_LAN,
 			VPCLcuuid:       network.VPCLcuuid,
 			AZLcuuid:        azLcuuid,
 			RegionLcuuid:    network.RegionLcuuid,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


