### PR TITLE
[eBPF] Set 'is_tls' flag in uprobe golang-http2 programe

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -233,6 +233,7 @@ http2_fill_common_socket_1(struct http2_header_data *data,
 	__u64 id = bpf_get_current_pid_tgid();
 	// source, coroutine_id, timestamp, comm
 	send_buffer->source = DATA_SOURCE_GO_HTTP2_UPROBE;
+	send_buffer->is_tls = is_http2_tls();
 	send_buffer->timestamp = bpf_ktime_get_ns();
 	bpf_get_current_comm(send_buffer->comm, sizeof(send_buffer->comm));
 
@@ -964,6 +965,7 @@ static __inline int fill_http2_dataframe_base(struct __http2_stack *stack,
 	struct __socket_data *send_buffer = &(stack->send_buffer);
 
 	send_buffer->source = DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE;
+	send_buffer->is_tls = is_http2_tls();
 	send_buffer->direction = direction;
 	int tgid = pid_tgid >> 32;
 
@@ -973,7 +975,6 @@ static __inline int fill_http2_dataframe_base(struct __http2_stack *stack,
 	bpf_get_current_comm(send_buffer->comm, sizeof(send_buffer->comm));
 	send_buffer->tcp_seq = 0;
 	send_buffer->data_type = PROTO_HTTP2;
-
 	send_buffer->tuple.l4_protocol = IPPROTO_TCP;
 	void *sk = get_socket_from_fd(fd, offset);
 

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -64,8 +64,9 @@ struct __socket_data {
 
 	/* 追踪数据信息 */
 	__u64 timestamp;     // 数据捕获时间戳
-	__u8  direction: 1;  // bits[0]: 方向，值为T_EGRESS(0), T_INGRESS(1)
-	__u8  msg_type:  7;  // bits[1-7]: 信息类型，值为MSG_UNKNOWN(0), MSG_REQUEST(1), MSG_RESPONSE(2)
+	__u8 direction: 1;  // bits[0]: 方向，值为T_EGRESS(0), T_INGRESS(1)
+	__u8 msg_type:  6;  // bits[1-7]: 信息类型，值为MSG_UNKNOWN(0), MSG_REQUEST(1), MSG_RESPONSE(2)
+	__u8 is_tls: 1;
 
 	__u64 syscall_len;   // 本次系统调用读、写数据的总长度
 	__u64 data_seq;      // cap_data在Socket中的相对顺序号

--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1243,6 +1243,7 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 	v->socket_id = sk_info.uid;
 	v->data_seq = sk_info.seq;
 	v->tgid = tgid;
+	v->is_tls = false;
 	v->pid = (__u32) bpf_get_current_pid_tgid();
 
 	// For blocking reads, there is a significant deviation between the

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -812,11 +812,10 @@ static void reader_raw_cb(void *t, void *raw, int raw_size)
 		submit_data->thread_id = sd->pid;
 		submit_data->coroutine_id = sd->coroutine_id;
 		submit_data->source = sd->source;
+		submit_data->is_tls = sd->is_tls;
 		if (sd->source == DATA_SOURCE_GO_TLS_UPROBE ||
 		    sd->source == DATA_SOURCE_OPENSSL_UPROBE)
 			submit_data->is_tls = true;
-		else
-			submit_data->is_tls = false;
 
 		submit_data->cap_data =
 		    (char *)((void **)&submit_data->cap_data + 1);
@@ -1823,10 +1822,6 @@ int running_socket_tracer(tracer_callback_t handle,
 	int buffer_sz;
 
 	if (check_kernel_version(4, 14) != 0) {
-		ebpf_warning
-		    ("[eBPF Kernel Adapt] Current linux %d.%d, not support, require Linux 4.14+\n",
-		     major, minor);
-
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Set 'is_tls' flag in uprobe golang-http2 programe

### This PR is for:


- Agent


#### Affected branches
- main
- v6.4

#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
   