### PR TITLE
[Agent] Fixes HSET mask problem

### DIFF
--- a/agent/src/flow_generator/protocol_logs/sql/redis_obfuscate.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis_obfuscate.rs
@@ -225,8 +225,8 @@ impl RedisTokenizer<'_> {
                         self.mask_start_index = 2;
                     }
                 }
-                HSET | HSETNX | LREM | LSET | SETBIT | SETEX | PSETEX | SETRANGE | ZINCRBY
-                | SMOVE | RESTORE => {
+                HSETNX | LREM | LSET | SETBIT | SETEX | PSETEX | SETRANGE | ZINCRBY | SMOVE
+                | RESTORE => {
                     self.mask_start_index = 3;
                 }
                 LINSERT => {
@@ -240,7 +240,7 @@ impl RedisTokenizer<'_> {
                     self.mask_start_index = 4;
                     self.mask_step = 3;
                 }
-                HMSET => {
+                HSET | HMSET => {
                     self.mask_start_index = 3;
                     self.mask_step = 2;
                 }
@@ -365,7 +365,7 @@ mod tests {
                     "HSET key field value \nHSETNX key field value\nBLAH",
                     Some("HSET key field ?\nHSETNX key field ?\nBLAH"),
                 ),
-                ("HSET key field value", Some("HSET key field ?")),
+                ("HSET key field value field1 value1 field2 value2", Some("HSET key field ? field1 ? field2 ?")),
                 ("HSETNX key field value", Some("HSETNX key field ?")),
                 ("LREM key count value", Some("LREM key count ?")),
                 ("LSET key index value", Some("LSET key index ?")),


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes HSET mask problem
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- before: "HSET key field value field1 value1 field2 value2" has been masked to "HSET key field ? field1 value1 field2 value2"
- after: "HSET key field value field1 value1 field2 value2" has been masked to "HSET key field ? field1 ? field2 ?"
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

