### PR TITLE
[ingester] IO event fill vtap's platformInfo at last

### DIFF
--- a/server/ingester/event/decoder/decoder.go
+++ b/server/ingester/event/decoder/decoder.go
@@ -186,13 +186,33 @@ func (d *Decoder) WritePerfEvent(vtapId uint16, e *pb.ProcEvent) {
 	s.L3EpcID = d.platformData.QueryVtapEpc0(uint32(vtapId))
 
 	info := d.platformData.QueryNetnsIdInfo(uint32(s.VTAPID), s.NetnsID)
+	// if platformInfo cannot be obtained from PodId, finally fill with Vtap's platformInfo
+	if info == nil {
+		vtapInfo := d.platformData.QueryVtapInfo(uint32(vtapId))
+		if vtapInfo != nil {
+			vtapIP := net.ParseIP(vtapInfo.Ip)
+			if vtapIP != nil {
+				if ip4 := vtapIP.To4(); ip4 != nil {
+					s.IsIPv4 = true
+					s.IP4 = utils.IpToUint32(ip4)
+					info = d.platformData.QueryIPV4Infos(vtapInfo.EpcId, s.IP4)
+				} else {
+					s.IP6 = vtapIP
+					info = d.platformData.QueryIPV6Infos(vtapInfo.EpcId, s.IP6)
+				}
+			}
+		}
+	}
+
 	podGroupType := uint8(0)
 	if info != nil {
 		s.RegionID = uint16(info.RegionID)
 		s.AZID = uint16(info.AZID)
 		s.L3EpcID = info.EpcID
 		s.HostID = uint16(info.HostID)
-		s.PodID = info.PodID
+		if s.PodID == 0 {
+			s.PodID = info.PodID
+		}
 		s.PodNodeID = info.PodNodeID
 		s.PodNSID = uint16(info.PodNSID)
 		s.PodClusterID = uint16(info.PodClusterID)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


