### PR TITLE
[eBPF] Fix ebpf loading failure in lower version kernels

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -150,20 +150,6 @@ struct conn_info_t {
 	 * kernel protocol inference.
 	 */
 	__u8 skip_proto;
-	// The protocol of traffic on the connection (HTTP, MySQL, etc.).
-	__u8 protocol;
-	// MSG_UNKNOWN, MSG_REQUEST, MSG_RESPONSE
-	__u8 message_type;
-	void *sk;
-	struct socket_info_t *socket_info_ptr;  /* lookup __socket_info_map */
-	size_t count;		// syscall data length
-	__u32 fd;
-	__u32 syscall_infer_len;
-	__s32 correlation_id;	// Currently used for Kafka determination
-	__u32 prev_count;	// Prestored data length
-	char prev_buf[EBPF_CACHE_SIZE];
-	char *syscall_infer_addr;
-
 	/*
 	   The matching logic is:
 
@@ -187,7 +173,21 @@ struct conn_info_t {
 	// the Go DNS case. Parse DNS save record type and ignore AAAA records
 	// in call chain trace
 	__u16 dns_q_type;
-	__u32 tcpseq_offset;	// Used for adjusting TCP sequence numbers
+
+	__u32 fd;
+	// The protocol of traffic on the connection (HTTP, MySQL, etc.).
+	enum traffic_protocol protocol;
+	// MSG_UNKNOWN, MSG_REQUEST, MSG_RESPONSE
+	enum message_type message_type;
+	__s32 correlation_id;	// Currently used for Kafka determination
+	__u32 prev_count;	// Prestored data length
+	__u32 syscall_infer_len;
+	__u64 count:40;
+	__u64 tcpseq_offset:24;
+	char prev_buf[EBPF_CACHE_SIZE];
+	char *syscall_infer_addr;
+	void *sk;
+	struct socket_info_t *socket_info_ptr;	/* lookup __socket_info_map */
 };
 
 struct process_data_extra {


### PR DESCRIPTION
In Linux versions 4.14 and 4.15, the following error occurred during the loading of the ebpf program:

```
bpf: Argument list too long. Program  too large (3999 insns), at most 4096 insns

[2024-01-09T08:58:31.181Z INFO  profiler::ebpf] [eBPF] WARNING: func load_obj__progs() [user/load.c:417] bcc_prog_load() failed. name: bpf_func_sys_exit_sendmmsg, Argument list too long errno: 7
[2024-01-09T08:58:31.181Z INFO  profiler::ebpf] [eBPF] WARNING: func ebpf_obj_load() [user/load.c:723] eBPF load programs failed. (errno 7)
[2024-01-09T08:58:31.181Z INFO  profiler::ebpf] [eBPF] INFO release object ("socket-trace-bpf-linux-common") ...
[2024-01-09T08:58:31.181Z INFO  profiler::ebpf] [eBPF] INFO release object done
[2024-01-09T08:58:31.181Z INFO  profiler::ebpf] [eBPF] WARNING: func tracer_bpf_load() [user/tracer.c:508] bpf load "socket-trace-bpf-linux-common" failed, error:Argument list too long (7).
running_socket_tracer() error.
```
Solve this problem by adjusting the `conn_info_t` member of the structure.


### This PR is for:


- Agent



#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [X] Verified eBPF program runs successfully on linux 4.14.x.
- [X] Verified eBPF program runs successfully on linux 4.19.x.
- [X] Verified eBPF program runs successfully on linux 5.2.x.



