### PR TITLE
[eBPF] Fix uprobe openssl library unable to retrieve data

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1156,6 +1156,14 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		sk_info.uid = socket_info_ptr->uid;
 
 		/*
+		 * The kernel syscall interface determines that it is the TLS
+		 * handshake protocol, and for the uprobe program, it needs to
+		 * be re inferred to determine the upper layer protocol of TLS.
+		 */
+		if (socket_info_ptr->l7_proto == PROTO_TLS)
+			socket_info_ptr->l7_proto = conn_info->protocol;
+
+		/*
 		 * 同方向多个连续请求或回应的场景时，
 		 * 保持捕获数据的序列号保持不变。
 		 */

--- a/agent/src/ebpf/samples/rust/socket-tracer/src/main.rs
+++ b/agent/src/ebpf/samples/rust/socket-tracer/src/main.rs
@@ -240,7 +240,7 @@ extern "C" fn socket_trace_callback(sd: *mut SK_BPF_DATA) {
         println!("+ --------------------------------- +");
         if sk_proto_safe(sd) == SOCK_DATA_HTTP1 {
             let data = sk_data_str_safe(sd);
-            println!("{} <{}> RECONFIRM {} DIR {} TYPE {} PID {} THREAD_ID {} COROUTINE_ID {} CONTAINER_ID {} SOURCE {} ROLE {} COMM {} {} LEN {} SYSCALL_LEN {} SOCKET_ID 0x{:x} TRACE_ID 0x{:x} TCP_SEQ {} DATA_SEQ {} TimeStamp {}\n{}", 
+            println!("{} <{}> RECONFIRM {} DIR {} TYPE {} PID {} THREAD_ID {} COROUTINE_ID {} CONTAINER_ID {} SOURCE {} ROLE {} COMM {} {} LEN {} SYSCALL_LEN {} SOCKET_ID 0x{:x} TRACE_ID 0x{:x} TCP_SEQ {} DATA_SEQ {} TLS {} TimeStamp {}\n{}", 
                      date_time((*sd).timestamp),
                      proto_tag,
                      (*sd).need_reconfirm,
@@ -260,11 +260,12 @@ extern "C" fn socket_trace_callback(sd: *mut SK_BPF_DATA) {
                      (*sd).syscall_trace_id_call,
                      (*sd).tcp_seq,
                      (*sd).cap_seq,
+                     (*sd).is_tls,
                      (*sd).timestamp,
                      data);
         } else {
             let data: Vec<u8> = sk_data_bytes_safe(sd);
-            println!("{} <{}> RECONFIRM {} DIR {} TYPE {} PID {} THREAD_ID {} COROUTINE_ID {} CONTAINER_ID {} SOURCE {} ROLE {} COMM {} {} LEN {} SYSCALL_LEN {} SOCKET_ID 0x{:x} TRACE_ID 0x{:x} TCP_SEQ {} DATA_SEQ {} TimeStamp {}",
+            println!("{} <{}> RECONFIRM {} DIR {} TYPE {} PID {} THREAD_ID {} COROUTINE_ID {} CONTAINER_ID {} SOURCE {} ROLE {} COMM {} {} LEN {} SYSCALL_LEN {} SOCKET_ID 0x{:x} TRACE_ID 0x{:x} TCP_SEQ {} DATA_SEQ {} TLS {} TimeStamp {}",
                      date_time((*sd).timestamp),
                      proto_tag,
                      (*sd).need_reconfirm,
@@ -284,6 +285,7 @@ extern "C" fn socket_trace_callback(sd: *mut SK_BPF_DATA) {
                      (*sd).syscall_trace_id_call,
                      (*sd).tcp_seq,
                      (*sd).cap_seq,
+                     (*sd).is_tls,
                      (*sd).timestamp);
             if (*sd).source == 2 {
                 print_uprobe_http2_info((*sd).cap_data, (*sd).cap_len);


### PR DESCRIPTION
[eBPF] Fix uprobe openssl library unable to retrieve data

### This PR is for:


- Agent



#### Affected branches
- main
- v6.4

#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
 