### PR TITLE
[querier] add offset to fix range query timestamp for v6.3

### DIFF
--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -175,7 +175,9 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 				// range query, aggregation for time step
 				// rebuild `time` in range query, replace `toUnixTimestamp(time) as timestamp`
 				// time(time, x) means aggregation with time by interval x
-				metricsArray[0] = fmt.Sprintf("time(time, %d) AS %s", q.Hints.StepMs/1e3, PROMETHEUS_TIME_COLUMNS)
+				// calculate `offset` for range query
+				offset := q.Hints.StartMs % q.Hints.StepMs
+				metricsArray[0] = fmt.Sprintf("time(time, %d, 1, 0, %d) AS %s", q.Hints.StepMs/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS)
 			}
 
 			groupBy = make([]string, 0, len(q.Hints.Grouping)+1)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes range query timestamp error
#### Steps to reproduce the bug
- use range query with promql 
- use large query interval like `10m` or `30m`
#### Changes to fix the bug
- add offset for each query timestamp
#### Affected branches
- v6.3