### PR TITLE
[eBPF] Linux 3.10.0 introduces checks for the revision version number

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -252,7 +252,7 @@ uint32_t get_sys_uptime(void);
 u64 get_sys_btime_msecs(void);
 u64 get_process_starttime(pid_t pid);
 int max_rlim_open_files_set(int num);
-int fetch_kernel_version(int *major, int *minor, int *patch);
+int fetch_kernel_version(int *major, int *minor, int *rev, int *num);
 unsigned int fetch_kernel_version_code(void);
 int get_num_possible_cpus(void);
 

--- a/agent/src/ebpf/user/ctrl_tracer.c
+++ b/agent/src/ebpf/user/ctrl_tracer.c
@@ -419,9 +419,10 @@ static inline void df_bpf_sockopt_msg_free(void *msg)
 
 static inline void get_kernel_version(char *buf)
 {
-	int major, minor, patch;
-	fetch_kernel_version(&major, &minor, &patch);
-	snprintf(buf, LINUX_VER_LEN, "Linux %d.%d.%d\n", major, minor, patch);
+	int major, minor, rev, num;
+	fetch_kernel_version(&major, &minor, &rev, &num);
+	snprintf(buf, LINUX_VER_LEN, "Linux %d.%d.%d-%d\n",
+		 major, minor, rev, num);
 }
 
 static int socktrace_do_cmd(struct df_bpf_obj *obj, df_bpf_cmd_t cmd,

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1823,10 +1823,6 @@ int running_socket_tracer(tracer_callback_t handle,
 	int buffer_sz;
 
 	if (check_kernel_version(4, 14) != 0) {
-		ebpf_warning
-		    ("[eBPF Kernel Adapt] Current linux %d.%d, not support, require Linux 4.14+\n",
-		     major, minor);
-
 		return -EINVAL;
 	}
 

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -74,6 +74,11 @@
 
 #define MAX_CPU_NR      256
 
+// RHEL 7 & CentOS 7 systems that run on kernel 3.10.
+// eBPF support has been backported to kernel 3.10 since 3.10.0-940.el7.x86_64.
+// See this blog post(https://www.redhat.com/en/blog/introduction-ebpf-red-hat-enterprise-linux-7).
+#define LINUX_3_10_MIN_REV_NUM	940
+
 /*
  * timeout (100ms), use for perf reader epoll().
  */


### PR DESCRIPTION
Linux 3.10.0 introduces checks for the revision version number

### This PR is for:


- Agent



#### Affected branches
- main
- 6.4
