### PR TITLE
[Querier] fix query when use offset but not use defaultValue fill

### DIFF
--- a/server/querier/engine/clickhouse/function.go
+++ b/server/querier/engine/clickhouse/function.go
@@ -640,7 +640,7 @@ func (t *Time) Format(m *view.Model) {
 		m.AddTag(&view.Tag{Value: tagField, Alias: t.Alias, Flag: view.NODE_FLAG_METRICS_OUTER, Withs: withs})
 	}
 	m.AddGroup(&view.Group{Value: t.Alias, Flag: view.GROUP_FLAG_METRICS_OUTER})
-	if m.Time.Fill != "" && m.Time.Interval > 0 {
+	if (m.Time.Fill == "0" || m.Time.Fill == "none" || m.Time.Fill == "null") && m.Time.Interval > 0 {
 		m.AddCallback("time", TimeFill([]interface{}{m}))
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes when query time() use offset but not use fill 
#### Steps to reproduce the bug
- use time(time, interval, '', offset ) as time when query
#### Changes to fix the bug
- remove time fill callback when fill = ''
#### Affected branches
- v.64
- same as #5279 ,but for v6.4