### PR TITLE
[Agent] Fixes wasm http unit test and  optimize http parse_payload

### DIFF
--- a/agent/src/plugin/wasm/test.rs
+++ b/agent/src/plugin/wasm/test.rs
@@ -166,9 +166,8 @@ fn test_wasm_http_req() {
         );
 
         assert_eq!(i.req.domain.as_str(), "rewrite domain");
-        assert_eq!(i.req.req_type.as_str(), "rewrite req type");
         assert_eq!(i.req.resource.as_str(), "rewrite resource");
-        assert_eq!(i.req.endpoint.as_str(), "rewrite endpoint");
+        assert_eq!(i.req.endpoint.as_str(), "/rewrite endpoint");
 
         let attr = i.ext_info.unwrap().attributes.unwrap();
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wasm http unit test and  optimize http parse_payload
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
