### PR TITLE
[eBPF] Add TCP sequence number offset for HTTP/2 protocol

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -395,6 +395,7 @@ static __inline enum message_type parse_http2_headers_frame(const char *buf_src,
 		if (offset >= count)
 			break;
 
+		conn_info->tcpseq_offset = offset;
 		bpf_probe_read(buf, sizeof(buf), buf_src + offset);
 		offset += (__bpf_ntohl(*(__u32 *) buf) >> 8) +
 		    HTTPV2_FRAME_PROTO_SZ;

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -187,6 +187,7 @@ struct conn_info_t {
 	// the Go DNS case. Parse DNS save record type and ignore AAAA records
 	// in call chain trace
 	__u16 dns_q_type;
+	__u32 tcpseq_offset;	// Used for adjusting TCP sequence numbers
 };
 
 struct process_data_extra {


### PR DESCRIPTION
Due to differences in the data captured through the `af_packet` and `eBPF methods` for HTTP/2, for example:

- Data captured using the af_packet method: `PING[0], HEADERS[86125]: 200 OK, DATA[86125]`

- Data captured using the eBPF method: `HEADERS[86125]: 200 OK, DATA[86125]`

Furthermore, both sides are unaware of the differences in the captured data. This inconsistency can lead to inconsistent `tcpseq` values, making it chal- lenging to correlate the data. To address this issue, it is agreed that both methods adjust the `tcpseq` to the starting position of the first `HEADER`.

### This PR is for:

- Agent

#### Affected branches
- main
- v6.3
