### PR TITLE
[eBPF] If generating Java symbol file fails, no retries will occur

### DIFF
--- a/agent/src/ebpf/user/profile/java/df_jattach.c
+++ b/agent/src/ebpf/user/profile/java/df_jattach.c
@@ -392,6 +392,19 @@ static inline i64 get_symbol_file_size(int pid, int ns_pid, bool is_target)
 	return -1;
 }
 
+int target_symbol_file_access(int pid, int ns_pid, bool is_same_mnt)
+{
+	char path[PERF_PATH_SZ];
+	if (!is_same_mnt)
+		snprintf(path, sizeof(path), DF_AGENT_PATH_FMT ".map",
+			 pid, ns_pid);
+	else
+		snprintf(path, sizeof(path),
+			 DF_AGENT_LOCAL_PATH_FMT ".map", pid);
+
+	return access(path, F_OK);
+}
+
 i64 get_target_symbol_file_sz(int pid, int ns_pid)
 {
 	return get_symbol_file_size(pid, ns_pid, true);

--- a/agent/src/ebpf/user/profile/java/df_jattach.h
+++ b/agent/src/ebpf/user/profile/java/df_jattach.h
@@ -27,4 +27,5 @@ void clear_local_perf_files(int pid);
 bool is_same_mntns(int target_pid);
 i64 get_target_symbol_file_sz(int pid, int ns_pid);
 i64 get_local_symbol_file_sz(int pid, int ns_pid);
+int target_symbol_file_access(int pid, int ns_pid, bool is_same_mnt);
 #endif /* DF_JATTACH_H */

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.h
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.h
@@ -28,7 +28,7 @@ struct java_syms_update_task {
 	struct symbolizer_proc_info *p;
 };
 
-void gen_java_symbols_file(int pid, int *ret);
+void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred);
 void clean_local_java_symbols_files(int pid);
 void add_java_syms_update_task(struct symbolizer_proc_info *p_info);
 void java_syms_update_main(void *arg);

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.h
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.h
@@ -17,6 +17,10 @@
 #ifndef GEN_SYMS_FILE_H
 #define GEN_SYMS_FILE_H
 
+#define JAVA_SYMS_OK		0
+#define JAVA_SYMS_ERR		1
+#define JAVA_SYMS_NEED_UPDATE	2
+
 #define DF_JAVA_ATTACH_CMD "/usr/bin/deepflow-jattach"
 
 struct java_syms_update_task {
@@ -24,7 +28,7 @@ struct java_syms_update_task {
 	struct symbolizer_proc_info *p;
 };
 
-void gen_java_symbols_file(int pid, bool *need_update);
+void gen_java_symbols_file(int pid, int *ret);
 void clean_local_java_symbols_files(int pid);
 void add_java_syms_update_task(struct symbolizer_proc_info *p_info);
 void java_syms_update_main(void *arg);

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -769,6 +769,7 @@ static int config_symbolizer_proc_info(struct symbolizer_proc_info *p, int pid)
 	p->unknown_syms_found = false;
 	p->new_java_syms_file = false;
 	p->cache_need_update = false;
+	p->gen_java_syms_file_err = false;
 	p->netns_id = get_netns_id_from_pid(pid);
 	if (p->netns_id == 0)
 		return ETR_INVAL;
@@ -975,7 +976,8 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 			 */
 			if ((p->unknown_syms_found
 			     || (void *)kv.v.cache == NULL)
-			    && p->update_syms_table_time == 0) {
+			    && p->update_syms_table_time == 0
+			    && !p->gen_java_syms_file_err) {
 				if (p->is_java && p->unknown_syms_found) {
 					p->update_syms_table_time =
 					    curr_time +

--- a/agent/src/ebpf/user/symbol.h
+++ b/agent/src/ebpf/user/symbol.h
@@ -69,6 +69,8 @@ struct symbolizer_proc_info {
 	bool new_java_syms_file;
 	/* Java symbol cache needs updating? */
 	bool cache_need_update;
+	/* Did the generation of the Java symbol file encounter any exceptions? */
+	bool gen_java_syms_file_err;
 	/* Unknown symbols was found, and it is currently mainly used to
 	 * obtain the match of the Java process.*/
 	bool unknown_syms_found;


### PR DESCRIPTION
[eBPF] If generating Java symbol file fails, no retries will occur

If an exception occurs during the process of generating the Java symbol table, such as a failure to establish a connection with the target JVM, the symbol file will not be generated. In this case, no further symbol requests will be made to this Java process.

[[eBPF] Print Java symbol file failure info at intervals determined by 'java-symbol-file-refresh-defer-interval'](https://github.com/deepflowio/deepflow/pull/4935/commits/d4ee3718d7b9cc5b9a0d470da5eee274c3790a48) 

[[eBPF] Add stack string '[unknown start_thread?]'](https://github.com/deepflowio/deepflow/pull/4935/commits/ceaccfc4b6510baf5cf417f65ec83eaefd1ad4e0)

### This PR is for:

- Agent



#### Affected branches
- main
- v6.3
