### PR TITLE
[ingester] fix OTel http version matching error

### DIFF
--- a/server/ingester/flow_log/log_data/otel.go
+++ b/server/ingester/flow_log/log_data/otel.go
@@ -286,13 +286,18 @@ func (h *L7FlowLog) fillAttributes(spanAttributes, resAttributes []*v11.KeyValue
 			h.IsTLS = 1
 		}
 		for l7ProtocolStr, l7Protocol := range datatype.L7ProtocolStringMap {
-			if strings.Contains(strings.ToLower(l7ProtocolStr), l7ProtocolStrLower) {
+			if strings.Contains(l7ProtocolStr, l7ProtocolStrLower) {
 				h.L7Protocol = uint8(l7Protocol)
 				break
 			}
 		}
-		if h.L7Protocol == uint8(datatype.L7_PROTOCOL_HTTP_1) && strings.HasPrefix(h.Version, "2") {
-			h.L7Protocol = uint8(datatype.L7_PROTOCOL_HTTP_2)
+		// If the protocol name is 'http', it may be randomly matched to 'http1' or 'http2' and needs to be corrected.
+		if h.L7Protocol == uint8(datatype.L7_PROTOCOL_HTTP_1) || h.L7Protocol == uint8(datatype.L7_PROTOCOL_HTTP_2) {
+			if strings.HasPrefix(h.Version, "2") {
+				h.L7Protocol = uint8(datatype.L7_PROTOCOL_HTTP_2)
+			} else {
+				h.L7Protocol = uint8(datatype.L7_PROTOCOL_HTTP_1)
+			}
 		}
 	}
 

--- a/server/libs/datatype/flow.go
+++ b/server/libs/datatype/flow.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/google/gopacket/layers"
@@ -701,16 +702,16 @@ func (p L7Protocol) String(isTLS bool) string {
 }
 
 var L7ProtocolStringMap = map[string]L7Protocol{
-	L7_PROTOCOL_HTTP_1.String(false):  L7_PROTOCOL_HTTP_1,
-	L7_PROTOCOL_HTTP_2.String(false):  L7_PROTOCOL_HTTP_2,
-	L7_PROTOCOL_DNS.String(false):     L7_PROTOCOL_DNS,
-	L7_PROTOCOL_MYSQL.String(false):   L7_PROTOCOL_MYSQL,
-	L7_PROTOCOL_REDIS.String(false):   L7_PROTOCOL_REDIS,
-	L7_PROTOCOL_DUBBO.String(false):   L7_PROTOCOL_DUBBO,
-	L7_PROTOCOL_GRPC.String(false):    L7_PROTOCOL_GRPC,
-	L7_PROTOCOL_KAFKA.String(false):   L7_PROTOCOL_KAFKA,
-	L7_PROTOCOL_MQTT.String(false):    L7_PROTOCOL_MQTT,
-	L7_PROTOCOL_UNKNOWN.String(false): L7_PROTOCOL_UNKNOWN,
+	strings.ToLower(L7_PROTOCOL_HTTP_1.String(false)):  L7_PROTOCOL_HTTP_1,
+	strings.ToLower(L7_PROTOCOL_HTTP_2.String(false)):  L7_PROTOCOL_HTTP_2,
+	strings.ToLower(L7_PROTOCOL_DNS.String(false)):     L7_PROTOCOL_DNS,
+	strings.ToLower(L7_PROTOCOL_MYSQL.String(false)):   L7_PROTOCOL_MYSQL,
+	strings.ToLower(L7_PROTOCOL_REDIS.String(false)):   L7_PROTOCOL_REDIS,
+	strings.ToLower(L7_PROTOCOL_DUBBO.String(false)):   L7_PROTOCOL_DUBBO,
+	strings.ToLower(L7_PROTOCOL_GRPC.String(false)):    L7_PROTOCOL_GRPC,
+	strings.ToLower(L7_PROTOCOL_KAFKA.String(false)):   L7_PROTOCOL_KAFKA,
+	strings.ToLower(L7_PROTOCOL_MQTT.String(false)):    L7_PROTOCOL_MQTT,
+	strings.ToLower(L7_PROTOCOL_UNKNOWN.String(false)): L7_PROTOCOL_UNKNOWN,
 }
 
 func (p *L4Protocol) String() string {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


