### PR TITLE
[Agent] Fix get_ebpf_tcp_score identifies the incorrect server when ebpf gets disorder packet #22927 #23004

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1173,6 +1173,8 @@ impl FlowMap {
             );
             let (direction_score, need_reverse) = self.service_table.get_ebpf_tcp_score(
                 meta_packet.socket_role,
+                meta_packet.lookup_key.l2_end_0,
+                meta_packet.lookup_key.l2_end_1,
                 flow_src_key,
                 flow_dst_key,
             );


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes get_ebpf_tcp_score identifies the incorrect server when ebpf gets disorder packet #22927 #23004
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- When the ebpf is out of order, the direction cannot be determined according to socket_role, so direction_score can only be assigned after the direction is corrected
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
