### PR TITLE
[eBPF] Remove capseq preservation for adjacent data in same direction

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -354,7 +354,7 @@ http2_fill_common_socket_2(struct http2_header_data *data,
 	struct trace_key_t trace_key = get_trace_key(timeout, true);
 	struct trace_info_t *trace_info_ptr = trace_map__lookup(&trace_key);
 
-	struct conn_info_t conn_info = {
+	struct conn_info_s conn_info = {
 		.direction = send_buffer->direction,
 		.message_type = send_buffer->msg_type,
 	};

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -122,7 +122,7 @@ union sockaddr_t {
 	struct sockaddr_in6 in6;
 };
 
-struct conn_info_t {
+struct conn_info_s {
 #ifdef PROBE_CONN
 	__u64 id;
 #endif
@@ -221,7 +221,7 @@ struct tail_calls_context {
 	int max_size_limit;	// The maximum size of the socket data that can be transferred.
 	enum traffic_direction dir;	// Data flow direction.
 	bool vecs;		// Whether a memory vector is used ? (for specific syscall)
-	struct conn_info_t conn_info;
+	struct conn_info_s conn_info;
 	struct process_data_extra extra;
 	__u32 bytes_count;
 	struct member_fields_offset *offset;


### PR DESCRIPTION
Remove the setting that keeps the capseq unchanged for consecutive data transmissions in the same direction.

The reason for removal is that if multiple data with the same capseq experience disorder, it will be impossible to correct (capseq is designed to address disorder).



### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
