### PR TITLE
Prom push 64

### DIFF
--- a/server/querier/app/prometheus/cache/cache_test.go
+++ b/server/querier/app/prometheus/cache/cache_test.go
@@ -71,7 +71,7 @@ type cacheHitResultOutput struct {
 
 func TestMain(m *testing.M) {
 	config.Cfg = &config.QuerierConfig{Prometheus: cfg.Prometheus{Cache: cfg.PrometheusCache{
-		Enabled:                true,
+		RemoteReadCache:        true,
 		CacheItemSize:          512,
 		CacheMaxCount:          5,
 		CacheMaxAllowDeviation: 60 * 60, // 60min

--- a/server/querier/app/prometheus/cache/keyGenerator.go
+++ b/server/querier/app/prometheus/cache/keyGenerator.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type WeakKeyGenerator struct {
+}
+
+// weak consistency for match QueryHint & Prometheus Hint
+func (w *WeakKeyGenerator) GenerateRequestKey(q model.QueryRequest) string {
+	// prometheus hint only have 1 funcs outside of <VectorSelector>
+	// so we should only use 1 func for cache key
+	var vectorWrapper string
+	if len(q.GetFunc()) > 0 {
+		vectorWrapper = q.GetFunc()[0]
+	}
+	return fmt.Sprintf(
+		"df:%s:%d:%s:%s:%s:%s",
+		q.GetMetric(),
+		q.GetStep(),
+		generateMatcherKey(q.GetLabels(), ":"),
+		vectorWrapper,
+		strings.Join(q.GetGrouping(vectorWrapper), ":"),
+		strconv.Itoa(int(q.GetRange(vectorWrapper))),
+	)
+}
+
+type CacheKeyGenerator struct {
+}
+
+// generate key without query time (start/end) for cache query
+func (k *CacheKeyGenerator) GenerateCacheKey(req *model.DeepFlowPromRequest) string {
+	return fmt.Sprintf(
+		"df:%s:%d:%d:%d:%s",
+		req.Query,
+		req.Step,
+		req.Start%int64(req.Step.Seconds()), // real interval for data
+		req.Slimit,
+		strings.Join(req.Matchers, ":"),
+	)
+}
+
+type HardKeyGenerator struct {
+}
+
+// hard consistency for QueryHint match cache data
+func (h *HardKeyGenerator) GenerateRequestKey(q model.QueryRequest) string {
+	funcs := q.GetFunc()
+	return fmt.Sprintf(
+		"df:%s:%d:%d:%d:%s:%s:%s:%s:%s",
+		q.GetMetric(),
+		q.GetStart(),
+		q.GetEnd(),
+		q.GetStep(),
+		generateMatcherKey(q.GetLabels(), ":"),
+		strings.Join(funcs, ":"),
+		strings.Join(getFuncCallArgs(funcs, func(s string) string {
+			return strings.Join(q.GetGrouping(s), ":")
+		}), ":"),
+		strings.Join(getFuncCallArgs(funcs, func(s string) string {
+			return strconv.Itoa(int(q.GetRange(s)))
+		}), ":"),
+		strings.Join(getFuncCallArgs(funcs, func(s string) string {
+			return strconv.Itoa(int(q.GetFuncParam(s)))
+		}), ":"),
+	)
+}
+
+func generateMatcherKey(matchers []*labels.Matcher, splitter string) string {
+	m := make([]string, 0, len(matchers))
+	f := &strings.Builder{}
+	for i := 0; i < len(matchers); i++ {
+		f.WriteString(matchers[i].Name)
+		f.WriteString(matchers[i].Type.String())
+		f.WriteString(matchers[i].Value)
+		m = append(m, f.String())
+		f.Reset()
+	}
+	return strings.Join(m, splitter)
+}
+
+func getFuncCallArgs(funcs []string, callback func(string) string) []string {
+	g := make([]string, 0, len(funcs))
+	for _, v := range funcs {
+		g = append(g, callback(v))
+	}
+	return g
+}

--- a/server/querier/app/prometheus/cache/keyGenerator.go
+++ b/server/querier/app/prometheus/cache/keyGenerator.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/cache/keyGenerator_test.go
+++ b/server/querier/app/prometheus/cache/keyGenerator_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestGenerateMatcherKey(t *testing.T) {
+	matchers := []*labels.Matcher{
+		{Name: "name1", Type: labels.MatchEqual, Value: "value1"},
+		{Name: "name2", Type: labels.MatchNotEqual, Value: "value2"},
+	}
+
+	expected := "name1=value1,name2!=value2"
+	result := generateMatcherKey(matchers, ",")
+
+	if result != expected {
+		t.Errorf("generateMatcherKey() = %s, want %s", result, expected)
+	}
+}

--- a/server/querier/app/prometheus/cache/keyGenerator_test.go
+++ b/server/querier/app/prometheus/cache/keyGenerator_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/cache/remoteread_cache.go
+++ b/server/querier/app/prometheus/cache/remoteread_cache.go
@@ -351,7 +351,7 @@ func (s *RemoteReadQueryCache) Get(req *prompb.ReadRequest) (*prompb.ReadRespons
 		return emptyResponse, CacheMiss, "", start, end
 	}
 
-	if !config.Cfg.Prometheus.Cache.Enabled {
+	if !config.Cfg.Prometheus.Cache.RemoteReadCache {
 		return emptyResponse, CacheMiss, "", start, end
 	}
 

--- a/server/querier/app/prometheus/cache/response_cache.go
+++ b/server/querier/app/prometheus/cache/response_cache.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/cache/response_cache.go
+++ b/server/querier/app/prometheus/cache/response_cache.go
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/deepflowio/deepflow/server/libs/lru"
+	"github.com/deepflowio/deepflow/server/querier/config"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+const (
+	pointSize    = int(unsafe.Sizeof(promql.Point{}))
+	pointPtrSize = int(unsafe.Sizeof(&promql.Point{}))
+)
+
+type item[T any] struct {
+	start int64
+	end   int64
+	step  int64
+	vType parser.ValueType // origin value type
+	data  T
+}
+
+func dataSizeOf(r *item[promql.Result]) uint64 {
+	if r == nil {
+		return 0
+	}
+	size := uint64(unsafe.Sizeof(r.start) + unsafe.Sizeof(r.end) + unsafe.Sizeof(r.step) + unsafe.Sizeof(r.vType))
+	matrix, err := r.data.Matrix()
+	if err != nil {
+		totalPoints := 0
+		for _, m := range matrix {
+			for _, v := range m.Metric {
+				size += uint64(unsafe.Sizeof(v))
+			}
+			totalPoints += len(m.Points)
+		}
+		size += uint64(totalPoints*pointSize + totalPoints*pointPtrSize)
+	}
+	return size
+}
+
+type Cacher struct {
+	entries *lru.Cache[string, item[promql.Result]]
+	lock    *sync.RWMutex
+}
+
+func NewCacher() *Cacher {
+	c := &Cacher{
+		lock:    &sync.RWMutex{},
+		entries: lru.NewCache[string, item[promql.Result]](config.Cfg.Prometheus.Cache.CacheMaxCount),
+	}
+	return c
+}
+
+func (c *Cacher) Fetch(key string, start, end int64) (r promql.Result, fixedStart int64, fixedEnd int64, queryRequired bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	entry, ok := c.entries.Get(key)
+	if !ok {
+		return promql.Result{Err: fmt.Errorf("key %s not found", key)}, start, end, true
+	}
+
+	if entry.vType == parser.ValueTypeVector {
+		r, queryRequired = c.fetchInstant(&entry, start, end)
+		return r, start, end, queryRequired
+	} else if entry.vType == parser.ValueTypeMatrix {
+		return c.fetchRange(&entry, start, end)
+	}
+
+	return promql.Result{Err: fmt.Errorf("value Type %s not found", key)}, start, end, true
+}
+
+func (c *Cacher) fetchRange(entry *item[promql.Result], start, end int64) (r promql.Result, fixedStart int64, fixedEnd int64, queryRequired bool) {
+	fixedStart, fixedEnd = c.validateQueryTs(start, end, entry.start, entry.end)
+	if fixedStart == 0 && fixedEnd == 0 {
+		return c.extractSubData(entry.data, start, end), fixedStart, fixedEnd, false
+	}
+	return entry.data, fixedStart, fixedEnd, true
+}
+
+func (c *Cacher) fetchInstant(entry *item[promql.Result], start, end int64) (r promql.Result, queryRequired bool) {
+	// for instant query, all data will storage as matrix, but depends on query promql, get difference result:
+	// query node_cpu_seconds_total: get vector, find out the matched query time
+	// query node_cpu_seconds_total[1m]: get matrix, find out the matched query time range
+	samples, err := entry.data.Matrix()
+	if err != nil {
+		return promql.Result{Err: err}, true
+	}
+	result := make(promql.Vector, 0, samples.Len())
+
+	// only when end == Points.T, can be added (time completely equal)
+	for i := 0; i < samples.Len(); i++ {
+		findEndTimeAt := sort.Search(len(samples[i].Points), func(j int) bool {
+			return samples[i].Points[j].T == end
+		})
+		if findEndTimeAt == len(samples[i].Points) {
+			// not found
+			// fmt.Errorf("time %v not found", end)
+			continue
+		}
+
+		result = append(result, promql.Sample{Metric: samples[i].Metric, Point: samples[i].Points[findEndTimeAt]})
+	}
+	if len(result) < samples.Len() {
+		return promql.Result{}, true
+	}
+	return promql.Result{Value: result}, false
+}
+
+func (c *Cacher) validateQueryTs(start, end int64, cacheStart, cacheEnd int64) (int64, int64) {
+	// cache miss:
+	// left
+	if end < cacheStart {
+		return start, end
+	}
+	// right
+	if start > cacheEnd {
+		return start, end
+	}
+	// outside
+	if start < cacheStart && end > cacheEnd {
+		return start, end
+	}
+
+	// cache hit
+	if start < cacheStart {
+		return start, cacheStart
+	}
+
+	if end > cacheEnd {
+		return cacheEnd, end
+	}
+
+	// cache hit, not query anything, return cache data
+	if start >= cacheStart && cacheEnd >= end {
+		return 0, 0
+	}
+
+	return start, end
+}
+
+func (c *Cacher) extractSubData(r promql.Result, start, end int64) promql.Result {
+	matrix, err := r.Matrix()
+	if err != nil {
+		return promql.Result{Err: err}
+	}
+	result := make(promql.Matrix, 0, len(matrix))
+	for _, series := range matrix {
+		newSeries := promql.Series{Metric: series.Metric}
+		begin := sort.Search(len(series.Points), func(i int) bool {
+			return series.Points[i].T >= start
+		})
+		stop := sort.Search(len(series.Points), func(i int) bool {
+			return series.Points[i].T > end // include end
+		})
+		newSeries.Points = series.Points[begin:stop]
+		result = append(result, newSeries)
+	}
+	return promql.Result{Value: result}
+}
+
+func (c *Cacher) Merge(key string, cached promql.Result, start, end, step int64, res promql.Result) (promql.Result, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	defer func(k string) {
+		// over size
+		val, _ := c.entries.Peek(k)
+		if dataSizeOf(&val) > config.Cfg.Prometheus.Cache.CacheItemSize {
+			c.entries.Remove(k)
+		}
+	}(key)
+
+	entry, ok := c.entries.Get(key)
+	if !ok {
+		item := item[promql.Result]{
+			start: start,
+			end:   end,
+			step:  step,
+			data:  res,
+			vType: res.Value.Type(),
+		}
+
+		if item.data.Value.Type() == parser.ValueTypeVector {
+			v, err := res.Vector()
+			if err == nil {
+				item.data.Value = vectorTomatrix(&v)
+				item.vType = parser.ValueTypeVector // mark origin value type
+			}
+			// else not vector, merge directly
+		}
+		c.entries.Add(key, item)
+		return res, nil
+	}
+
+	var mergeResult promql.Result
+	switch res.Value.Type() {
+	case parser.ValueTypeVector:
+		vector, err := res.Vector()
+		if err != nil {
+			return res, err
+		}
+		mergeResult, err = c.vectorMerge(vector, &entry.data)
+		if err != nil {
+			return promql.Result{Err: err}, err
+		}
+	case parser.ValueTypeMatrix:
+		// replace
+		if start > entry.end || end < entry.start {
+			entry.start = start
+			entry.end = end
+			entry.data = res
+		}
+
+		if start < entry.start && end > entry.end {
+			entry.start = start
+			entry.end = end
+			entry.data = res
+		}
+
+		matrix, err := res.Matrix()
+		if err != nil {
+			return res, err
+		}
+		mergeResult, err = c.matrixMerge(matrix, &entry.data)
+		if err != nil {
+			return promql.Result{Err: err}, err
+		}
+	default:
+	}
+
+	if entry.end < end {
+		entry.end = end
+	}
+	if entry.start > start {
+		entry.start = start
+	}
+
+	entry.data = mergeResult
+	return entry.data, nil
+}
+
+func (c *Cacher) matrixMerge(resp promql.Matrix, cache *promql.Result) (promql.Result, error) {
+	cacheMatrix, err := cache.Matrix()
+	if err != nil {
+		return promql.Result{Err: err}, err
+	}
+	output := make(promql.Matrix, 0, len(cacheMatrix))
+	for _, cachedTs := range cacheMatrix {
+		cachedSeries := genSeriesLabelString(&cachedTs.Metric)
+		newSeries := promql.Series{Metric: cachedTs.Metric}
+		newSeries.Points = cachedTs.Points
+		for _, series := range resp {
+			respSeries := genSeriesLabelString(&series.Metric)
+			if respSeries == cachedSeries {
+				existsStartT := newSeries.Points[0].T
+				existsEndT := newSeries.Points[len(newSeries.Points)-1].T
+
+				if existsEndT < series.Points[0].T {
+					newSeries.Points = append(newSeries.Points, series.Points...)
+				} else if existsStartT > series.Points[len(series.Points)-1].T {
+					newSeries.Points = append(series.Points, newSeries.Points...)
+				} else if existsEndT >= series.Points[0].T && existsEndT < series.Points[len(series.Points)-1].T {
+					// cached data & resp overlap
+					overlapPointAt := sort.Search(len(series.Points), func(i int) bool {
+						return series.Points[i].T > existsEndT
+					})
+					newSeries.Points = append(newSeries.Points, series.Points[overlapPointAt:]...)
+				} else if existsStartT <= series.Points[len(series.Points)-1].T && existsStartT > series.Points[0].T {
+					overlapPointAt := sort.Search(len(series.Points), func(i int) bool {
+						return series.Points[i].T >= existsStartT
+					})
+					newSeries.Points = append(series.Points[:overlapPointAt], newSeries.Points...)
+				}
+
+				sort.Slice(newSeries.Points, func(i, j int) bool {
+					return newSeries.Points[i].T < newSeries.Points[j].T
+				})
+			}
+		}
+		output = append(output, newSeries)
+	}
+
+	sort.Sort(output)
+	return promql.Result{Value: output}, nil
+}
+
+func (c *Cacher) vectorMerge(resp promql.Vector, cached *promql.Result) (promql.Result, error) {
+	cacheMatrix, err := cached.Matrix()
+	if err != nil {
+		return promql.Result{Err: err}, err
+	}
+	output := make(promql.Matrix, 0, len(cacheMatrix))
+	for _, cachedTs := range cacheMatrix {
+		cachedSeries := genSeriesLabelString(&cachedTs.Metric)
+		newSeries := promql.Series{Metric: cachedTs.Metric}
+		newSeries.Points = cachedTs.Points
+		for _, samples := range resp {
+			respSeries := genSeriesLabelString(&samples.Metric)
+			if respSeries == cachedSeries {
+				insertedPointAt := sort.Search(len(newSeries.Points), func(i int) bool {
+					return newSeries.Points[i].T >= samples.Point.T
+				})
+				newSeries.Points = append(newSeries.Points, promql.Point{})
+				copy(newSeries.Points[insertedPointAt+1:], newSeries.Points[insertedPointAt:])
+				newSeries.Points[insertedPointAt] = samples.Point
+
+				sort.Slice(newSeries.Points, func(i, j int) bool {
+					return newSeries.Points[i].T < newSeries.Points[j].T
+				})
+			}
+		}
+	}
+	sort.Sort(output)
+	return promql.Result{Value: output}, nil
+}
+
+func vectorTomatrix(v *promql.Vector) promql.Matrix {
+	output := make(promql.Matrix, 0, len(*v))
+	for _, m := range *v {
+		output = append(output, promql.Series{
+			Metric: m.Metric,
+			Points: []promql.Point{m.Point},
+		})
+	}
+	return output
+}
+
+func genSeriesLabelString(lb *labels.Labels) string {
+	lbs := make([]string, 0, len(*lb))
+	for i := 0; i < len(*lb); i++ {
+		lbs = append(lbs, fmt.Sprintf("%s=%s", (*lb)[i].Name, (*lb)[i].Value))
+	}
+	return strings.Join(lbs, ",")
+}

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -26,6 +26,7 @@ type Prometheus struct {
 	ExternalTagCacheSize    int             `default:"1024" yaml:"external-tag-cache-size"`
 	ExternalTagLoadInterval int             `default:"300" yaml:"external-tag-load-interval"`
 	ThanosReplicaLabels     []string        `yaml:"thanos-replica-labels"`
+	OperatorOffloading      bool            `default:"false" yaml:"operator-offloading"`
 	Cache                   PrometheusCache `yaml:"cache"`
 }
 

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -31,7 +31,8 @@ type Prometheus struct {
 }
 
 type PrometheusCache struct {
-	Enabled                bool    `default:"false" yaml:"enabled"`
+	RemoteReadCache        bool    `default:"false" yaml:"remote-read-cache"`  // cache for database quering
+	ResponseCache          bool    `default:"false" yaml:"response-cache"`     // cache for query response (only operator offloading mode)
 	CacheItemSize          uint64  `default:"51200000" yaml:"cache-item-size"` // cache-item-size for each cache item, default: 50M
 	CacheMaxCount          int     `default:"1024" yaml:"cache-max-count"`     // cache-max-count for list of cache size
 	CacheMaxAllowDeviation float64 `default:"3600" yaml:"cache-max-allow-deviation"`

--- a/server/querier/app/prometheus/model/prometheus.go
+++ b/server/querier/app/prometheus/model/prometheus.go
@@ -18,21 +18,21 @@ package model
 
 import (
 	"context"
+	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
 type PromQueryParams struct {
-	MetricsWithPrefix   string
-	Promql              string
-	StartTime           string
-	EndTime             string
-	Step                string
-	Debug               bool
-	Slimit              string
-	ThanosReplicaLabels []string
-	Matchers            []string
-	Context             context.Context
+	Debug      bool
+	Offloading bool
+	Slimit     int
+	Promql     string
+	StartTime  string
+	EndTime    string
+	Step       string
+	Matchers   []string
+	Context    context.Context
 }
 
 type PromQueryData struct {
@@ -41,11 +41,11 @@ type PromQueryData struct {
 }
 
 type PromQueryResponse struct {
-	Status    string         `json:"status"`
-	Data      interface{}    `json:"data,omitempty"`
-	ErrorType errorType      `json:"errorType,omitempty"`
-	Error     string         `json:"error,omitempty"`
-	Stats     PromQueryStats `json:"stats,omitempty"`
+	Status    string           `json:"status"`
+	Data      interface{}      `json:"data,omitempty"`
+	ErrorType errorType        `json:"errorType,omitempty"`
+	Error     string           `json:"error,omitempty"`
+	Stats     []PromQueryStats `json:"stats,omitempty"`
 }
 
 type PromMetaParams struct {
@@ -56,8 +56,9 @@ type PromMetaParams struct {
 }
 
 type PromQueryStats struct {
-	SQL       []string  `json:"sql,omitempty"`
-	QueryTime []float64 `json:"query_time,omitempty"`
+	Duration   float64 `json:"duration,omitempty"`
+	SQL        string  `json:"sql,omitempty"`
+	QuerierSQL string  `json:"querier_sql,omitempty"`
 }
 
 type errorType string
@@ -73,4 +74,13 @@ type PromQueryWrapper struct {
 type WrapHistorySeries struct {
 	Toi   int64   `json:"toi"`
 	Value float64 `json:"value"`
+}
+
+type DeepFlowPromRequest struct {
+	Slimit   int
+	Start    int64
+	End      int64
+	Step     time.Duration
+	Query    string
+	Matchers []string
 }

--- a/server/querier/app/prometheus/model/querierable.go
+++ b/server/querier/app/prometheus/model/querierable.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/model/querierable.go
+++ b/server/querier/app/prometheus/model/querierable.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/storage"
+)
+
+type Querierable interface {
+	storage.Queryable
+	// get sql and sql cost duration
+	GetSQLQuery() []PromQueryStats
+
+	BindSelectedCallBack(promql.Query)
+	AfterQueryExec(promql.Query)
+}

--- a/server/querier/app/prometheus/model/query_request.go
+++ b/server/querier/app/prometheus/model/query_request.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/model/query_request.go
+++ b/server/querier/app/prometheus/model/query_request.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type QueryRequest interface {
+	// GetStart returns the start timestamp of query, unit: ms
+	GetStart() int64
+
+	// GetEnd returns the end timestamp of query, unit: ms
+	GetEnd() int64
+
+	// GetStep returns the query step of range-query
+	GetStep() int64
+
+	// GetFunc returns the query aggregation functions of query
+	GetFunc() []string
+
+	// GetGrouping returns the group labels for query functions of query
+	GetGrouping(f string) []string
+
+	// GetBy returns the group way for group labels of query
+	GetBy() bool
+
+	// GetQuery returns the whole query promql of query
+	GetQuery() string
+
+	// GetMetric returns the metric name of query
+	GetMetric() string
+
+	// GetLables returns query labels of query
+	GetLabels() []*labels.Matcher
+
+	// GetRange returns the range of query function
+	GetRange(f string) int64
+
+	// GetFuncParam returns query params of query function, only for 'topk'/'quantile'/'bottomk'
+	GetFuncParam(f string) float64
+}
+
+/*
+difference between those query type:
+- series query: get `series` only, it won't get any time series samples; don't use cache
+  - params: start, end, matchers
+- instant query: get instant value
+  - params: start, end, query(metric, matchers, func, range)
+  - specially: subQuery with step, but it should calculated in memory, not databases
+- range query: get time series samples for multiple values
+  - params: start, end, step, query(metric, matchers, func, range)
+*/
+
+type QueryType uint8
+
+const (
+	// Series Query
+	Series QueryType = iota
+	// Instant Query
+	Instant
+	// Range Query
+	Range
+)

--- a/server/querier/app/prometheus/router/middleware.go
+++ b/server/querier/app/prometheus/router/middleware.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ func Limiter(limiter *datastructure.LeakyBucket) gin.HandlerFunc {
 		// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
 		if !limiter.Acquire(1000) {
 			c.AbortWithStatus(http.StatusTooManyRequests)
+			return
 		}
 		c.Next()
 	}

--- a/server/querier/app/prometheus/router/middleware.go
+++ b/server/querier/app/prometheus/router/middleware.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package router
+
+import (
+	"net/http"
+
+	"github.com/deepflowio/deepflow/server/libs/datastructure"
+	"github.com/gin-gonic/gin"
+)
+
+// rate limit middleware
+func Limiter(limiter *datastructure.LeakyBucket) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// QPS Limit Check
+		// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
+		if !limiter.Acquire(1000) {
+			c.AbortWithStatus(http.StatusTooManyRequests)
+		}
+		c.Next()
+	}
+}

--- a/server/querier/app/prometheus/router/prometheus.go
+++ b/server/querier/app/prometheus/router/prometheus.go
@@ -18,7 +18,7 @@ package router
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 
@@ -32,6 +32,7 @@ import (
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/service"
 	"github.com/deepflowio/deepflow/server/querier/common"
+	"github.com/deepflowio/deepflow/server/querier/config"
 )
 
 const _STATUS_FAIL = "fail"
@@ -48,29 +49,20 @@ func promQuery(svc *service.PrometheusService) gin.HandlerFunc {
 		// ref: https://github.com/prometheus/prometheus/blob/main/prompb/types.proto#L157
 		args.StartTime = c.Request.FormValue("time")
 		args.EndTime = c.Request.FormValue("time")
-		args.Slimit = c.Request.FormValue("slimit")
+		slimit := c.Request.FormValue("slimit")
 		debug := c.Request.FormValue("debug")
-		args.Debug, _ = strconv.ParseBool(debug)
+		offloading := c.Request.FormValue("operator-offloading")
+		setRouterArgs(slimit, &args.Slimit, config.Cfg.Prometheus.SeriesLimit, strconv.Atoi)
+		setRouterArgs(debug, &args.Debug, config.Cfg.Prometheus.RequestQueryWithDebug, strconv.ParseBool)
+		setRouterArgs(offloading, &args.Offloading, config.Cfg.Prometheus.OperatorOffloading, strconv.ParseBool)
 
 		result, err := svc.PromInstantQueryService(&args, c.Request.Context())
 		if err != nil {
-			if tErr := getInnerError(err); tErr != nil {
-				// only for `RESOURCE_NOT_FOUND` error, it means query non-existence metrics, it should return 200 with empty result
-				switch t := tErr.(type) {
-				case *common.ServiceError:
-					if t.Status == common.RESOURCE_NOT_FOUND {
-						c.JSON(200, &model.PromQueryResponse{
-							Status: _STATUS_SUCCESS,
-							Data:   &model.PromQueryData{ResultType: parser.ValueTypeVector, Result: promql.Vector{}},
-						})
-						return
-					}
-				}
-			}
-			c.JSON(500, &model.PromQueryResponse{Error: err.Error(), Status: _STATUS_FAIL})
-			return
+			code, obj := handleError(err)
+			c.JSON(code, obj)
+		} else {
+			c.JSON(200, result)
 		}
-		c.JSON(200, result)
 	})
 }
 
@@ -83,36 +75,27 @@ func promQueryRange(svc *service.PrometheusService) gin.HandlerFunc {
 		args.StartTime = c.Request.FormValue("start")
 		args.EndTime = c.Request.FormValue("end")
 		args.Step = c.Request.FormValue("step")
-		args.Slimit = c.Request.FormValue("slimit")
+		slimit := c.Request.FormValue("slimit")
 		debug := c.Request.FormValue("debug")
-		args.Debug, _ = strconv.ParseBool(debug)
+		offloading := c.Request.FormValue("operator-offloading")
+		setRouterArgs(slimit, &args.Slimit, config.Cfg.Prometheus.SeriesLimit, strconv.Atoi)
+		setRouterArgs(debug, &args.Debug, config.Cfg.Prometheus.RequestQueryWithDebug, strconv.ParseBool)
+		setRouterArgs(offloading, &args.Offloading, config.Cfg.Prometheus.OperatorOffloading, strconv.ParseBool)
 
 		result, err := svc.PromRangeQueryService(&args, c.Request.Context())
 		if err != nil {
-			if tErr := getInnerError(err); tErr != nil {
-				// only for `RESOURCE_NOT_FOUND` error, it means query non-existence metrics, it should return 200 with empty result
-				switch t := tErr.(type) {
-				case *common.ServiceError:
-					if t.Status == common.RESOURCE_NOT_FOUND {
-						c.JSON(200, &model.PromQueryResponse{
-							Status: _STATUS_SUCCESS,
-							Data:   &model.PromQueryData{ResultType: parser.ValueTypeVector, Result: promql.Vector{}},
-						})
-						return
-					}
-				}
-			}
-			c.JSON(500, &model.PromQueryResponse{Error: err.Error(), Status: _STATUS_FAIL})
-			return
+			code, obj := handleError(err)
+			c.JSON(code, obj)
+		} else {
+			c.JSON(200, result)
 		}
-		c.JSON(200, result)
 	})
 }
 
 // RemoteRead API
 func promReader(svc *service.PrometheusService) gin.HandlerFunc {
 	return gin.HandlerFunc(func(c *gin.Context) {
-		compressed, _ := ioutil.ReadAll(c.Request.Body)
+		compressed, _ := io.ReadAll(c.Request.Body)
 		reqBuf, err := snappy.Decode(nil, compressed)
 		if err != nil {
 			c.JSON(500, err)
@@ -123,22 +106,18 @@ func promReader(svc *service.PrometheusService) gin.HandlerFunc {
 			c.JSON(500, err)
 			return
 		}
-
-		resp, err := svc.PromRemoteReadService(&req, c.Request.Context())
+		// configure remote read like: /api/v1/prom/read?operator-offloading=true
+		offloading := c.Request.FormValue("operator-offloading")
+		var offloadingArgs bool
+		setRouterArgs(offloading, &offloadingArgs, config.Cfg.Prometheus.OperatorOffloading, strconv.ParseBool)
+		resp, err := svc.PromRemoteReadService(&req, c.Request.Context(), offloadingArgs)
 		if err != nil {
-			if tErr := getInnerError(err); tErr != nil {
-				switch t := tErr.(type) {
-				case *common.ServiceError:
-					if t.Status == common.RESOURCE_NOT_FOUND {
-						c.JSON(200, &model.PromQueryResponse{
-							Status: _STATUS_SUCCESS,
-							Data:   &model.PromQueryData{ResultType: parser.ValueTypeVector, Result: promql.Vector{}},
-						})
-						return
-					}
-				}
+			code, _ := handleError(err)
+			// remote read use different response, not use `obj`, otherwise it will cause decode response error
+			if code == 200 {
+				err = nil
 			}
-			c.JSON(500, err)
+			c.JSON(code, err)
 			return
 		}
 		data, err := resp.Marshal()
@@ -176,26 +155,19 @@ func promSeriesReader(svc *service.PrometheusService) gin.HandlerFunc {
 			Matchers:  c.Request.Form["match[]"],
 			Context:   c.Request.Context(),
 		}
+		debug := c.Request.FormValue("debug")
+		offloading := c.Request.FormValue("operator-offloading")
+		setRouterArgs(debug, &args.Debug, config.Cfg.Prometheus.RequestQueryWithDebug, strconv.ParseBool)
+		setRouterArgs(offloading, &args.Offloading, config.Cfg.Prometheus.OperatorOffloading, strconv.ParseBool)
 		// should show tags when get `Series`
 		ctx := context.WithValue(c.Request.Context(), service.CtxKeyShowTag{}, true)
 		result, err := svc.PromSeriesQueryService(&args, ctx)
 		if err != nil {
-			if tErr := getInnerError(err); tErr != nil {
-				switch t := tErr.(type) {
-				case *common.ServiceError:
-					if t.Status == common.RESOURCE_NOT_FOUND {
-						c.JSON(200, &model.PromQueryResponse{
-							Status: _STATUS_SUCCESS,
-							Data:   &model.PromQueryData{ResultType: parser.ValueTypeVector, Result: promql.Vector{}},
-						})
-						return
-					}
-				}
-			}
-			c.JSON(500, &model.PromQueryResponse{Error: err.Error(), Status: _STATUS_FAIL})
-			return
+			code, obj := handleError(err)
+			c.JSON(code, obj)
+		} else {
+			c.JSON(200, result)
 		}
-		c.JSON(200, result)
 	})
 }
 
@@ -254,6 +226,27 @@ func promQLAddFilters(svc *service.PrometheusService) gin.HandlerFunc {
 	})
 }
 
+// handle special errors
+// only for `RESOURCE_NOT_FOUND` error, it means query non-existence metrics, it should return 200 with empty result
+// but in querier, it will still cause a `RESOURCE_NOT_FOUND` to log error
+func handleError(err error) (code int, obj any) {
+	if err == nil {
+		return 200, nil
+	}
+	if tErr := getInnerError(err); tErr != nil {
+		switch t := tErr.(type) {
+		case *common.ServiceError:
+			if t.Status == common.RESOURCE_NOT_FOUND {
+				return 200, &model.PromQueryResponse{
+					Status: _STATUS_SUCCESS,
+					Data:   &model.PromQueryData{ResultType: parser.ValueTypeVector, Result: promql.Vector{}},
+				}
+			}
+		}
+	}
+	return 500, &model.PromQueryResponse{Error: err.Error(), Status: _STATUS_FAIL}
+}
+
 func getInnerError(err error) error {
 	for {
 		innerError := errors.Unwrap(err)
@@ -261,5 +254,18 @@ func getInnerError(err error) error {
 			return err
 		}
 		err = innerError
+	}
+}
+
+// set args from router query or config
+func setRouterArgs[T any](flag string, target *T, defaultValue T, parser func(string) (T, error)) {
+	var err error
+	if flag != "" && parser != nil {
+		*target, err = parser(flag)
+		if err != nil {
+			*target = defaultValue
+		}
+	} else {
+		*target = defaultValue
 	}
 }

--- a/server/querier/app/prometheus/router/router.go
+++ b/server/querier/app/prometheus/router/router.go
@@ -19,38 +19,41 @@ package router
 import (
 	"github.com/gin-gonic/gin"
 
-	"github.com/deepflowio/deepflow/server/libs/datastructure"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/router/packet_adapter"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/service"
 	"github.com/deepflowio/deepflow/server/querier/config"
 )
 
 func PrometheusRouter(e *gin.Engine) {
-	// prometheus query rate limit
-	service.QPSLeakyBucket = &datastructure.LeakyBucket{}
-	// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
-	service.QPSLeakyBucket.Init(uint64(config.Cfg.Prometheus.QPSLimit * 1000))
-
 	// only one instance during server lifetime
 	prometheusService := service.NewPrometheusService()
+	// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
+	prometheusService.QPSLeakyBucket.Init(uint64(config.Cfg.Prometheus.QPSLimit * 1000))
 
 	// api router for prometheus
-	e.POST("/api/v1/prom/read", promReader(prometheusService))
-	e.GET("/prom/api/v1/query", promQuery(prometheusService))
-	e.GET("/prom/api/v1/query_range", promQueryRange(prometheusService))
-	e.POST("/prom/api/v1/query", promQuery(prometheusService))
-	e.POST("/prom/api/v1/query_range", promQueryRange(prometheusService))
-	e.GET("/prom/api/v1/series", promSeriesReader(prometheusService))
-	e.POST("/prom/api/v1/series", promSeriesReader(prometheusService))
-	e.GET("/prom/api/v1/label/:labelName/values", promTagValuesReader(prometheusService))
-	e.GET("/prom/api/v1/analysis", promQLAnalysis(prometheusService))
+	e.POST("/api/v1/prom/read", Limiter(prometheusService.QPSLeakyBucket), promReader(prometheusService))
 
-	// not use "/prom/api/v1/adapter/:name", suitable for map[rouer key]counter in statsd
-	for _, v := range []string{"label", "query_range", "query", "series"} {
-		e.POST("/prom/api/v1/adapter/"+v, packet_adapter.AdaptPromQuery(prometheusService, v))
-		e.GET("/prom/api/v1/adapter/"+v, packet_adapter.AdaptPromQuery(prometheusService, v))
+	promGroup := e.Group("/prom")
+	// prometheus query rate limit
+	promGroup.Use(Limiter(prometheusService.QPSLeakyBucket))
+	{
+		promGroup.GET("/api/v1/query", promQuery(prometheusService))
+		promGroup.GET("/api/v1/query_range", promQueryRange(prometheusService))
+		promGroup.POST("/api/v1/query", promQuery(prometheusService))
+		promGroup.POST("/api/v1/query_range", promQueryRange(prometheusService))
+		promGroup.GET("/api/v1/series", promSeriesReader(prometheusService))
+		promGroup.POST("/api/v1/series", promSeriesReader(prometheusService))
+		promGroup.GET("/api/v1/label/:labelName/values", promTagValuesReader(prometheusService))
+
+		// not use "/prom/api/v1/adapter/:name", suitable for map[rouer key]counter in statsd
+		for _, v := range []string{"label", "query_range", "query", "series"} {
+			promGroup.POST("/api/v1/adapter/"+v, packet_adapter.AdaptPromQuery(prometheusService, v))
+			promGroup.GET("/api/v1/adapter/"+v, packet_adapter.AdaptPromQuery(prometheusService, v))
+		}
 	}
 
+	// not using rate-limit, cause it's low-frequency of request-calling
+	e.GET("/prom/api/v1/analysis", promQLAnalysis(prometheusService))
 	e.GET("/prom/api/v1/parse", promQLParse(prometheusService))
 	e.GET("/prom/api/v1/addfilter", promQLAddFilters(prometheusService))
 }

--- a/server/querier/app/prometheus/service/analyzer.go
+++ b/server/querier/app/prometheus/service/analyzer.go
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"math"
+	"time"
+
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+)
+
+/*
+consider <VectorSelector> could only wrap by such expr:
+1. <Vector>  e.g.: node_cpu_seconds_total [output: <Vector>]
+2. Matrix<Vector>  e.g.: node_cpu_seconds_total[5m] [output: <Matrix>]
+3. SubQuery<Vector>  e.g.: node_cpu_seconds_total[5m:1m] [output: <Matrix>]
+4. Aggregate<Vector>  e.g.: sum(node_cpu_seconds_total)by(cpu) [input<Vector> output<Vector>]
+5. Call<Matrix>  e.g.: rate(node_cpu_seconds_total[5m]) [input<Matrix> output<Vector>]
+6. Call<Vector>  e.g.: abs(node_cpu_seconds_total) [input<Vector> output<Vector>]
+
+...then, it can combined with each other,
+like: Call<SubQuery<Aggregate<Vector>>>
+e.g.: sum_over_time(sum(node_cpu_seconds_total)by(cpu)[5m:5m])
+e.g.: sum(sum_over_time(node_cpu_seconds_total[5m]))by(cpu)
+
+base on the combinations above, we could extract query hints by:
+- Call: get query func
+- MatrixSelector: get query range
+- AggregateExpr: get aggreagate function & aggregation group tags
+
+- Special: SubQueryExpr
+SubQueryExpr use a self-defined step for query (like: node_cpu_seconds_total[5m:1m]), [1m] is the step.
+When step > scrape_interval, it's downsampling, when step < scrape_interval, it's upsampling.
+
+parse case for wrap combinations:
+1&2. select value from m [where start < time < end];
+3. select last(value), time from m group by time;
+# upsampling:
+select time, sum(value) over (partition by metric_id,target_id,COLUMNS('app_label_value_id')
+order by time asc RANGE BETWEEN X PRECEDING AND CURRENT ROW) as `value`
+from m where start < time < end ORDER BY time WITH FILL STEP $STEP INTERPOLATE ( value AS value )
+4. select agg(value), time from m [where start < time < end] group by tags, time;
+- sum(node_cpu_seconds_total)by(cpu)[5m:1m]
+5. select time, call(value) over (partition by metric_id,target_id,COLUMNS('app_label_value_id')
+order by time asc RANGE BETWEEN X PRECEDING AND CURRENT ROW) from m where start < time < end;
+- x=[range * 60] (secs) (maybe it needs -1 secs for `x`), start = start - range (should calculate double time range for the first half of timestamp)
+6. select call(value) from m [where start < time < end];
+
+such exprs could only calculate by prometheus engine, ignore currently:
+BinaryExpr/UnaryExpr/ParenExpr/StepInvariantExpr/Others...
+*/
+
+type queryAnalyzer struct {
+	lookBackDelta  time.Duration
+	offloadEnabled offloadEnabledFunc
+}
+
+type functionCall struct {
+	Range    time.Duration
+	Param    float64 // only for `topk`/`bottomk`/`quantile`
+	Name     string  // function name
+	Grouping []string
+}
+
+// use QueryHint to get multiple `func` in promql query
+type QueryHint struct {
+	start    int64
+	end      int64
+	step     int64
+	query    string
+	funcs    []functionCall
+	matchers []*labels.Matcher
+}
+
+func (q *QueryHint) GetStart() int64 {
+	return q.start
+}
+func (q *QueryHint) GetEnd() int64 {
+	return q.end
+}
+
+func (q *QueryHint) GetStep() int64 {
+	return q.step
+}
+func (q *QueryHint) GetFunc() []string {
+	f := make([]string, 0, len(q.funcs))
+	for _, v := range q.funcs {
+		f = append(f, v.Name)
+	}
+	return f
+}
+
+func (q *QueryHint) GetGrouping(f string) []string {
+	for i := 0; i < len(q.funcs); i++ {
+		if q.funcs[i].Name == f {
+			return q.funcs[i].Grouping
+		}
+	}
+	return nil
+}
+
+func (q *QueryHint) GetRange(f string) int64 {
+	for i := 0; i < len(q.funcs); i++ {
+		if q.funcs[i].Name == f {
+			return int64(q.funcs[i].Range / (time.Millisecond / time.Nanosecond))
+		}
+	}
+	return 0
+}
+
+func (q *QueryHint) GetFuncParam(f string) float64 {
+	// iterate from top to last
+	for i := 0; i < len(q.funcs); i++ {
+		if q.funcs[i].Name == f {
+			return q.funcs[i].Param
+		}
+	}
+	return 0
+}
+
+func (q *QueryHint) GetLabels() []*labels.Matcher {
+	return q.matchers
+}
+
+func (q *QueryHint) GetQuery() string {
+	return q.query
+}
+
+func (q *QueryHint) GetBy() bool {
+	return true
+}
+
+func (q *QueryHint) GetMetric() string {
+	return extractMetricName(&q.matchers)
+}
+
+// prometheusHint is for orginal prometheus SelectHints
+type prometheusHint struct {
+	hints    *storage.SelectHints
+	matchers []*labels.Matcher
+	query    string
+}
+
+func (p *prometheusHint) GetStart() int64 {
+	return p.hints.Start
+}
+func (p *prometheusHint) GetEnd() int64 {
+	return p.hints.End
+}
+
+func (p *prometheusHint) GetStep() int64 {
+	return p.hints.Step
+}
+
+func (p *prometheusHint) GetFunc() []string {
+	return []string{p.hints.Func}
+}
+
+func (p *prometheusHint) GetGrouping(f string) []string {
+	// only one func
+	if !p.hints.By {
+		return nil
+	}
+	return p.hints.Grouping
+}
+
+func (p *prometheusHint) GetQuery() string {
+	return p.query
+}
+
+func (p *prometheusHint) GetMetric() string {
+	return extractMetricName(&p.matchers)
+}
+
+func (p *prometheusHint) GetRange(f string) int64 {
+	return p.hints.Range
+}
+
+func (p *prometheusHint) GetLabels() []*labels.Matcher {
+	return p.matchers
+}
+
+func (p *prometheusHint) GetBy() bool {
+	return p.hints.By
+}
+
+// not implement
+func (p *prometheusHint) GetFuncParam(f string) float64 {
+	return 0
+}
+
+func newQueryAnalyzer(lookBackDelta time.Duration) *queryAnalyzer {
+	return &queryAnalyzer{
+		lookBackDelta:  lookBackDelta,
+		offloadEnabled: offloadEnabled,
+	}
+}
+
+func (d *queryAnalyzer) parsePromQL(qry string, start time.Time, end time.Time, interval time.Duration) []model.QueryRequest {
+	// build Expr from promql analysis
+	expr, err := parser.ParseExpr(qry)
+	if err != nil {
+		return nil
+	}
+	stmt := &parser.EvalStmt{
+		Expr:     promql.PreprocessExpr(expr, start, end),
+		Start:    start,
+		End:      end,
+		Interval: interval,
+	}
+	return d.parseStmt(stmt)
+}
+
+/*
+difference between SelectHints & combinHint:
+in prometheus, SelectHints only extract inner function for <VectorSelector> and get the max query [range]
+but we may need multiple functions query in clickhouse, like: sum(rate(metric[1d])) should get only 1 point from database, not 1d
+so use CombineHint to get multiple functions outside of <VectorSelector>
+*/
+func (d *queryAnalyzer) parseStmt(stmt *parser.EvalStmt) []model.QueryRequest {
+	result := make([]model.QueryRequest, 0)
+	var evalRange time.Duration
+	parser.Inspect(stmt.Expr, func(node parser.Node, path []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.VectorSelector:
+			start, end := d.getTimeRangesForSelector(stmt, n, path, evalRange)
+
+			queryHint := &QueryHint{
+				start:    start,
+				end:      end,
+				step:     durationMilliseconds(stmt.Interval),
+				matchers: n.LabelMatchers,
+				funcs:    extractSubFunctionFromPath(path),
+				query:    stmt.String(),
+			}
+			evalRange = 0
+			result = append(result, queryHint)
+
+			// hints := &storage.SelectHints{
+			// 	Start: start,
+			// 	End:   end,
+			// 	Step:  durationMilliseconds(stmt.Interval),
+			// 	Range: durationMilliseconds(evalRange),
+			// 	Func:  extractFuncFromPath(path),
+			// }
+			// hints.By, hints.Grouping = extractGroupsFromPath(path)
+
+			// prometheusHint := &prometheusHint{
+			// 	hints:    hints,
+			// 	matchers: n.LabelMatchers,
+			// 	query:    stmt.String(),
+			// }
+
+			// result = append(result, prometheusHint)
+
+		case *parser.MatrixSelector:
+			// matrix range is the query range of inside vector, evalRange will retrive in *parser.VectorSelector case
+			// e.g.: test[1h] == <MatrixSelector>, `test` == <VectorSelector>, [1h] == <Range>
+			evalRange = n.Range
+		}
+
+		return nil
+	})
+	return result
+}
+
+func (d *queryAnalyzer) getTimeRangesForSelector(s *parser.EvalStmt, n *parser.VectorSelector, path []parser.Node, evalRange time.Duration) (int64, int64) {
+	start, end := timestamp.FromTime(s.Start), timestamp.FromTime(s.End)
+	subqOffset, subqRange, subqTs := subqueryTimes(path)
+
+	if subqTs != nil {
+		// The timestamp on the subquery overrides the eval statement time ranges.
+		start = *subqTs
+		end = *subqTs
+	}
+
+	if n.Timestamp != nil {
+		// The timestamp on the selector overrides everything.
+		start = *n.Timestamp
+		end = *n.Timestamp
+	} else {
+		offsetMilliseconds := durationMilliseconds(subqOffset)
+		start = start - offsetMilliseconds - durationMilliseconds(subqRange)
+		end -= offsetMilliseconds
+	}
+
+	if evalRange == 0 {
+		start -= durationMilliseconds(d.lookBackDelta)
+	} else {
+		// For all matrix queries we want to ensure that we have (end-start) + range selected
+		// this way we have `range` data before the start time
+		start -= durationMilliseconds(evalRange)
+	}
+
+	offsetMilliseconds := durationMilliseconds(n.OriginalOffset)
+	start -= offsetMilliseconds
+	end -= offsetMilliseconds
+
+	return start, end
+}
+
+func subqueryTimes(path []parser.Node) (time.Duration, time.Duration, *int64) {
+	var (
+		subqOffset, subqRange time.Duration
+		ts                    int64 = math.MaxInt64
+	)
+	for _, node := range path {
+		if n, ok := node.(*parser.SubqueryExpr); ok {
+			subqOffset += n.OriginalOffset
+			subqRange += n.Range
+			if n.Timestamp != nil {
+				// The @ modifier on subquery invalidates all the offset and
+				// range till now. Hence resetting it here.
+				subqOffset = n.OriginalOffset
+				subqRange = n.Range
+				ts = *n.Timestamp
+			}
+		}
+	}
+	var tsp *int64
+	if ts != math.MaxInt64 {
+		tsp = &ts
+	}
+	return subqOffset, subqRange, tsp
+}
+
+// extracts `minimum possible` calculation unit for ck
+func extractSubFunctionFromPath(p []parser.Node) []functionCall {
+	funcs := make([]functionCall, 0, len(p))
+	if len(p) == 0 {
+		return funcs
+	}
+	var evalRange time.Duration
+	for i := len(p) - 1; i >= 0; i-- {
+		switch n := p[i].(type) {
+		case *parser.AggregateExpr:
+			// AggregateExpr: sum/avg/group...
+			if n.Without {
+				// if group without, we can not offload this function, return funcs
+				return funcs
+			}
+			var p float64 = 0
+			if n.Param != nil {
+				// p for topk(N) & quantile(N)
+				if numExpr, ok := n.Param.(*parser.NumberLiteral); ok {
+					p = numExpr.Val
+				}
+			}
+			f := functionCall{Name: n.Op.String(), Grouping: n.Grouping, Range: evalRange, Param: p}
+			evalRange = 0
+			funcs = append(funcs, f)
+		case *parser.Call:
+			// Call: rate/delta/increase/x_over_time...
+			f := functionCall{Name: n.Func.Name, Range: evalRange}
+			evalRange = 0
+			funcs = append(funcs, f)
+		case *parser.MatrixSelector:
+			evalRange = n.Range
+		default:
+			// other Expr can not be offloaded, when we meet other `Expr`, return funcs
+			return funcs
+		}
+	}
+	return funcs
+}
+
+// get the inner function of <VectorSelector>
+func extractFuncFromPath(p []parser.Node) string {
+	if len(p) == 0 {
+		return ""
+	}
+	switch n := p[len(p)-1].(type) {
+	case *parser.AggregateExpr:
+		return n.Op.String()
+	case *parser.Call:
+		return n.Func.Name
+	case *parser.BinaryExpr:
+		// If we hit a binary expression we terminate since we only care about functions
+		// or aggregations over a single metric.
+		return ""
+	}
+	return extractFuncFromPath(p[:len(p)-1])
+}
+
+// extractGroupsFromPath parses vector outer function and extracts grouping information if by or without was used.
+func extractGroupsFromPath(p []parser.Node) (bool, []string) {
+	if len(p) == 0 {
+		return false, nil
+	}
+	switch n := p[len(p)-1].(type) {
+	case *parser.AggregateExpr:
+		return !n.Without, n.Grouping
+	}
+	return false, nil
+}
+
+func extractMetricName(matchers *[]*labels.Matcher) string {
+	var metric string
+	for _, v := range *matchers {
+		if v.Name == labels.MetricName {
+			metric = v.Value
+			break
+		}
+	}
+	return metric
+}

--- a/server/querier/app/prometheus/service/analyzer.go
+++ b/server/querier/app/prometheus/service/analyzer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/service/analyzer_test.go
+++ b/server/querier/app/prometheus/service/analyzer_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/service/analyzer_test.go
+++ b/server/querier/app/prometheus/service/analyzer_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analyzer := newQueryAnalyzer(5 * time.Minute)
+
+	t.Run("test parser count_over_time(node_cpu_seconds_total[5m])", func(t *testing.T) {
+		qrs := analyzer.parsePromQL("count_over_time(node_cpu_seconds_total[5m])", time.Now(), time.Now(), 1*time.Minute)
+		assert.Greater(t, len(qrs), 0)
+		qr0 := qrs[0]
+		assert.Equal(t, qr0.GetFunc(), []string{"count_over_time"})
+		assert.Equal(t, qr0.GetRange("count_over_time"), (5 * time.Minute).Milliseconds())
+	})
+
+	t.Run("test parser max by (namespace,pod,node,owner_name,owner_kind,qos,cluster)(kube_pod_info{})", func(t *testing.T) {
+		qrs := analyzer.parsePromQL("max by (namespace,pod,node,owner_name,owner_kind,qos,cluster)(kube_pod_info{})", time.Now(), time.Now(), 1*time.Minute)
+		assert.Greater(t, len(qrs), 0)
+		qr0 := qrs[0]
+		assert.Equal(t, qr0.GetFunc(), []string{"max"})
+		assert.Equal(t, qr0.GetGrouping("max"), []string{"namespace", "pod", "node", "owner_name", "owner_kind", "qos", "cluster"})
+	})
+
+	t.Run("test parser sum(irate(apiserver_request_total[5m])) by (verb,cluster)", func(t *testing.T) {
+		qrs := analyzer.parsePromQL("sum(irate(apiserver_request_total[5m])) by (verb,cluster)", time.Now(), time.Now(), 1*time.Minute)
+		assert.Greater(t, len(qrs), 0)
+		qr0 := qrs[0]
+		assert.Equal(t, qr0.GetFunc(), []string{"irate", "sum"})
+		assert.Equal(t, qr0.GetRange("irate"), (5 * time.Minute).Milliseconds())
+		assert.Equal(t, qr0.GetGrouping("sum"), []string{"verb", "cluster"})
+	})
+
+	t.Run(`test parser (sum by(cluster) (rate(scheduler_e2e_scheduling_duration_seconds_sum{job="kube-scheduler"}[1h]))  / sum by(cluster) (rate(scheduler_e2e_scheduling_duration_seconds_count{job="kube-scheduler"}[1h])))`, func(t *testing.T) {
+		qrs := analyzer.parsePromQL(`(sum by(cluster) (rate(scheduler_e2e_scheduling_duration_seconds_sum{job="kube-scheduler"}[1h]))  / sum by(cluster) (rate(scheduler_e2e_scheduling_duration_seconds_count{job="kube-scheduler"}[1h])))`, time.Now(), time.Now(), 1*time.Minute)
+		assert.Greater(t, len(qrs), 0)
+		qr0 := qrs[0]
+		assert.Equal(t, qr0.GetFunc(), []string{"rate", "sum"})
+		assert.Equal(t, qr0.GetRange("rate"), (1 * time.Hour).Milliseconds())
+		assert.Equal(t, qr0.GetGrouping("sum"), []string{"cluster"})
+
+		qr1 := qrs[1]
+		assert.Equal(t, qr1.GetFunc(), []string{"rate", "sum"})
+		assert.Equal(t, qr1.GetRange("rate"), (1 * time.Hour).Milliseconds())
+		assert.Equal(t, qr1.GetGrouping("sum"), []string{"cluster"})
+	})
+}

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -233,6 +233,10 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		}
 	}
 
+	if q.Hints.Func == "topk" || q.Hints.Func == "bottomk" {
+		p.slimit = -1
+	}
+
 	// append query field: 2. append metric name
 	if db == "" || db == chCommon.DB_NAME_PROMETHEUS {
 		// append metricName `value`
@@ -559,7 +563,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 	// Scan all the results, determine the seriesID of each sample and the number of samples in each series,
 	// so that the size of the sample array in each series can be determined in advance.
 	maxPossibleSeries := len(result.Values)
-	if maxPossibleSeries > p.slimit {
+	if maxPossibleSeries > p.slimit && p.slimit > 0 {
 		maxPossibleSeries = p.slimit
 	}
 
@@ -641,7 +645,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			sampleSeriesIndex[i] = index
 			seriesSampleCount[index]++
 		} else {
-			if len(seriesIndexMap) >= p.slimit {
+			if len(seriesIndexMap) >= p.slimit && p.slimit > 0 {
 				sampleSeriesIndex[i] = -1
 				continue
 			}

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -25,10 +25,11 @@ import (
 	"time"
 
 	"github.com/goccy/go-json"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
 
-	"github.com/deepflowio/deepflow/server/libs/datastructure"
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/config"
 	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
@@ -64,8 +65,6 @@ const (
 	IGNORABLE_TAG_TYPE = "map"
 )
 
-var QPSLeakyBucket *datastructure.LeakyBucket
-
 // /querier/engine/clickhouse/clickhouse.go: `pod_ingress` and `lb_listener` are not supported by select
 // `time` as tag is pointless
 var ignorableTagNames = []string{"pod_ingress", "lb_listener", "time"}
@@ -75,12 +74,6 @@ var edgeTableNames = []string{
 	VTAP_APP_EDGE_PORT_TABLE,
 	L4_FLOW_LOG_TABLE,
 	L7_FLOW_LOG_TABLE,
-}
-
-// rules for convert prom tag to native tag when query prometheus metrics
-var matcherRules = map[string]string{
-	"k8s_label_": "k8s.label.",
-	"cloud_tag_": "cloud.tag.",
 }
 
 // definition: https://github.com/prometheus/prometheus/blob/main/promql/parser/lex.go#L106
@@ -114,16 +107,10 @@ const (
 
 type ctxKeyPrefixType struct{}
 
-func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest, startTime int64, endTime int64) (context.Context, string, string, string, string, error) {
-	// QPS Limit Check
-	// Both SetRate and Acquire are expanded by 1000 times, making it suitable for small QPS scenarios.
-	if !QPSLeakyBucket.Acquire(1000) {
-		return ctx, "", "", "", "", errors.New("Prometheus query rate exceeded!")
-	}
-
+func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb.ReadRequest, startTime int64, endTime int64, debug bool) (context.Context, string, string, string, string, error) {
 	queriers := req.Queries
 	if len(queriers) < 1 {
-		return ctx, "", "", "", "", errors.New("len(req.Queries) == 0, this feature is not yet implemented!")
+		return ctx, "", "", "", "", errors.New("len(req.Queries) == 0, this feature is not yet implemented! ")
 	}
 	q := queriers[0]
 
@@ -290,11 +277,11 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		}
 
 		if db == "" || db == chCommon.DB_NAME_PROMETHEUS || db == chCommon.DB_NAME_EXT_METRICS {
-			if isDeepFlowTag {
-				if len(q.Hints.Grouping) == 0 || tagAlias != "" {
-					expectedDeepFlowNativeTags[tagName] = tagAlias
-				}
-			} else if config.Cfg.Prometheus.RequestQueryWithDebug {
+			if isDeepFlowTag && (len(q.Hints.Grouping) == 0 || tagAlias != "") {
+				expectedDeepFlowNativeTags[tagName] = tagAlias
+			}
+
+			if !isDeepFlowTag && debug {
 				// append in query for analysis (findout if tag is target_label)
 				expectedDeepFlowNativeTags[tagName] = tagAlias
 			}
@@ -478,57 +465,56 @@ func parsePrometheusTag(tag string) string {
 	return fmt.Sprintf("`tag.%s`", tag)
 }
 
+func removePrometheusTagPrefix(tag string) string {
+	return strings.Replace(tag, "tag.", "", 1)
+}
+
 func (p *prometheusReader) parsePromQLTag(prefixType prefix, db, tag string) (tagName string, tagAlias string, isDeepFlowTag bool) {
-	switch prefixType {
-	case prefixTag:
-		// query ext_metrics/prometheus
-		if strings.HasPrefix(tag, "tag_") {
-			tagName = parsePrometheusTag(removeTagPrefix(tag))
-			isDeepFlowTag = false
-		} else {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(tag))
-			isDeepFlowTag = true
-		}
-	case prefixDeepFlow:
-		// query prometheus native metrics
-		if strings.HasPrefix(tag, config.Cfg.Prometheus.AutoTaggingPrefix) {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(removeDeepFlowPrefix(tag)))
-			isDeepFlowTag = true
-		} else {
-			tagName = parsePrometheusTag(removeTagPrefix(tag))
-			isDeepFlowTag = false
-		}
-	default:
-		// query deepflow native metrics (deepflow_system/flow_metrics/flow_log)
-		if db == chCommon.DB_NAME_DEEPFLOW_SYSTEM {
-			tagName = parsePrometheusTag(tag)
-		} else {
-			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(tag))
-		}
+	// set flag
+	if prefixType == prefixNone {
 		isDeepFlowTag = true
 	}
-	// `tagAlias` return only when tag is `enum tag`
+	if prefixType == prefixTag && !strings.HasPrefix(tag, "tag_") {
+		isDeepFlowTag = true
+	}
+	if prefixType == prefixDeepFlow && strings.HasPrefix(tag, config.Cfg.Prometheus.AutoTaggingPrefix) {
+		isDeepFlowTag = true
+	}
+
+	// `tagAlias` return only when tag is `enum tag` (returns `Enum(tag)` as `_tag_enum`)
+	if isDeepFlowTag {
+		if strings.HasPrefix(tag, config.Cfg.Prometheus.AutoTaggingPrefix) {
+			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(removeDeepFlowPrefix(tag)))
+		} else {
+			tagName, tagAlias = parseDeepFlowTag(prefixType, p.convertToQuerierAllowedTagName(tag))
+		}
+	} else {
+		// query ext_metrics/prometheus
+		// query deepflow native metrics (deepflow_system/flow_metrics/flow_log)
+		tagName = parsePrometheusTag(removeTagPrefix(tag))
+	}
+
+	// deepflow_system don't have any DeepFlow universal tag, overwrite the tagName
+	if db == chCommon.DB_NAME_DEEPFLOW_SYSTEM {
+		tagName = parsePrometheusTag(tag)
+		tagAlias = ""
+	}
 	return
 }
 
 func parseToQuerierSQL(ctx context.Context, db string, table string, metrics []string, filters []string, groupBy []string, orderBy []string) (sql string) {
 	// order by DESC for get data completely, then scan data reversely for data combine(see func.RespTransToProm)
 	// querier will be called later, so there is no need to display the declaration db
-	if db != "" {
-		sqlBuilder := strings.Builder{}
-		sqlBuilder.WriteString(fmt.Sprintf("SELECT %s FROM `%s` WHERE %s ", strings.Join(metrics, ","), table, strings.Join(filters, " AND ")))
-		if len(groupBy) > 0 {
-			sqlBuilder.WriteString("GROUP BY " + strings.Join(groupBy, ","))
-		}
-		sqlBuilder.WriteString(fmt.Sprintf(" ORDER BY %s LIMIT %s", strings.Join(orderBy, ","), config.Cfg.Prometheus.Limit))
-		sql = sqlBuilder.String()
-	} else {
-		sql = fmt.Sprintf("SELECT %s FROM `%s` WHERE %s ORDER BY %s LIMIT %s", strings.Join(metrics, ","),
-			table, // equals prometheus metric name
-			strings.Join(filters, " AND "),
-			strings.Join(orderBy, ","), config.Cfg.Prometheus.Limit)
+	sqlBuilder := strings.Builder{}
+	sqlBuilder.WriteString(fmt.Sprintf("SELECT %s FROM `%s` WHERE %s ",
+		strings.Join(metrics, ","),
+		table,
+		strings.Join(filters, " AND ")))
+	if len(groupBy) > 0 {
+		sqlBuilder.WriteString("GROUP BY " + strings.Join(groupBy, ","))
 	}
-	return
+	sqlBuilder.WriteString(fmt.Sprintf(" ORDER BY %s LIMIT %s", strings.Join(orderBy, ","), config.Cfg.Prometheus.Limit))
+	return sqlBuilder.String()
 }
 
 // querier result trans to Prom Response
@@ -613,6 +599,29 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			}
 			promFilterTagJson, _ := json.Marshal(filterTagMap)
 			deepflowNativeTagString = string(promFilterTagJson)
+		} else if len(tagsFieldIndex) > 0 {
+			// agg prometheus query, directly get tag.x
+			filterTagMap = make(map[string]string, len(tagsFieldIndex))
+			for idx := range tagsFieldIndex {
+				name := removePrometheusTagPrefix(result.Columns[idx].(string))
+				val := values[idx].(string)
+
+				if name == "" || val == "" {
+					continue
+				}
+				// ignore replica labels if passed
+				if config.Cfg.Prometheus.ThanosReplicaLabels != nil && common.IsValueInSliceString(name, config.Cfg.Prometheus.ThanosReplicaLabels) {
+					continue
+				}
+				filterTagMap[name] = val
+			}
+			promFilterTagJson, _ := json.Marshal(filterTagMap)
+			deepflowNativeTagString = string(promFilterTagJson)
+		} else {
+			// if tagIndex = -1 and len(tagsFieldIndex) = 0, append metric name
+			filterTagMap = map[string]string{PROMETHEUS_METRICS_NAME: metricsName}
+			promFilterTagJson, _ := json.Marshal(filterTagMap)
+			deepflowNativeTagString = string(promFilterTagJson)
 		}
 
 		// merge deepflow autotagging tags
@@ -639,7 +648,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 
 			// tag label pair
 			var pairs []prompb.Label
-			if tagIndex > -1 && filterTagMap != nil {
+			if len(filterTagMap) > 0 { // has any prometheus tag
 				pairs = make([]prompb.Label, 0, 1+len(filterTagMap)+len(allDeepFlowNativeTags))
 				for k, v := range filterTagMap {
 					if prefix == prefixTag {
@@ -668,7 +677,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 				if isZero(values[idx]) {
 					continue
 				}
-				if tagIndex > -1 && prefix == prefixDeepFlow {
+				if (len(filterTagMap) > 0) && prefix == prefixDeepFlow {
 					// deepflow tag for prometheus metrics
 					formatTag := formatTagName(result.Columns[idx].(string))
 					pairs = append(pairs, prompb.Label{
@@ -690,10 +699,13 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			if len(pairs) == 0 {
 				continue
 			}
-			pairs = append(pairs, prompb.Label{
-				Name:  PROMETHEUS_METRICS_NAME,
-				Value: metricsName,
-			})
+			// avoid duplicated __name__ label
+			if filterTagMap[PROMETHEUS_METRICS_NAME] == "" {
+				pairs = append(pairs, prompb.Label{
+					Name:  PROMETHEUS_METRICS_NAME,
+					Value: metricsName,
+				})
+			}
 			series = &prompb.TimeSeries{Labels: pairs}
 			seriesArray = append(seriesArray, series)
 
@@ -722,18 +734,35 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			metricsValue = 0
 			continue
 		}
-		if metricsType == "Int" {
+
+		switch metricsType {
+		case "Int":
 			metricsValue = float64(values[metricsIndex].(int))
-		} else if metricsType == "Float64" {
+		case "Float64":
 			// metricsType == "Float64" but typeof(values[metricsIndex]) is `int` ?? for robustness add type assert
 			val, ok := values[metricsIndex].(float64)
 			if ok {
 				metricsValue = val
 			} else {
-				metricsValue = float64(values[metricsIndex].(int))
+				metricsValueInt, ok := values[metricsIndex].(int)
+				if !ok {
+					continue
+				}
+				metricsValue = float64(metricsValueInt)
 			}
-		} else {
-			return nil, fmt.Errorf("Unknown metrics type %s, value = %v", metricsType, values[metricsIndex])
+		// for Arrays(use topk() aggregation), it group by timestamp & tag.*, so it won't get multiple values per time & tag, get index [0] is OK
+		case "Array(Int)":
+			metricsArrayInt := values[metricsIndex].(*[]int)
+			if len(*metricsArrayInt) > 0 {
+				metricsValue = float64((*metricsArrayInt)[0])
+			}
+		case "Array(Float64)":
+			metricsValueArray := values[metricsIndex].(*[]float64)
+			if len(*metricsValueArray) > 0 {
+				metricsValue = (*metricsValueArray)[0]
+			}
+		default:
+			return nil, fmt.Errorf("unknown metrics type %s, value = %v ", metricsType, values[metricsIndex])
 		}
 
 		// add a sample for the TimeSeries
@@ -761,6 +790,134 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 	}
 	resp.Results[0].Timeseries = append(resp.Results[0].Timeseries, seriesArray...)
 	return resp, nil
+}
+
+func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq model.QueryRequest, queryType model.QueryType) string {
+	// get funcs
+	funcs := queryReq.GetFunc()
+	f0, f1 := "", ""
+	if len(funcs) > 0 {
+		f0 = funcs[0]
+	}
+	// when len(funcs)>1, only support aggregate for rates like sum(rate)/avg(irate)
+	// not support multiple aggregate like sum(sum)/sum(avg)... (require subquery)
+	if len(funcs) > 1 {
+		f1 = funcs[1]
+	}
+
+	// group by
+	groupBy := make([]string, 0, len(queryReq.GetGrouping(f0))+len(queryReq.GetGrouping(f1))+1)
+	expectedQueryTags := make(map[string]string, cap(groupBy)+len(queryReq.GetLabels())-1)
+
+	handleTagFunc := func(tag string) string {
+		tagName, tagAlias, _ := p.parsePromQLTag(prefixDeepFlow, chCommon.DB_NAME_PROMETHEUS, tag)
+		expectedQueryTags[tagName] = tagAlias
+		return tagName
+	}
+
+	// filter
+	start := queryReq.GetStart() / 1000
+	end := queryReq.GetEnd() / 1000
+	if queryReq.GetEnd()%1000 > 0 {
+		end += 1
+	}
+	filters := make([]string, 0, len(queryReq.GetLabels())+1)
+	// include Range in Start to End
+	filters = append(filters, fmt.Sprintf("(time >= %d AND time <= %d)", start, end))
+	// build filter
+	for _, matcher := range queryReq.GetLabels() {
+		if matcher.Name == labels.MetricName {
+			continue
+		}
+		operation, value := getLabelMatcher(parseMatcherType(matcher.Type), matcher.Value)
+		if operation == "" {
+			continue
+		}
+
+		// TODO: confirm Enum here
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, chCommon.DB_NAME_PROMETHEUS, matcher.Name)
+		if isDeepFlowTag && tagAlias != "" {
+			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagAlias, operation, value))
+		} else {
+			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagName, operation, value))
+		}
+
+		if isDeepFlowTag && cap(groupBy) == 0 {
+			// if not grouping tag, but use filter or has alias for enum tag, append into `expectedDeepFlowNativeTags` for `select df_tag`
+			// why cap(groupBy) == 0: select would influence group result, so when cap(groupBy)>0, we don't append select
+			expectedQueryTags[tagName] = tagAlias
+		}
+	}
+
+	// order
+	orderBy := []string{fmt.Sprintf("%s desc", PROMETHEUS_TIME_COLUMNS)}
+
+	// select
+	selection := []string{fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)}
+	if queryType == model.Range {
+		interval := queryReq.GetStep()
+		offset := queryReq.GetStart() % interval
+		selection[0] = fmt.Sprintf("time(time, %d, 1, 0, %d) AS %s", interval/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS)
+	}
+
+	// build selection
+	metricAlias := "value"
+	call := QueryFuncCall[f0]
+	if call == nil {
+		return ""
+	}
+
+	call(metricAlias, &selection, &orderBy, &groupBy, queryReq, queryType, handleTagFunc)
+
+	if strings.HasSuffix(f0, "rate") {
+		if f1 == "" {
+			lastQuery := &(selection[len(selection)-1])
+			*lastQuery = fmt.Sprintf("Last(%s)", *lastQuery)
+		} else {
+			// for irate/rate, get f1 for sum(rate)/avg(rate) ...
+			// remove last query `Derivative(value)` & `tag` for another group by
+			lastQuery := selection[len(selection)-1]
+			selection = selection[:len(selection)-2]
+			groupBy = groupBy[:len(groupBy)-1]
+
+			call_agg := QueryFuncCall[f1]
+			if call_agg != nil {
+				call_agg(lastQuery, &selection, &orderBy, &groupBy, queryReq, queryType, handleTagFunc)
+			}
+		}
+	}
+
+	// alias
+	lastQuery := &(selection[len(selection)-1])
+	*lastQuery = fmt.Sprintf("%s as %s", *lastQuery, metricAlias)
+
+	for tagName, tagAlias := range expectedQueryTags {
+		if tagAlias == "" {
+			selection = append(selection, tagName)
+		} else {
+			selection = append(selection, fmt.Sprintf("%s as %s", tagName, tagAlias))
+		}
+	}
+
+	// timestamp
+	groupBy = append(groupBy, PROMETHEUS_TIME_COLUMNS)
+	sql := parseToQuerierSQL(ctx, chCommon.DB_NAME_PROMETHEUS, queryReq.GetMetric(), selection, filters, groupBy, orderBy)
+	return sql
+}
+
+func parseMatcherType(t labels.MatchType) prompb.LabelMatcher_Type {
+	switch t {
+	case labels.MatchEqual:
+		return prompb.LabelMatcher_EQ
+	case labels.MatchNotEqual:
+		return prompb.LabelMatcher_NEQ
+	case labels.MatchRegexp:
+		return prompb.LabelMatcher_RE
+	case labels.MatchNotRegexp:
+		return prompb.LabelMatcher_NRE
+	default:
+		return prompb.LabelMatcher_EQ
+	}
 }
 
 // match prometheus lable matcher type

--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -22,13 +22,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/deepflowio/deepflow/server/libs/datastructure"
+	"github.com/deepflowio/deepflow/server/libs/lru"
 	cfg "github.com/deepflowio/deepflow/server/querier/app/prometheus/config"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/config"
+	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
+	tagdescription "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/tag"
 )
 
 type promqlParse struct {
@@ -63,13 +67,18 @@ type promqlHints struct {
 
 func TestMain(m *testing.M) {
 	// init runtime objects for tests
-	QPSLeakyBucket = new(datastructure.LeakyBucket)
-	QPSLeakyBucket.Init(1e9)
-	config.Cfg = &config.QuerierConfig{Limit: "10000", Prometheus: cfg.Prometheus{AutoTaggingPrefix: "df_", ExternalTagCacheSize: 1024, ExternalTagLoadInterval: 300}}
-
+	config.Cfg = &config.QuerierConfig{
+		Limit:    "10000",
+		Language: "en",
+		Prometheus: cfg.Prometheus{
+			Limit:                   "1000000",
+			AutoTaggingPrefix:       "df_",
+			ExternalTagCacheSize:    1024,
+			ExternalTagLoadInterval: 300,
+		},
+	}
 	// run for test
 	m.Run()
-	QPSLeakyBucket.Close()
 }
 
 func TestParseMetric(t *testing.T) {
@@ -362,7 +371,7 @@ func TestPromReaderTransToSQL(t *testing.T) {
 				},
 			})
 
-			_, sql, db, ds, metricName, err := prometheusReader.promReaderTransToSQL(ctx, &prompb.ReadRequest{Queries: queries}, startMs, endMs)
+			_, sql, db, ds, metricName, err := prometheusReader.promReaderTransToSQL(ctx, &prompb.ReadRequest{Queries: queries}, startMs, endMs, false)
 
 			if !p.hasError {
 				So(err, ShouldBeNil)
@@ -377,14 +386,459 @@ func TestPromReaderTransToSQL(t *testing.T) {
 	})
 }
 
-func TestParseQuerierSQL(t *testing.T) {
-	svc := NewPrometheusService()
-	args := model.PromQueryParams{
-		Promql:    "apiserver_admission_step_admission_duration_seconds_summary_count[10m]",
-		StartTime: "1690284145",
-		EndTime:   "1690284145",
-		Context:   context.Background(),
+func TestParsePromQLTag(t *testing.T) {
+	// mock test data
+	executor := &prometheusExecutor{
+		extraLabelCache: lru.NewCache[string, string](1),
 	}
-	result, err := svc.PromInstantQueryService(&args, args.Context)
-	fmt.Println(err, result)
+	executor.extraLabelCache.Add("app_kubernetes_io_managed_by", "app.kubernetes.io/managed-by")
+	p := &prometheusReader{}
+	p.getExternalTagFromCache = executor.convertExternalTagToQuerierAllowTag
+	tagdescription.TAG_ENUMS["l7_protocol"] = []*tagdescription.TagEnum{{Value: 20, DisplayName: "HTTP"}}
+	tagdescription.TAG_ENUMS["auto_service_type.ch"] = []*tagdescription.TagEnum{{Value: 1, DisplayName: "云服务器"}}
+	tagdescription.TAG_ENUMS["auto_service_type.en"] = []*tagdescription.TagEnum{{Value: 1, DisplayName: "Cloud Host"}}
+
+	// Test cases generation
+	// Test cases for prefixType prefixTag
+	t.Run("prefixType prefixTag - tag starts with tag_", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixTag, "prometheus", "tag_example")
+		assert.Equal(t, "`tag.example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.False(t, isDeepFlowTag)
+	})
+
+	t.Run("prefixType prefixTag - tag does not start with tag_", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixTag, "ext_metrics", "example")
+		assert.Equal(t, "`example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	// Test cases for prefixType prefixDeepFlow
+	t.Run("prefixType prefixDeepFlow - tag starts with AutoTaggingPrefix", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, "", "df_example")
+		assert.Equal(t, "`example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	t.Run("prefixType prefixDeepFlow - tag does not start with AutoTaggingPrefix", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, "", "example")
+		assert.Equal(t, "`tag.example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.False(t, isDeepFlowTag)
+	})
+
+	// Test case for default prefixType
+	t.Run("default prefixType", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixNone, chCommon.DB_NAME_DEEPFLOW_SYSTEM, "example")
+		assert.Equal(t, "`tag.example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	t.Run("default prefixType - db is not deepflow system", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixNone, "other_db", "example")
+		assert.Equal(t, "`example`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	// Test cases for `app_kubernetes_io_managed_by` tag
+	t.Run("test case for app_kubernetes_io_managed_by tag", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, "prometheus", "df_app_kubernetes_io_managed_by")
+		assert.Equal(t, "`app.kubernetes.io/managed-by`", tagName)
+		assert.Equal(t, "", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	// Test cases for get tagAlias on Enum Tag
+	t.Run("test case for get tagAlias on enum tag", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, "prometheus", "df_l7_protocol")
+		assert.Equal(t, "Enum(l7_protocol)", tagName)
+		assert.Equal(t, "`l7_protocol_enum`", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+
+	// Test cases for get tagAlias on Enum Tag with languages
+	t.Run("test case for get tagAlias on enum tag", func(t *testing.T) {
+		tagName, tagAlias, isDeepFlowTag := p.parsePromQLTag(prefixDeepFlow, "prometheus", "df_auto_service_type")
+		assert.Equal(t, "Enum(auto_service_type)", tagName)
+		assert.Equal(t, "`auto_service_type_enum`", tagAlias)
+		assert.True(t, isDeepFlowTag)
+	})
+}
+
+type queryRequestParse struct {
+	input *QueryHint
+
+	output string
+	err    error
+}
+
+func TestParseQueryRequestToSQL(t *testing.T) {
+	p := &prometheusReader{}
+	ctx := context.Background()
+	start := time.Now().Add(-30 * time.Minute).Unix()
+	end := time.Now().Unix()
+	startMs := start * 1000
+	endMs := end * 1000
+	min_5 := 5 * time.Minute
+	var interval int64 = 14 * 1000
+
+	// instant query
+	instantQueryTestcases := []queryRequestParse{
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval sum(rate(node_cpu_seconds_total[5m])) by (cpu)",
+				funcs: []functionCall{
+					{Range: min_5, Name: "rate"},
+					{Name: "sum", Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, %d, 1, 0, %d) AS timestamp,Sum(Derivative(value,`tag`)) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", int64(min_5.Seconds()), (startMs%min_5.Milliseconds())/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval sum(node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "sum", Grouping: []string{"cpu"}, Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval topk(10, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "topk", Grouping: []string{"cpu"}, Param: 10},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,topK(value, 10) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval bottomk(10, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "bottomk", Grouping: []string{"cpu"}, Param: 10},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: "",
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval present_over_time(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{
+					{Name: "present_over_time", Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,1 as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval sum_over_time(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{
+					{Name: "sum_over_time", Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Sum(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval sum(sum_over_time(node_cpu_seconds_total[5m]))by(cpu)",
+				funcs: []functionCall{
+					{Name: "sum_over_time", Range: min_5},
+					{Name: "sum", Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Sum(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval quantile(0.5, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "quantile", Param: 0.5, Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,Percentile(value, 0.5) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval rate(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{{Name: "rate", Range: min_5}},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, %d, 1, 0, %d) AS timestamp,`tag`,Last(Derivative(value,`tag`)) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", int64(min_5.Seconds()), (startMs%min_5.Milliseconds())/1e3, start, end),
+			err:    nil,
+		},
+	}
+
+	// range query
+	rangeQueryTestcases := []queryRequestParse{
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval, // 14s
+				query: "eval sum(rate(node_cpu_seconds_total[5m])) by (cpu)",
+				funcs: []functionCall{
+					{Range: min_5, Name: "rate"},
+					{Name: "sum", Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,Sum(Derivative(value,`tag`)) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval sum(node_cpu_seconds_total[5m]) by (cpu)",
+				funcs: []functionCall{
+					{Name: "sum", Grouping: []string{"cpu"}, Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval topk(10, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "topk", Grouping: []string{"cpu"}, Param: 10},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,`tag`,topK(value, 10) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval bottomk(10, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "bottomk", Grouping: []string{"cpu"}, Param: 10},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: "",
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval present_over_time(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{
+					{Name: "present_over_time", Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,`tag`,1 as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval sum_over_time(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{
+					{Name: "sum_over_time", Range: min_5},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,`tag`,Last(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval sum(sum_over_time(node_cpu_seconds_total[5m])) by (cpu)",
+				funcs: []functionCall{
+					{Name: "sum_over_time", Range: min_5},
+					{Name: "sum", Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,`tag`,Last(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  interval,
+				query: "eval quantile(0.5, node_cpu_seconds_total) by (cpu)",
+				funcs: []functionCall{
+					{Name: "quantile", Param: 0.5, Grouping: []string{"cpu"}},
+				},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+				},
+			},
+			output: fmt.Sprintf("SELECT time(time, 14, 1, 0, %d) AS timestamp,Percentile(value, 0.5) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			err:    nil,
+		},
+	}
+
+	// instant query
+	for i := 0; i < len(instantQueryTestcases); i++ {
+		t.Run(instantQueryTestcases[i].input.query, func(t *testing.T) {
+			result := p.parseQueryRequestToSQL(ctx, instantQueryTestcases[i].input, model.Instant)
+			if result != instantQueryTestcases[i].output {
+				t.Errorf("Expected SQL: %s, got: %s", instantQueryTestcases[i].output, result)
+			} else {
+				fmt.Printf("parse SQL: %s \n", result)
+			}
+		})
+	}
+
+	// range query
+	for i := 0; i < len(rangeQueryTestcases); i++ {
+		t.Run(rangeQueryTestcases[i].input.query, func(t *testing.T) {
+			result := p.parseQueryRequestToSQL(ctx, rangeQueryTestcases[i].input, model.Range)
+			if result != rangeQueryTestcases[i].output {
+				t.Errorf("Expected SQL: %s, got: %s", rangeQueryTestcases[i].output, result)
+			} else {
+				fmt.Printf("parse SQL: %s \n", result)
+			}
+		})
+	}
+
 }

--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Yunshan Networks
+ * Copyright (c) 2024 Yunshan Networks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
+)
+
+const (
+	_prometheus_tag_key = "`tag`"
+	min_interval        = 10 * time.Second
+)
+
+type offloadEnabledFunc func(string, []string, bool) bool
+
+// validate `func` & `by`, return if the <XSelector> can be offloaded
+func offloadEnabled(metric string, funcs []string, by bool) bool {
+	// if func() without (tags), can not be offloaded
+	// not offloaded DeepFlow Native Metric, because it's already offloaded
+	if strings.Contains(metric, "__") || !by || len(funcs) == 0 {
+		return false
+	}
+
+	// when len(funcs)>2, we don't consider offload
+	// the inner function offloaded <VectorSelector> for data reduce is enough, i.e.: sum(rate(x))
+	maxIterateLevel := math.Min(float64(len(funcs)), 2)
+	for i := 0; i < int(maxIterateLevel); i++ {
+		if QueryFuncCall[funcs[i]] == nil {
+			return false
+		}
+	}
+	return true
+}
+
+type QueryFunc func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string)
+
+// NOTICE: query `value` should be LAST index of `query`, it will append `query` as value outside of QueryFuncCall
+var QueryFuncCall = map[string]QueryFunc{
+	// Vector
+	"avg_over_time": simpleCallMatrixFunc("AAvg"),
+	"count_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*group = append(*group, _prometheus_tag_key)
+		*query = append(*query, _prometheus_tag_key)
+		*query = append(*query, "Count(row)") // change to sum in range query
+	},
+	"last_over_time": simpleCallMatrixFunc("Last"),
+	"max_over_time":  simpleCallMatrixFunc("Max"),
+	"min_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		// `Min` in querier will try get min(value, 0) in the query time window
+		// when use instant query, toUnixTimestamp will use [5m] time window, it required 5m/10s +1=31 data points in time window, otherwise it will get `0`
+		// if(count(`_sum_value`)=31, min(`_sum_value`), 0)
+		// so we specific time window=1s here
+
+		if len(*query) > 0 {
+			(*query)[0] = fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS)
+		} else {
+			*query = append(*query, fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS))
+		}
+
+		*query = append(*query, _prometheus_tag_key)
+		*group = append(*group, _prometheus_tag_key)
+
+		if queryType == model.Instant {
+			*query = append(*query, fmt.Sprintf("%s(%s)", "Min", metric))
+		} else if queryType == model.Range {
+			*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+		}
+	},
+	"stddev_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*query = append(*query, _prometheus_tag_key)
+		*group = append(*group, _prometheus_tag_key)
+
+		if queryType == model.Instant {
+			// timeWindow := req.GetEnd() - req.GetStart()
+			// offset := (req.GetStart() % timeWindow) / 1e3
+			if len(*query) > 0 {
+				(*query)[0] = fmt.Sprintf("%d AS %s", req.GetEnd()/1e3, PROMETHEUS_TIME_COLUMNS)
+				// fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", timeWindow/1e3, offset, PROMETHEUS_TIME_COLUMNS)
+			} else {
+				*query = append(*query, fmt.Sprintf("%d AS %s", req.GetEnd()/1e3, PROMETHEUS_TIME_COLUMNS))
+			}
+			*query = append(*query, fmt.Sprintf("%s(%s)", "Stddev", metric))
+		} else if queryType == model.Range {
+			*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+		}
+	},
+	"sum_over_time": simpleCallMatrixFunc("Sum"),
+	"present_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		// get 1
+		*group = append(*group, _prometheus_tag_key)
+		*query = append(*query, _prometheus_tag_key)
+		*query = append(*query, "1")
+	},
+	"quantile_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*group = append(*group, _prometheus_tag_key)
+		*query = append(*query, _prometheus_tag_key)
+
+		quantile_param := req.GetFuncParam("quantile_over_time")
+		if queryType == model.Instant {
+			*query = append(*query, fmt.Sprintf("%s(%s, %g)", "Percentile", metric, quantile_param))
+		} else if queryType == model.Range {
+			*query = append(*query, fmt.Sprintf("%s(%s)", "Last", metric))
+		}
+	},
+
+	// aggregation operators
+	"sum": simpleCallFunc("sum", "Sum"),
+	"min": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		if len(*query) > 0 {
+			(*query)[0] = fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS)
+		} else {
+			*query = append(*query, fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS))
+		}
+
+		*query = append(*query, fmt.Sprintf("%s(%s)", "Min", metric))
+		*group = append(*group, _prometheus_tag_key)
+		for _, tag := range req.GetGrouping("min") {
+			*group = append(*group, handleLabelsMatch(tag))
+		}
+	},
+	"max":          simpleCallFunc("max", "Max"),
+	"avg":          simpleCallFunc("avg", "AAvg"),
+	"stddev":       nil,
+	"group":        simpleSelection("group", "1"),
+	"count":        simpleSelection("count", "Count(row)"),
+	"count_values": simpleCallFunc("count_values", "Last"),
+
+	"topk": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		if len(*group) == 0 {
+			*group = append(*group, _prometheus_tag_key)
+			*query = append(*query, _prometheus_tag_key)
+		}
+		*query = append(*query, fmt.Sprintf("Max(%s)", metric)) // use for max value, then order by value, try best to get topN
+		*order = append(*order, fmt.Sprintf("%s desc", metric))
+	},
+
+	"bottomk": nil, // don't use Min(%s), because min will fill zero as default value
+
+	"quantile": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*group = append(*group, _prometheus_tag_key)
+		quantile_param := req.GetFuncParam("quantile")
+		*query = append(*query, fmt.Sprintf("Percentile(%s, %g)", metric, quantile_param))
+		for _, tag := range req.GetGrouping("quantile") {
+			*group = append(*group, handleLabelsMatch(tag))
+		}
+	},
+
+	// range-vector functions, but needs counter reset
+	"idelta":   nil, // minus(last, last-1) maybe: (nonNegativeDerivative * interval?)
+	"increase": nil, // minus(last, first) maybe: (nonNegativeDerivative * interval?)
+	"delta":    nil, // minus(last, last-1) without counter reset (nonNegativeDerivative)
+
+	"irate": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		if queryType == model.Range {
+			// NOTICE: for irate, `range` is meaningless, it always calculate the last 2 points
+			// e.g.: irate(m[5m]) == irate(m[15m]) == irate(m[1h])
+
+			// use toUnixTimestamp will change to time(time, 15) as default interval grouping
+			if len(*query) > 0 {
+				(*query)[0] = fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)
+			} else {
+				*query = append(*query, fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS))
+			}
+		}
+
+		if len(*group) == 0 {
+			*group = append(*group, _prometheus_tag_key)
+			*query = append(*query, _prometheus_tag_key)
+		}
+
+		// use default interval to get irate in instant query
+		*query = append(*query, fmt.Sprintf("Derivative(%s,`tag`)", metric))
+	},
+
+	"rate": nil, // not implemented
+	// the functions below is PARTLY correct, but is not fully correct
+	// like, when we try to get rate(m[5m]), it gets rate(m[5m+(scrape_interval)m]) actually, it's always calculate 1 more point
+	// KEEP this for a refer
+	// 目前计算 rate 算子不正确，因为 time() 会聚合时间范围[5m]内的数据，再做相邻计算，无法确定准确的聚合时间窗口（因取决于 scrape_interval）
+	// 期望：(m.At(5m)-m.At(0))/5m, 实际：(m.At(5m+1m)-m.At(5m))/1m
+	// 保留注释以供参考
+	// func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+	// 	var interval, offset int64
+	// 	if queryType == model.Instant {
+	// 		interval = req.GetRange("rate")
+	// 		// when timeRange > 1m, use t-1m as rate range
+	// 		// otherwise it calculs wrong value
+	// 		if interval > 0 {
+	// 			offset = req.GetStart() % interval
+	// 		}
+	// 	} else if queryType == model.Range {
+	// 		step := req.GetStep()
+	// 		timeRange := req.GetRange("rate") // unit:ms
+	// 		// use min(step, range) as interval
+	// 		// if range < step, it will downsampling data
+	// 		// if step < range, ???
+	// 		interval = int64(math.Min(float64(step), float64(timeRange)))
+	// 		offset = req.GetStart() % interval
+	// 	}
+
+	// 	// set `time` column query
+	// 	if len(*query) > 0 {
+	// 		(*query)[0] = fmt.Sprintf("time(time, %d, 1,'', %d) AS %s", interval/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS)
+	// 	} else {
+	// 		*query = append(*query, fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", interval/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS))
+	// 	}
+
+	// 	if len(*group) == 0 {
+	// 		*group = append(*group, _prometheus_tag_key)
+	// 		*query = append(*query, _prometheus_tag_key)
+	// 	}
+
+	// 	*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+	// },
+}
+
+func simpleSelection(oriFunc string, aftFunc string) QueryFunc {
+	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*query = append(*query, aftFunc)
+		*group = append(*group, _prometheus_tag_key)
+		for _, tag := range req.GetGrouping(oriFunc) {
+			*group = append(*group, handleLabelsMatch(tag))
+		}
+	}
+}
+
+func simpleCallFunc(oriFunc string, aftFunc string) QueryFunc {
+	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*query = append(*query, fmt.Sprintf("%s(%s)", aftFunc, metric))
+		*group = append(*group, _prometheus_tag_key)
+		for _, tag := range req.GetGrouping(oriFunc) {
+			*group = append(*group, handleLabelsMatch(tag))
+		}
+	}
+}
+
+func simpleCallMatrixFunc(f string) QueryFunc {
+	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		*query = append(*query, _prometheus_tag_key)
+		*group = append(*group, _prometheus_tag_key)
+
+		if queryType == model.Instant {
+			*query = append(*query, fmt.Sprintf("%s(%s)", f, metric))
+		} else if queryType == model.Range {
+			*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+		}
+	}
+}

--- a/server/querier/app/prometheus/service/promql.go
+++ b/server/querier/app/prometheus/service/promql.go
@@ -38,6 +38,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/deepflowio/deepflow/server/libs/lru"
+	cache "github.com/deepflowio/deepflow/server/querier/app/prometheus/cachev2"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/config"
 	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
@@ -76,12 +77,20 @@ type prometheusExecutor struct {
 	extraLabelCache *lru.Cache[string, string]
 	ticker          *time.Ticker
 	lookbackDelta   time.Duration
+
+	cacher            *cache.Cacher
+	queryKeyGenerator *cache.WeakKeyGenerator
+	cacheKeyGenerator *cache.CacheKeyGenerator
 }
 
 func NewPrometheusExecutor(delta time.Duration) *prometheusExecutor {
 	executor := &prometheusExecutor{
 		extraLabelCache: lru.NewCache[string, string](config.Cfg.Prometheus.ExternalTagCacheSize),
 		lookbackDelta:   delta,
+
+		cacher:            cache.NewCacher(),
+		queryKeyGenerator: &cache.WeakKeyGenerator{},
+		cacheKeyGenerator: &cache.CacheKeyGenerator{},
 	}
 	go executor.triggerLoadExternalTag()
 	return executor
@@ -96,7 +105,7 @@ func (p *prometheusExecutor) triggerLoadExternalTag() {
 		}
 	}()
 	for range p.ticker.C {
-		p.loadExternalTagCache()
+		p.loadExtraLabelsCache()
 	}
 }
 
@@ -106,7 +115,7 @@ func (p *prometheusExecutor) promQueryExecute(ctx context.Context, args *model.P
 	if err != nil {
 		return nil, err
 	}
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
+	if args.Debug {
 		var span trace.Span
 		tr := otel.GetTracerProvider().Tracer("querier/app/PrometheusInstantQueryRequest")
 		ctx, span = tr.Start(ctx, "PrometheusInstantQuery",
@@ -118,17 +127,12 @@ func (p *prometheusExecutor) promQueryExecute(ctx context.Context, args *model.P
 		// record query cost in span cost time
 		defer span.End()
 	}
-
-	slimit := config.Cfg.Prometheus.SeriesLimit
-	if slimitArgs, err := strconv.Atoi(args.Slimit); err == nil && slimitArgs < slimit {
-		slimit = slimitArgs
-	}
-	reader := newPrometheusReader(slimit)
+	reader := newPrometheusReader(args.Slimit)
 	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
-	reader.addExternalTagToCache = p.addExtraLabelConvertion
+	reader.addExternalTagToCache = p.addExtraLabelsToCache
 	// instant query will hint default query range:
 	// query.lookback-delta: https://github.com/prometheus/prometheus/blob/main/cmd/prometheus/main.go#L398
-	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
+	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, reader: reader}
 	qry, err := engine.NewInstantQuery(queriable, nil, args.Promql, queryTime)
 	if qry == nil || err != nil {
 		log.Error(err)
@@ -148,7 +152,7 @@ func (p *prometheusExecutor) promQueryExecute(ctx context.Context, args *model.P
 		Status: _SUCCESS,
 	}
 	if args.Debug {
-		result.Stats = model.PromQueryStats{SQL: queriable.sql, QueryTime: queriable.query_time}
+		result.Stats = queriable.GetSQLQuery()
 	}
 	return result, err
 }
@@ -169,7 +173,7 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 		log.Error(err)
 		return nil, err
 	}
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
+	if args.Debug {
 		var span trace.Span
 		tr := otel.GetTracerProvider().Tracer("querier/app/PrometheusRangeQueryRequest")
 		ctx, span = tr.Start(ctx, "PrometheusRangeQuery",
@@ -182,14 +186,10 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 		)
 		defer span.End()
 	}
-	slimit := config.Cfg.Prometheus.SeriesLimit
-	if slimitArgs, err := strconv.Atoi(args.Slimit); err == nil && slimitArgs < slimit {
-		slimit = slimitArgs
-	}
-	reader := newPrometheusReader(slimit)
+	reader := newPrometheusReader(args.Slimit)
 	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
-	reader.addExternalTagToCache = p.addExtraLabelConvertion
-	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
+	reader.addExternalTagToCache = p.addExtraLabelsToCache
+	queriable := &RemoteReadQuerierable{Args: args, Ctx: ctx, reader: reader}
 	qry, err := engine.NewRangeQuery(queriable, nil, args.Promql, start, end, step)
 	if qry == nil || err != nil {
 		log.Error(err)
@@ -210,17 +210,289 @@ func (p *prometheusExecutor) promQueryRangeExecute(ctx context.Context, args *mo
 	}
 	if args.Debug {
 		// if query with `debug` parmas, return sql & query time
-		result.Stats = model.PromQueryStats{SQL: queriable.sql, QueryTime: queriable.query_time}
+		result.Stats = queriable.GetSQLQuery()
 	}
 	return result, err
 }
 
-func (p *prometheusExecutor) promRemoteReadExecute(ctx context.Context, req *prompb.ReadRequest) (resp *prompb.ReadResponse, err error) {
-	// analysis for ReadRequest
+func (p *prometheusExecutor) offloadRangeQueryExecute(ctx context.Context, args *model.PromQueryParams, engine *promql.Engine) (result *model.PromQueryResponse, err error) {
+	start, err := parseTime(args.StartTime)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	end, err := parseTime(args.EndTime)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	step, err := parseDuration(args.Step)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	if args.Debug {
+		var span trace.Span
+		tr := otel.GetTracerProvider().Tracer("querier/app/OffloadPrometheusRangeQueryRequest")
+		ctx, span = tr.Start(ctx, "OffloadingRangeQuery",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.String("promql.query", args.Promql),
+				attribute.Int64("promql.query.range", int64(end.Sub(start).Minutes())),
+				attribute.Int64("promql.query.step", int64(step.Seconds())),
+			),
+		)
+		defer span.End()
+	}
+
+	analyzer := newQueryAnalyzer(p.lookbackDelta)
+	keyGenerator := &cache.WeakKeyGenerator{}
+	reader := &prometheusReader{
+		slimit:                  args.Slimit,
+		getExternalTagFromCache: p.convertExternalTagToQuerierAllowTag,
+		addExternalTagToCache:   p.addExtraLabelsToCache,
+	}
+	queryRequests := analyzer.parsePromQL(args.Promql, start, end, step)
+	promRequest := &model.DeepFlowPromRequest{
+		Slimit: args.Slimit,
+		Start:  start.UnixMilli(),
+		End:    end.UnixMilli(),
+		Step:   step,
+		Query:  args.Promql,
+	}
+
+	var cached promql.Result
+	var cachedKey string
+	var queryRequired = true
+	if config.Cfg.Prometheus.Cache.Enabled {
+		cachedKey = p.cacheKeyGenerator.GenerateCacheKey(promRequest)
+		var fixedStart, fixedEnd int64
+		if cached, fixedStart, fixedEnd, queryRequired = p.cacher.Fetch(cachedKey, promRequest.Start, promRequest.End); queryRequired {
+			log.Debugf("cache hit for instant query: %s, start: %s, end: %s", cachedKey, fixedStart, fixedEnd)
+			start, end = time.UnixMilli(fixedStart), time.UnixMilli(fixedEnd)
+		} else {
+			log.Debugf("get cache data error: %s", cached.Err)
+		}
+	}
+
+	if !queryRequired {
+		return &model.PromQueryResponse{
+			Data:   &model.PromQueryData{ResultType: cached.Value.Type(), Result: cached.Value},
+			Status: _SUCCESS,
+		}, err
+	}
+
+	var queriable model.Querierable
+	var offloadEnabled bool
+
+	for _, v := range queryRequests {
+		if analyzer.offloadEnabled(v.GetMetric(), v.GetFunc(), v.GetBy()) {
+			offloadEnabled = true
+			break
+		}
+	}
+
+	if offloadEnabled {
+		queriable = NewOffloadQueriable(args,
+			WithQueryType(model.Range),
+			WithPrometheuReader(reader),
+			WithQueryRequests(queryRequests),
+			WithKeyGenerator(keyGenerator.GenerateRequestKey))
+	} else {
+		queriable = &RemoteReadQuerierable{
+			Args:   args,
+			Ctx:    ctx,
+			reader: reader,
+		}
+	}
+
+	qry, err := engine.NewRangeQuery(queriable, nil, args.Promql, start, end, step)
+	if qry == nil || err != nil {
+		log.Error(err)
+		return nil, err
+	}
+	if queriable != nil {
+		queriable.BindSelectedCallBack(qry)
+	}
+	res := qry.Exec(ctx)
+	if res.Err != nil {
+		log.Error(res.Err)
+		return nil, res.Err
+	}
+	if queriable != nil {
+		queriable.AfterQueryExec(qry)
+	}
+	data := &model.PromQueryData{ResultType: res.Value.Type(), Result: res.Value}
+	result = &model.PromQueryResponse{
+		Data:   data,
+		Status: _SUCCESS,
+	}
+	if args.Debug {
+		result.Stats = queriable.GetSQLQuery()
+	}
+
+	if config.Cfg.Prometheus.Cache.Enabled {
+		if mergeResult, err := p.cacher.Merge(cachedKey, cached, promRequest.Start, promRequest.End, promRequest.Step.Microseconds(), *res); err == nil {
+			return &model.PromQueryResponse{
+				Data:   &model.PromQueryData{ResultType: mergeResult.Value.Type(), Result: mergeResult.Value},
+				Status: _SUCCESS,
+			}, err
+		} else {
+			// err != nil
+			log.Errorf("cache merge error: %v", err)
+			return nil, res.Err
+		}
+	}
+
+	return result, err
+}
+
+/*
+offload query for instant query
+1. parse promql to get functions & find out which can be offloaded
+2. offload query for request, if one of the functions can not be offloaeded, try query with remote read query
+3. get/put cache before query/after query
+*/
+func (p *prometheusExecutor) offloadInstantQueryExecute(ctx context.Context, args *model.PromQueryParams, engine *promql.Engine) (result *model.PromQueryResponse, err error) {
+	queryTime, err := parseTime(args.StartTime)
+	if err != nil {
+		return nil, err
+	}
+	if args.Debug {
+		var span trace.Span
+		tr := otel.GetTracerProvider().Tracer("querier/app/OffloadPrometheusInstantQueryRequest")
+		ctx, span = tr.Start(ctx, "OffloadPrometheusInstantQuery",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(attribute.String("promql.query", args.Promql)),
+		)
+		defer span.End()
+	}
+
+	analyzer := newQueryAnalyzer(p.lookbackDelta)
+	keyGenerator := &cache.WeakKeyGenerator{}
+	reader := &prometheusReader{
+		slimit:                  args.Slimit,
+		getExternalTagFromCache: p.convertExternalTagToQuerierAllowTag,
+		addExternalTagToCache:   p.addExtraLabelsToCache,
+	}
+	queryRequests := analyzer.parsePromQL(args.Promql, queryTime, queryTime, 0)
+
+	// for matrix selector in instant query, may need a bigger time range than query
+	var minStart, maxEnd int64
+	for _, qr := range queryRequests {
+		if minStart == 0 || qr.GetStart() < minStart {
+			minStart = qr.GetStart()
+		}
+		if qr.GetEnd() > maxEnd {
+			maxEnd = qr.GetEnd()
+		}
+	}
+
+	promRequest := &model.DeepFlowPromRequest{
+		Slimit: args.Slimit,
+		Start:  minStart,
+		End:    maxEnd,
+		Step:   0,
+		Query:  args.Promql,
+	}
+
+	var cached promql.Result
+	var cachedKey string
+	var queryRequired = true
+	if config.Cfg.Prometheus.Cache.Enabled {
+		cachedKey = p.cacheKeyGenerator.GenerateCacheKey(promRequest)
+		if cached, _, _, queryRequired = p.cacher.Fetch(cachedKey, promRequest.Start, promRequest.End); queryRequired {
+			log.Debugf("cache hit for instant query: %s, start: %s, end: %s", cachedKey)
+		}
+	}
+
+	if !queryRequired {
+		return &model.PromQueryResponse{
+			Data:   &model.PromQueryData{ResultType: cached.Value.Type(), Result: cached.Value},
+			Status: _SUCCESS,
+		}, err
+	}
+
+	var queriable model.Querierable
+	var offloadEnabled bool
+	for _, v := range queryRequests {
+		// any one of Hints can be offloaded is acceptable, when <func.Select> get nothing, use query directly
+		// 任意一个表达式可被卸载即可，当 Select 无法获取到数据时会执行直接查询
+		if analyzer.offloadEnabled(v.GetMetric(), v.GetFunc(), v.GetBy()) {
+			offloadEnabled = true
+			break
+		}
+	}
+
+	if offloadEnabled {
+		queriable = NewOffloadQueriable(args,
+			WithQueryType(model.Instant),
+			WithPrometheuReader(reader),
+			WithQueryRequests(queryRequests),
+			WithKeyGenerator(keyGenerator.GenerateRequestKey))
+	} else {
+		queriable = &RemoteReadQuerierable{
+			Args:   args,
+			Ctx:    ctx,
+			reader: reader,
+		}
+	}
+
+	qry, err := engine.NewInstantQuery(queriable, nil, args.Promql, queryTime)
+	if qry == nil || err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	if queriable != nil {
+		queriable.BindSelectedCallBack(qry)
+	}
+	res := qry.Exec(ctx)
+	if res.Err != nil {
+		log.Error(res.Err)
+		return nil, res.Err
+	}
+	if queriable != nil {
+		queriable.AfterQueryExec(qry)
+	}
+	data := &model.PromQueryData{ResultType: res.Value.Type(), Result: res.Value}
+	result = &model.PromQueryResponse{
+		Data:   data,
+		Status: _SUCCESS,
+	}
+	if args.Debug {
+		result.Stats = queriable.GetSQLQuery()
+	}
+
+	if config.Cfg.Prometheus.Cache.Enabled {
+		if mergeResult, err := p.cacher.Merge(cachedKey, cached, promRequest.Start, promRequest.End, promRequest.Step.Microseconds(), *res); err == nil {
+			return &model.PromQueryResponse{
+				Data:   &model.PromQueryData{ResultType: mergeResult.Value.Type(), Result: mergeResult.Value},
+				Status: _SUCCESS,
+			}, err
+		} else {
+			// err != nil
+			log.Errorf("cache merge error: %v", err)
+			return nil, res.Err
+		}
+	}
+
+	return result, err
+}
+
+func (p *prometheusExecutor) promRemoteReadOffloadingExecute(ctx context.Context, req *prompb.ReadRequest) (resp *prompb.ReadResponse, err error) {
 	reader := newPrometheusReader(config.Cfg.Prometheus.SeriesLimit)
 	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
-	reader.addExternalTagToCache = p.addExtraLabelConvertion
-	result, _, _, err := reader.promReaderExecute(ctx, req, false)
+	reader.addExternalTagToCache = p.addExtraLabelsToCache
+	result, _, _, _, err := reader.promReaderExecute(ctx, req, config.Cfg.Prometheus.RequestQueryWithDebug)
+	return result, err
+}
+
+func (p *prometheusExecutor) promRemoteReadExecute(ctx context.Context, req *prompb.ReadRequest) (resp *prompb.ReadResponse, err error) {
+	reader := newPrometheusReader(config.Cfg.Prometheus.SeriesLimit)
+	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
+	reader.addExternalTagToCache = p.addExtraLabelsToCache
+	result, _, _, _, err := reader.promReaderExecute(ctx, req, config.Cfg.Prometheus.RequestQueryWithDebug)
 	return result, err
 }
 
@@ -289,7 +561,7 @@ func (p *prometheusExecutor) series(ctx context.Context, args *model.PromQueryPa
 		return nil, err
 	}
 
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
+	if args.Debug {
 		var span trace.Span
 		tr := otel.GetTracerProvider().Tracer("querier/app/PrometheusSeriesRequest")
 		ctx, span = tr.Start(ctx, "PrometheusSeriesRequest",
@@ -311,8 +583,8 @@ func (p *prometheusExecutor) series(ctx context.Context, args *model.PromQueryPa
 	}
 	reader := newPrometheusReader(config.Cfg.Prometheus.SeriesLimit)
 	reader.getExternalTagFromCache = p.convertExternalTagToQuerierAllowTag
-	reader.addExternalTagToCache = p.addExtraLabelConvertion
-	querierable := &RemoteReadQuerierable{Args: args, Ctx: ctx, MatchMetricNameFunc: p.matchMetricName, reader: reader}
+	reader.addExternalTagToCache = p.addExtraLabelsToCache
+	querierable := &RemoteReadQuerierable{Args: args, Ctx: ctx, reader: reader}
 	q, err := querierable.Querier(ctx, timestamp.FromTime(start), timestamp.FromTime(end))
 	if err != nil {
 		log.Error(err)
@@ -446,17 +718,6 @@ func (p *prometheusExecutor) addExtraFilters(promQL string, filters map[string]s
 	return res, nil
 }
 
-func (p *prometheusExecutor) matchMetricName(matchers *[]*labels.Matcher) string {
-	var metric string
-	for _, v := range *matchers {
-		if v.Name == PROMETHEUS_METRICS_NAME {
-			metric = v.Value
-			break
-		}
-	}
-	return metric
-}
-
 // handle promql Expression before prometheus calculate
 // TODO: add more pre-calculation to avoid re-calculate in prometheus
 func (p *prometheusExecutor) beforePrometheusCalculate(q promql.Query, f func(e *parser.AggregateExpr) error) error {
@@ -470,7 +731,7 @@ func (p *prometheusExecutor) beforePrometheusCalculate(q promql.Query, f func(e 
 	return nil
 }
 
-func (p *prometheusExecutor) loadExternalTagCache() {
+func (p *prometheusExecutor) loadExtraLabelsCache() {
 	// DeepFlow Source have same tag collections, so just try query 1 table to add all external tags
 	showTags := fmt.Sprintf("show tags from %s", VTAP_FLOW_PORT_TABLE)
 	data, err := tagdescription.GetTagDescriptions(chCommon.DB_NAME_FLOW_METRICS, VTAP_FLOW_PORT_TABLE, showTags, context.Background())
@@ -491,7 +752,7 @@ func (p *prometheusExecutor) loadExternalTagCache() {
 				continue
 			}
 			tag := values[0].(string)
-			p.addExtraLabelConvertion(formatTagName(tag), tag)
+			p.addExtraLabelsToCache(formatTagName(tag), tag)
 		}
 	}
 }
@@ -513,6 +774,6 @@ func (p *prometheusExecutor) convertExternalTagToQuerierAllowTag(displayTag stri
 	return ""
 }
 
-func (p *prometheusExecutor) addExtraLabelConvertion(displayTag string, querierTag string) {
+func (p *prometheusExecutor) addExtraLabelsToCache(displayTag string, querierTag string) {
 	p.extraLabelCache.Add(displayTag, querierTag)
 }

--- a/server/querier/app/prometheus/service/promql_analysis.go
+++ b/server/querier/app/prometheus/service/promql_analysis.go
@@ -97,5 +97,6 @@ func (e *prometheusExecutor) promQLAnalysis(ctx context.Context, metric string, 
 		strings.Join(group, ","),
 		10000,
 	)
-	return queryDataExecute(ctx, sql, "flow_log", "")
+	result, _, _, err := queryDataExecute(ctx, sql, "flow_log", "", false)
+	return result, err
 }

--- a/server/querier/app/prometheus/service/promql_test.go
+++ b/server/querier/app/prometheus/service/promql_test.go
@@ -106,7 +106,6 @@ func TestParsePromQL(t *testing.T) {
 }
 
 func BenchmarkForMatchMetricName(b *testing.B) {
-	executor := &prometheusExecutor{}
 	matchers := [][]*labels.Matcher{
 		{
 			{Type: labels.MatchEqual, Name: "job", Value: "prometheus-demo-job"},
@@ -149,7 +148,7 @@ func BenchmarkForMatchMetricName(b *testing.B) {
 	for j := 0; j < len(matchers); j++ {
 		b.Run(fmt.Sprintf("BenchmarkTestFor[%d]", j), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				executor.matchMetricName(&matchers[j])
+				extractMetricName(&matchers[j])
 			}
 		})
 	}

--- a/server/querier/app/prometheus/service/queryable.go
+++ b/server/querier/app/prometheus/service/queryable.go
@@ -23,26 +23,41 @@ import (
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/storage/remote"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
-	"github.com/deepflowio/deepflow/server/querier/config"
 )
 
 type RemoteReadQuerierable struct {
-	Args                *model.PromQueryParams
-	Ctx                 context.Context
-	MatchMetricNameFunc func(*[]*labels.Matcher) string
-	sql                 []string
-	query_time          []float64
-	reader              *prometheusReader
+	Args *model.PromQueryParams
+	Ctx  context.Context
+
+	reader     *prometheusReader
+	queryStats []model.PromQueryStats
 }
 
 func (q *RemoteReadQuerierable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
-	return &RemoteReadQuerier{Args: q.Args, Ctx: q.Ctx, Querierable: q, reader: q.reader}, nil
+	querier := &RemoteReadQuerier{Args: q.Args, Ctx: q.Ctx, Querierable: q, reader: q.reader}
+	if q.Args.Debug {
+		q.queryStats = make([]model.PromQueryStats, 0)
+	}
+	return querier, nil
+}
+
+func (q *RemoteReadQuerierable) GetSQLQuery() []model.PromQueryStats {
+	return q.queryStats
+}
+
+func (q *RemoteReadQuerierable) BindSelectedCallBack(qry promql.Query) {
+	// not implement
+}
+
+func (q *RemoteReadQuerierable) AfterQueryExec(qry promql.Query) {
+	// not implement
 }
 
 type RemoteReadQuerier struct {
@@ -52,7 +67,6 @@ type RemoteReadQuerier struct {
 	reader      *prometheusReader
 }
 
-// For PromQL instant query
 func (q *RemoteReadQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	startTimeS, err := parseTime(q.Args.StartTime)
 	if err != nil {
@@ -66,11 +80,11 @@ func (q *RemoteReadQuerier) Select(sortSeries bool, hints *storage.SelectHints, 
 	}
 	queryRange := time.Duration(hints.End-hints.Start) * time.Millisecond
 
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
+	if q.Args.Debug {
 		// get span from context
 		span := trace.SpanFromContext(q.Ctx)
 		span.SetAttributes(attribute.Float64("promql.query.range", math.Trunc((queryRange.Minutes()+0.5/math.Pow10(2))*math.Pow10(2))/math.Pow10(2)))
-		metric := q.Querierable.MatchMetricNameFunc(&matchers)
+		metric := extractMetricName(&matchers)
 		// append metric names
 		// target/app labels would be append after query ck finished, see <remote_read.go#82>
 		span.SetAttributes(attribute.String("promql.query.metric.name", metric))
@@ -85,20 +99,13 @@ func (q *RemoteReadQuerier) Select(sortSeries bool, hints *storage.SelectHints, 
 		Queries:               []*prompb.Query{prompbQuery},
 		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
 	}
-	resp, sql, query_time, err := q.reader.promReaderExecute(q.Ctx, req, q.Args.Debug)
+	resp, querierSql, sql, duration, err := q.reader.promReaderExecute(q.Ctx, req, q.Args.Debug)
+	if q.Args.Debug {
+		q.Querierable.queryStats = append(q.Querierable.queryStats, model.PromQueryStats{SQL: sql, QuerierSQL: querierSql, Duration: duration})
+	}
 	if err != nil {
 		log.Error(err)
 		return storage.ErrSeriesSet(err)
-	}
-	if q.Args.Debug {
-		if q.Querierable.sql == nil {
-			q.Querierable.sql = make([]string, 0)
-		}
-		if q.Querierable.query_time == nil {
-			q.Querierable.query_time = make([]float64, 0)
-		}
-		q.Querierable.sql = append(q.Querierable.sql, sql)
-		q.Querierable.query_time = append(q.Querierable.query_time, query_time)
 	}
 	return remote.FromQueryResult(sortSeries, resp.Results[0])
 }

--- a/server/querier/app/prometheus/service/queryable_offload.go
+++ b/server/querier/app/prometheus/service/queryable_offload.go
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"context"
+
+	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
+	"github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/remote"
+)
+
+type OffloadQuerierable struct {
+	queryType    model.QueryType
+	args         *model.PromQueryParams
+	reader       *prometheusReader
+	querier      *OffloadQuerier
+	keyGenerator func(model.QueryRequest) string
+
+	queryStats        []model.PromQueryStats
+	queryRequest      []model.QueryRequest
+	mapToQueryRequest map[string]model.QueryRequest
+	cachedQueryExprs  map[parser.Expr]func(parser.Expr)
+}
+
+type OffloadQuerierableOpts func(*OffloadQuerierable)
+
+func NewOffloadQueriable(args *model.PromQueryParams, opts ...OffloadQuerierableOpts) *OffloadQuerierable {
+	o := &OffloadQuerierable{args: args}
+	if o.args.Debug {
+		o.queryStats = make([]model.PromQueryStats, 0)
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if len(o.queryRequest) > 0 {
+		o.mapToQueryRequest = make(map[string]model.QueryRequest, len(o.queryRequest))
+		for _, queryReq := range o.queryRequest {
+			o.mapToQueryRequest[o.keyGenerator(queryReq)] = queryReq
+		}
+
+		o.cachedQueryExprs = make(map[parser.Expr]func(parser.Expr))
+	}
+
+	o.querier = &OffloadQuerier{
+		querierable:  o,
+		ctx:          o.args.Context,
+		keyGenerator: o.keyGenerator,
+		startTime:    o.args.StartTime,
+		endTime:      o.args.EndTime,
+		debug:        o.args.Debug,
+	}
+
+	return o
+}
+
+func WithQueryType(queryType model.QueryType) OffloadQuerierableOpts {
+	return func(o *OffloadQuerierable) {
+		o.queryType = queryType
+	}
+}
+
+func WithQueryRequests(queryReq []model.QueryRequest) OffloadQuerierableOpts {
+	return func(o *OffloadQuerierable) {
+		o.queryRequest = queryReq
+	}
+}
+
+func WithPrometheuReader(reader *prometheusReader) OffloadQuerierableOpts {
+	return func(o *OffloadQuerierable) {
+		o.reader = reader
+	}
+}
+
+func WithKeyGenerator(generator func(model.QueryRequest) string) OffloadQuerierableOpts {
+	return func(o *OffloadQuerierable) {
+		o.keyGenerator = generator
+	}
+}
+
+func (o *OffloadQuerierable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	return o.querier, nil
+}
+
+func (o *OffloadQuerierable) GetSQLQuery() []model.PromQueryStats {
+	return o.queryStats
+}
+
+func (o *OffloadQuerierable) BindSelectedCallBack(q promql.Query) {
+	o.querier.selectedCallback = func(queryType model.QueryType) error {
+		stmt := q.Statement()
+		if stmt, ok := stmt.(*parser.EvalStmt); ok {
+			o.changeFunctionAfterOffloadSelected(stmt, queryType)
+		}
+		return nil
+	}
+}
+
+func (o *OffloadQuerierable) AfterQueryExec(promql.Query) {
+	o.restoreFunctionAfterQueryFinished()
+}
+
+// we've already do aggregation in database query, so we need to return result to frontend directly
+// e.g.: count(node_cpu_seconds_total), we do `Count` in database, get `10` for count(node_cpu_seconds_total)
+// but in prometheus engine, it recognise the aggregate function is `count`, it will count data samples, and we can not escape this second-aggregation
+// so end up it gets samples count as `1`, which is wrong.
+// the better way now is to change aggregate function, change count to sum, finally it will return `10` to the frontend, which is the correct result as our expected
+func (o *OffloadQuerierable) changeFunctionAfterOffloadSelected(stmt *parser.EvalStmt, queryType model.QueryType) {
+	parser.Inspect(stmt.Expr, func(node parser.Node, path []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.AggregateExpr:
+			switch n.Op {
+			case parser.COUNT:
+				if !n.Without {
+					parseAggToSum(n, n.Op, parser.SUM)
+				}
+			}
+		case *parser.Call:
+			switch n.Func.Name {
+			case "irate":
+				o.cachedQueryExprs[n] = parseCallToLastOverTime(n, n.Func.Name, "last_over_time")
+			case "stddev_over_time":
+				if queryType == model.Instant {
+					o.cachedQueryExprs[n] = parseCallToLastOverTime(n, n.Func.Name, "last_over_time")
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// the way to restore the real function calculation, because promql engine has functional cache for the same promql
+func parseAggToSum(n *parser.AggregateExpr, oriOp parser.ItemType, afterOp parser.ItemType) func(parser.Expr) {
+	n.Op = afterOp
+	return func(e parser.Expr) {
+		if a, ok := e.(*parser.AggregateExpr); ok {
+			a.Op = oriOp
+		}
+	}
+}
+
+func parseCallToLastOverTime(n *parser.Call, oriFunc string, afterFunc string) func(parser.Expr) {
+	n.Func.Name = afterFunc
+	return func(e parser.Expr) {
+		if a, ok := e.(*parser.Call); ok {
+			a.Func.Name = oriFunc
+		}
+	}
+}
+
+// why restore: expr would have a cache for the same promql
+func (o *OffloadQuerierable) restoreFunctionAfterQueryFinished() {
+	for expr, restoreFunc := range o.cachedQueryExprs {
+		restoreFunc(expr)
+	}
+}
+
+type OffloadQuerier struct {
+	ctx              context.Context
+	querierable      *OffloadQuerierable
+	keyGenerator     func(model.QueryRequest) string
+	selectedCallback func(model.QueryType) error
+
+	debug              bool
+	startTime, endTime string
+}
+
+func (o *OffloadQuerier) Select(sortSeries bool, hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
+	// get query Request by hint
+	promtheusHint := &prometheusHint{hints: hints, matchers: matchers}
+	queryReq := o.querierable.mapToQueryRequest[o.keyGenerator(promtheusHint)]
+
+	//lint:ignore SA1029 use string as context key, ensure no type reference to app/prometheus
+	ctx := context.WithValue(o.ctx, "remote_read", true)
+	querierSql := o.querierable.reader.parseQueryRequestToSQL(ctx, queryReq, o.querierable.queryType)
+	if querierSql != "" {
+		result, sql, duration, err := queryDataExecute(ctx, querierSql, common.DB_NAME_PROMETHEUS, "", o.debug)
+		if err != nil {
+			log.Error(err)
+			log.Errorf("offload querier sql: %s", querierSql)
+			return storage.ErrSeriesSet(err)
+		}
+		if o.debug {
+			o.querierable.queryStats = append(o.querierable.queryStats, model.PromQueryStats{SQL: sql, QuerierSQL: querierSql, Duration: duration})
+		}
+		startS, endS := queryReq.GetStart()/1e3, queryReq.GetEnd()/1e3
+		resp, err := o.querierable.reader.respTransToProm(ctx, queryReq.GetMetric(), startS, endS, result)
+		if err != nil {
+			log.Error(err)
+			return storage.ErrSeriesSet(err)
+		}
+
+		err = o.selectedCallback(o.querierable.queryType)
+		if err != nil {
+			// not return, selected callback only fixed query exprs
+			log.Error(err)
+		}
+
+		return remote.FromQueryResult(sortSeries, resp.Results[0])
+	}
+
+	// else: querierSql == "", offload failed, try normal query
+	// same to queryable.go#63 <func.Select>
+	startTimeS, err := parseTime(o.startTime)
+	if err != nil {
+		log.Error(err)
+		return storage.ErrSeriesSet(err)
+	}
+	endTimeS, err := parseTime(o.endTime)
+	if err != nil {
+		log.Error(err)
+		return storage.ErrSeriesSet(err)
+	}
+	prompbQuery, err := remote.ToQuery(startTimeS.UnixMilli(), endTimeS.UnixMilli(), matchers, hints)
+	if err != nil {
+		log.Error(err)
+		return storage.ErrSeriesSet(err)
+	}
+	req := &prompb.ReadRequest{
+		Queries:               []*prompb.Query{prompbQuery},
+		AcceptedResponseTypes: []prompb.ReadRequest_ResponseType{prompb.ReadRequest_STREAMED_XOR_CHUNKS},
+	}
+	resp, querierSql, sql, duration, err := o.querierable.reader.promReaderExecute(o.ctx, req, o.debug)
+	if err != nil {
+		log.Error(err)
+		return storage.ErrSeriesSet(err)
+	}
+	if o.debug {
+		o.querierable.queryStats = append(o.querierable.queryStats, model.PromQueryStats{SQL: sql, QuerierSQL: querierSql, Duration: duration})
+	}
+	return remote.FromQueryResult(sortSeries, resp.Results[0])
+}
+
+func (o *OffloadQuerier) LabelValues(name string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (o *OffloadQuerier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
+	return nil, nil, nil
+}
+
+func (q *OffloadQuerier) Close() error {
+	return nil
+}

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -60,7 +60,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 		response = item
 	}
 
-	if config.Cfg.Prometheus.Cache.Enabled && hit == cache.CacheKeyFoundNil {
+	if config.Cfg.Prometheus.Cache.RemoteReadCache && hit == cache.CacheKeyFoundNil {
 		cacheLoadingFinished := &sync.WaitGroup{}
 		cacheLoadingFinished.Add(1)
 
@@ -178,7 +178,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 	// response trans to prom resp
 	resp, err = p.respTransToProm(ctx, metricName, api_query_start, api_query_end, result)
 
-	if config.Cfg.Prometheus.Cache.Enabled {
+	if config.Cfg.Prometheus.Cache.RemoteReadCache {
 		// merge result into cache
 		response = cache.PromReadResponseCache().AddOrMerge(req, resp)
 	} else {

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -44,10 +44,6 @@ type prometheusReader struct {
 	addExternalTagToCache   func(string, string)
 }
 
-func newPrometheusReader(slimit int) *prometheusReader {
-	return &prometheusReader{slimit: slimit}
-}
-
 func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.ReadRequest, debug bool) (resp *prompb.ReadResponse, querierSql, sql string, duration float64, err error) {
 	// promrequest trans to sql
 	// pp.Println(req)

--- a/server/querier/app/prometheus/service/service.go
+++ b/server/querier/app/prometheus/service/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql"
 
+	"github.com/deepflowio/deepflow/server/libs/datastructure"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/service/packet_wrapper"
 	"github.com/deepflowio/deepflow/server/querier/common"
@@ -33,10 +34,15 @@ import (
 
 var log = logging.MustGetLogger("prometheus")
 
+// equals defaultLookbackDelta in prometheus engine
+const defaultLookbackDelta = 5 * time.Minute
+
 type PrometheusService struct {
 	// keep only 1 instance of prometheus engine during server lifetime
 	engine   *promql.Engine
 	executor *prometheusExecutor
+	// prometheus query rate limit
+	QPSLeakyBucket *datastructure.LeakyBucket
 }
 
 func NewPrometheusService() *PrometheusService {
@@ -45,6 +51,7 @@ func NewPrometheusService() *PrometheusService {
 		Logger:                   newPrometheusLogger(),
 		Reg:                      nil,
 		MaxSamples:               config.Cfg.Prometheus.MaxSamples,
+		LookbackDelta:            defaultLookbackDelta,
 		Timeout:                  100 * time.Second,
 		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
 		EnableAtModifier:         true,
@@ -52,21 +59,34 @@ func NewPrometheusService() *PrometheusService {
 		EnablePerStepStats:       true,
 	}
 	return &PrometheusService{
-		engine:   promql.NewEngine(opts),
-		executor: NewPrometheusExecutor(opts.LookbackDelta),
+		engine:         promql.NewEngine(opts),
+		executor:       NewPrometheusExecutor(opts.LookbackDelta),
+		QPSLeakyBucket: &datastructure.LeakyBucket{},
 	}
 }
 
-func (s *PrometheusService) PromRemoteReadService(req *prompb.ReadRequest, ctx context.Context) (resp *prompb.ReadResponse, err error) {
-	return s.executor.promRemoteReadExecute(ctx, req)
+func (s *PrometheusService) PromRemoteReadService(req *prompb.ReadRequest, ctx context.Context, offloading bool) (resp *prompb.ReadResponse, err error) {
+	if offloading {
+		return s.executor.promRemoteReadOffloadingExecute(ctx, req)
+	} else {
+		return s.executor.promRemoteReadExecute(ctx, req)
+	}
 }
 
 func (s *PrometheusService) PromInstantQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return s.executor.promQueryExecute(ctx, args, s.engine)
+	if args.Offloading {
+		return s.executor.offloadInstantQueryExecute(ctx, args, s.engine)
+	} else {
+		return s.executor.promQueryExecute(ctx, args, s.engine)
+	}
 }
 
 func (s *PrometheusService) PromRangeQueryService(args *model.PromQueryParams, ctx context.Context) (*model.PromQueryResponse, error) {
-	return s.executor.promQueryRangeExecute(ctx, args, s.engine)
+	if args.Offloading {
+		return s.executor.offloadRangeQueryExecute(ctx, args, s.engine)
+	} else {
+		return s.executor.promQueryRangeExecute(ctx, args, s.engine)
+	}
 }
 
 func (s *PrometheusService) PromLabelValuesService(args *model.PromMetaParams, ctx context.Context) (*model.PromQueryResponse, error) {

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -329,7 +329,8 @@ querier:
     external-tag-load-interval: 300
     thanos-replica-labels: [] # remove duplicate replica labels when query data
     cache:
-      enabled: true
+      remote-read-cache: true
+      response-cache: false
       cache-item-size: 512000 # max size of cache item, unit: byte
       cache-max-count: 1024 # max capacity of cache list
       cache-max-allow-deviation: 3600 # unit:s 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### add prometheus offloading calculation

#### Summary

- When we do promql query with prometheus api `/api/v1/query` and `/api/v1/query_range` with aggregation functions, we add offloading calculation. It means some calculations or aggregations could be calculated in **database**, not in **application**. 
- Specifically, the functions which could be offloading could be found [here](https://github.com/deepflowio/deepflow/blob/758f7d85647d67b3a60f975692d8494fe6d3fd48/server/querier/app/prometheus/service/functions.go#L57)

#### How to use it
- when do query with `/api/v1/query` and `/api/v1/query_range` apis, add `operator-offloding=true` params in requests.

#### How it works
- consider the promql like this: `sum by(cpu) (irate(node_cpu_seconds_total[1d]))`
- before, the `Server` will load `1d` (one day) data for `node_cpu_seconds_total` metrics into **memory** , then use `prometheus engine` to calculate the `irate` function and `sum by` function.
- after `operator-offloading` works, we use `nonNegativeDerivative` functions in **clickhouse** to calculate this expresssion. Which means it will do `irate` and `sum` calculatioin in the **database**, and get **less** data in **memory**  as return result. It will reduces so much **data** transport between `Server` and `Clickhouse`.

- but there're still more features & fix up for `operator offloding` calculate, it should be fixed up in the future.

- same to #5031 ,but for v6.4


#### Checklist
- [X] Added unit test.
#### Backport to branches
- v6.4