### PR TITLE
[ingester] profile should fill deviceType/deviceId/ip from vtapInfo when empty

### DIFF
--- a/server/libs/grpc/grpc_platformdata.go
+++ b/server/libs/grpc/grpc_platformdata.go
@@ -1596,9 +1596,9 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 			if ip == "" {
 				ip = podNodeIp
 			}
+			info := Info{}
 			if ip != "" {
 				isIPv4, ip4, ip6 := parseIP(ip)
-				info := Info{}
 				var infoPtr *Info
 				if isIPv4 {
 					infoPtr = t.QueryIPV4Infos(epcId, ip4)
@@ -1607,15 +1607,17 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 				}
 				if infoPtr != nil {
 					info = *infoPtr
-					info.HitCount = new(uint64)
-					info.PodID = podId
-					info.PodClusterID = podClusterId
-					info.PodNSID = podNsId
-					info.PodGroupID = podGroupId
-					info.PodGroupType = podGroupType
-					podIDInfos[podId] = &info
 				}
+				info.IsIPv4, info.IP4, info.IP6 = isIPv4, ip4, ip6
 			}
+			info.HitCount = new(uint64)
+			info.PodID = podId
+			info.PodClusterID = podClusterId
+			info.PodNSID = podNsId
+			info.PodGroupID = podGroupId
+			info.PodGroupType = podGroupType
+			info.EpcID = epcId
+			podIDInfos[podId] = &info
 		}
 	}
 	t.podNameInfos = podNameInfos


### PR DESCRIPTION
when profile deviceType/deviceId/ip is invalid, should be filled from vtapInfo

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server

-->


#### Affected branches
- main
- v6.3

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


