### PR TITLE
[querier] change  to all labels query

### DIFF
--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -92,7 +92,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 	var db, datasource string
 	var debugInfo map[string]interface{}
 	log.Debugf("metric: [%s] data query range: [%d-%d]", metricName, storage_query_start, storage_query_end)
-	ctx, sql, db, datasource, metricName, err = p.promReaderTransToSQL(ctx, req, storage_query_start, storage_query_end, debug)
+	ctx, querierSql, db, datasource, metricName, err = p.promReaderTransToSQL(ctx, req, storage_query_start, storage_query_end, debug)
 	// fmt.Println(sql, db)
 	if err != nil {
 		return nil, "", "", 0, err
@@ -110,7 +110,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 	debugQuerier := debug || config.Cfg.Prometheus.RequestQueryWithDebug
 	args := common.QuerierParams{
 		DB:         db,
-		Sql:        sql,
+		Sql:        querierSql,
 		DataSource: datasource,
 		Debug:      strconv.FormatBool(debugQuerier),
 		QueryUUID:  query_uuid.String(),


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fix Query Metrics by PromQL with all tags
- When use promql to query any expression, **Server** will query all `tag` in the query statements.
- But, in fact, it doesn't need all `tag` in most of scenes, i.e.: `sum(node_cpu_seconds_total)by(cpu)` only required one tag .
- But also, we need to aggregate different series for `sum`, to avoid calculation error, we need a **hash** or **hint** for us to identified different series. We use `all label index` instead of `tag` text to do such thing.
#### Checklist
- [X] Added unit test.
#### Backport to branches
- v6.4