### PR TITLE
[eBPF] Add TCP sequence number offset for HTTP/2 protocol #22985

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -279,6 +279,7 @@ static __inline enum message_type parse_http2_headers_frame(const char *buf_src,
 		if (offset >= count)
 			break;
 
+		conn_info->tcpseq_offset = offset;
 		bpf_probe_read(buf, sizeof(buf), buf_src + offset);
 		offset += (__bpf_ntohl(*(__u32 *) buf) >> 8) +  
 			HTTPV2_FRAME_PROTO_SZ;

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -170,6 +170,7 @@ struct conn_info_t {
 	// the Go DNS case. Parse DNS save record type and ignore AAAA records
 	// in call chain trace
 	__u16 dns_q_type;
+	__u32 tcpseq_offset;	// Used for adjusting TCP sequence numbers
 };
 
 struct process_data_extra {

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1266,6 +1266,22 @@ __data_submit(struct pt_regs *ctx, struct conn_info_t *conn_info,
 		conn_info->prev_count = 0;
 	}
 
+	/*
+	 * Due to differences in the data captured through the `af_packet` and
+	 * `eBPF methods` for HTTP/2, for example:
+	 * - Data captured using the af_packet method:
+	 *   `PING[0], HEADERS[86125]: 200 OK, DATA[86125]`
+	 * - Data captured using the eBPF method:
+	 *   `HEADERS[86125]: 200 OK, DATA[86125]`
+	 *
+	 * Furthermore, both sides are unaware of the differences in the captured data.
+	 * This inconsistency can lead to inconsistent `tcpseq` values, making it chal-
+	 * lenging to correlate the data. To address this issue, it is agreed that both
+	 * methods adjust the `tcpseq` to the starting position of the first `HEADER`.
+	 */
+	if (conn_info->protocol == PROTO_HTTP2)
+		v->tcp_seq += conn_info->tcpseq_offset;
+
 	if (conn_info->prev_count > 0) {
 		// 注意这里没有调整v->syscall_len和v->len我们会在用户层做。
 		bpf_probe_read(v->extra_data, sizeof(v->extra_data), conn_info->prev_buf);


### PR DESCRIPTION
Due to differences in the data captured through the `af_packet` and `eBPF methods` for HTTP/2, for example:

- Data captured using the af_packet method: `PING[0], HEADERS[86125]: 200 OK, DATA[86125]`

- Data captured using the eBPF method: `HEADERS[86125]: 200 OK, DATA[86125]`

Furthermore, both sides are unaware of the differences in the captured data. This inconsistency can lead to inconsistent `tcpseq` values, making it chal- lenging to correlate the data. To address this issue, it is agreed that both methods adjust the `tcpseq` to the starting position of the first `HEADER`.


### This PR is for:


- Agent


#### Affected branches
- main
- v6.3