### PR TITLE
[eBPF] Fixing Java symbol cache not updating in RPM deployment

### DIFF
--- a/agent/src/ebpf/user/profile/java/gen_syms_file.c
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.c
@@ -73,6 +73,9 @@ void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred)
 			 DF_AGENT_LOCAL_PATH_FMT ".log");
 	}
 
+	i64 curr_local_sz;
+	curr_local_sz = get_local_symbol_file_sz(pid, target_ns_pid);
+
 	exec_command(DF_JAVA_ATTACH_CMD, args);
 
 	if (target_symbol_file_access(pid, target_ns_pid, is_same_mnt) != 0) {
@@ -83,8 +86,7 @@ void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred)
 
 	if (!is_same_mnt) {
 		i64 target_sz = get_target_symbol_file_sz(pid, target_ns_pid);
-		i64 local_sz = get_local_symbol_file_sz(pid, target_ns_pid);
-		if (target_sz > local_sz) {
+		if (target_sz > curr_local_sz) {
 			if (copy_file_from_target_ns(pid, target_ns_pid, "map")
 			    || copy_file_from_target_ns(pid, target_ns_pid,
 							"log")) {
@@ -93,12 +95,16 @@ void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred)
 				ebpf_info
 				    ("java need update cache pid %d target file"
 				     " size %ld local file size %ld\n",
-				     pid, target_sz, local_sz);
+				     pid, target_sz, curr_local_sz);
 				*ret_val = JAVA_SYMS_NEED_UPDATE;
 			}
 		}
 
 		clear_target_ns(pid, target_ns_pid);
+	} else {
+		i64 new_file_sz = get_local_symbol_file_sz(pid, target_ns_pid);
+		if (new_file_sz > curr_local_sz)
+			*ret_val = JAVA_SYMS_NEED_UPDATE;
 	}
 
 	return;


### PR DESCRIPTION
[eBPF] Fixing Java symbol cache not updating in RPM deployment

### This PR is for:

- Agent


#### Affected branches
- main
- v6.3