### PR TITLE
[Agent] Optimizes HTTP2 parsing headers

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "hostname",
  "hpack",
  "http",
+ "http2",
  "humantime-serde",
  "hyper",
  "ipnet",
@@ -1479,8 +1480,7 @@ dependencies = [
 [[package]]
 name = "hpack"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c68f61350ad23817dd207b035b5258d91ac5eaef69e96f906628aaed8854dda"
+source = "git+https://github.com/deepflowio/hpack-rs/#230591a8255598370cf0fc8f2a86b2754baab9c5"
 dependencies = [
  "log 0.3.9",
 ]
@@ -1512,6 +1512,10 @@ name = "http-range-header"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
+name = "http2"
+version = "0.1.0"
 
 [[package]]
 name = "httparse"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -34,8 +34,9 @@ futures = "~0.3"
 grpc = { path = "plugins/grpc" }
 hex = "0.4.3"
 hostname = "0.3.1"
-hpack = "0.3.0"
+hpack = { git = "https://github.com/deepflowio/hpack-rs/" }
 http = "0.2.5"
+http2 = { path = "plugins/http2" }
 humantime-serde = "1.0"
 hyper = { version = "0.14", features = ["full"] }
 ipnet = "2.4.0"

--- a/agent/plugins/http2/Cargo.toml
+++ b/agent/plugins/http2/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "http2"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/agent/plugins/http2/src/lib.rs
+++ b/agent/plugins/http2/src/lib.rs
@@ -1,0 +1,15 @@
+use std::collections::HashSet;
+
+pub fn get_expected_headers() -> HashSet<Vec<u8>> {
+    let mut hash_set = HashSet::new();
+    hash_set.insert(b":method".to_vec());
+    hash_set.insert(b":status".to_vec());
+    hash_set.insert(b"host".to_vec());
+    hash_set.insert(b":authority".to_vec());
+    hash_set.insert(b":path".to_vec());
+    hash_set.insert(b"content-type".to_vec());
+    hash_set.insert(b"content-length".to_vec());
+    hash_set.insert(b"user-agent".to_vec());
+    hash_set.insert(b"referer".to_vec());
+    hash_set
+}

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -33,6 +33,7 @@ use flexi_logger::{
     writers::FileLogWriter, Age, Cleanup, Criterion, FileSpec, FlexiLoggerError, LoggerHandle,
     Naming,
 };
+use http2::get_expected_headers;
 #[cfg(target_os = "linux")]
 use libc::{c_int, setpriority, PRIO_PROCESS};
 use log::{info, warn, Level};
@@ -877,6 +878,7 @@ pub struct L7LogDynamicConfig {
 
     trace_set: HashSet<String>,
     span_set: HashSet<String>,
+    pub expected_headers_set: Arc<HashSet<Vec<u8>>>,
 }
 
 impl PartialEq for L7LogDynamicConfig {
@@ -899,19 +901,27 @@ impl L7LogDynamicConfig {
     ) -> Self {
         proxy_client.make_ascii_lowercase();
 
+        let mut expected_headers_set = get_expected_headers();
+        expected_headers_set.insert(proxy_client.as_bytes().to_vec());
         let mut x_request_id_set = HashSet::new();
         for t in x_request_id.iter() {
-            x_request_id_set.insert(t.trim().to_string());
+            let t = t.trim();
+            expected_headers_set.insert(t.as_bytes().to_vec());
+            x_request_id_set.insert(t.to_string());
         }
 
         let mut trace_set = HashSet::new();
         for t in trace_types.iter() {
-            trace_set.insert(t.to_checker_string());
+            let t = t.to_checker_string();
+            expected_headers_set.insert(t.as_bytes().to_vec());
+            trace_set.insert(t);
         }
 
         let mut span_set = HashSet::new();
         for t in span_types.iter() {
-            span_set.insert(t.to_checker_string());
+            let t = t.to_checker_string();
+            expected_headers_set.insert(t.as_bytes().to_vec());
+            span_set.insert(t);
         }
 
         Self {
@@ -921,6 +931,7 @@ impl L7LogDynamicConfig {
             span_types,
             trace_set,
             span_set,
+            expected_headers_set: Arc::new(expected_headers_set),
         }
     }
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Optimizes HTTP2 parsing headers
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Fixed panic when parsing unexpected http2 payload
- Reduce http2 dynamic table size by add a header filter
#### Affected branches
- main
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
