### PR TITLE
[ingester] prometheus support lable cache expiration

### DIFF
--- a/server/ingester/prometheus/config/config.go
+++ b/server/ingester/prometheus/config/config.go
@@ -36,6 +36,7 @@ const (
 	DefaultLabelRequestMetricBatchCount = 128
 	DefaultAppLabelColumnIncrement      = 4
 	DefaultAppLabelColumnMinCount       = 8
+	DefaultLabelCacheExpiration         = 86400 // 1 day
 )
 
 type Config struct {
@@ -49,6 +50,7 @@ type Config struct {
 	AppLabelColumnIncrement      int                   `yaml:"prometheus-app-label-column-increment"`
 	AppLabelColumnMinCount       int                   `yaml:"prometheus-app-label-column-min-count"`
 	IgnoreUniversalTag           bool                  `yaml:"prometheus-sample-ignore-universal-tag"`
+	LabelCacheExpiration         int                   `yaml:"prometheus-label-cache-expiration"`
 }
 
 type PrometheusConfig struct {
@@ -74,6 +76,9 @@ func (c *Config) Validate() error {
 	if c.AppLabelColumnMinCount <= 0 {
 		c.AppLabelColumnMinCount = DefaultAppLabelColumnMinCount
 	}
+	if c.LabelCacheExpiration <= 0 {
+		c.LabelCacheExpiration = DefaultLabelCacheExpiration
+	}
 
 	return nil
 }
@@ -90,6 +95,7 @@ func Load(base *config.Config, path string) *Config {
 			LabelRequestMetricBatchCount: DefaultLabelRequestMetricBatchCount,
 			AppLabelColumnIncrement:      DefaultAppLabelColumnIncrement,
 			AppLabelColumnMinCount:       DefaultAppLabelColumnMinCount,
+			LabelCacheExpiration:         DefaultLabelCacheExpiration,
 		},
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/server/ingester/prometheus/prometheus/prometheus.go
+++ b/server/ingester/prometheus/prometheus/prometheus.go
@@ -66,7 +66,7 @@ func NewPrometheusHandler(config *config.Config, recv *receiver.Receiver, platfo
 
 	recv.RegistHandler(msgType, decodeQueues, queueCount)
 
-	prometheusLabelTable := decoder.NewPrometheusLabelTable(config.Base.ControllerIPs, int(config.Base.ControllerPort), config.LabelMsgMaxSize)
+	prometheusLabelTable := decoder.NewPrometheusLabelTable(config.Base.ControllerIPs, int(config.Base.ControllerPort), config.LabelMsgMaxSize, config.LabelCacheExpiration)
 
 	prometheusLabelTable.RequestAllLabelIDs()
 	currentColumnIndexMax := prometheusLabelTable.GetMaxAppLabelColumnIndex()

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -526,6 +526,9 @@ ingester:
   ## Whether to ignore the writing of Universal Tag, the default is false, which means writing
   #prometheus-sample-ignore-universal-tag: false
 
+  ## prometheus cache expiration of label ids. uint: s
+  #prometheus-label-cache-expiration: 86400
+
   #ck-disk-monitor:
   #  check-interval: 300 # 检查时间间隔(单位: 秒)
   ## 磁盘空间不足时，同时满足磁盘占用率>used-percent和磁盘空闲<free-space, 或磁盘占用大于used-space, 开始清理数据


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


