### PR TITLE
[Agent] Fix the problem of http2 statistical error #23623

### DIFF
--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -475,7 +475,7 @@ impl L7ProtocolParserInterface for HttpLog {
                         if param.direction == PacketDirection::ServerToClient {
                             return false;
                         }
-                        self.parse_http2_go_uprobe(
+                        self.check_http2_go_uprobe(
                             &config.l7_log_dynamic,
                             payload,
                             param,
@@ -483,7 +483,7 @@ impl L7ProtocolParserInterface for HttpLog {
                         )
                         .is_ok()
                     }
-                    _ => self.parse_http_v2(payload, param, &mut info).is_ok(),
+                    _ => self.check_http_v2(payload, param, &mut info).is_ok(),
                 }
             }
             _ => unreachable!(),
@@ -662,7 +662,7 @@ impl HttpLog {
     // +---------------------------------------------------------------+
     // |                          value (valueLength,变长)           ...|
     // +---------------------------------------------------------------+
-    pub fn parse_http2_go_uprobe(
+    pub fn check_http2_go_uprobe(
         &mut self,
         config: &L7LogDynamicConfig,
         payload: &[u8],
@@ -708,16 +708,26 @@ impl HttpLog {
             );
         }
 
+        info.version = String::from("2");
+        info.stream_id = Some(stream_id);
+        Ok(())
+    }
+
+    pub fn parse_http2_go_uprobe(
+        &mut self,
+        config: &L7LogDynamicConfig,
+        payload: &[u8],
+        param: &ParseParam,
+        info: &mut HttpInfo,
+    ) -> Result<()> {
+        self.check_http2_go_uprobe(config, payload, param, info)?;
+
         if info.is_req_end {
             self.perf_stats.as_mut().map(|p| p.inc_req());
         }
         if info.is_resp_end {
             self.perf_stats.as_mut().map(|p| p.inc_resp());
         }
-
-        info.version = String::from("2");
-        info.stream_id = Some(stream_id);
-
         info.cal_rrt_for_multi_merge_log(param).map(|rrt| {
             info.rrt = rrt;
         });
@@ -725,7 +735,7 @@ impl HttpLog {
         if info.is_req_end || info.is_resp_end {
             self.perf_stats.as_mut().map(|p| p.update_rrt(info.rrt));
         }
-        return Ok(());
+        Ok(())
     }
 
     pub fn parse_http_v1(
@@ -833,7 +843,7 @@ impl HttpLog {
         &payload[..HTTPV2_MAGIC_PREFIX.len()] == HTTPV2_MAGIC_PREFIX.as_bytes()
     }
 
-    fn parse_http_v2(
+    fn check_http_v2(
         &mut self,
         payload: &[u8],
         param: &ParseParam,
@@ -968,11 +978,14 @@ impl HttpLog {
         }
 
         if is_httpv2 {
+            info.version = String::from("2");
+            if info.stream_id.is_none() {
+                info.stream_id = Some(httpv2_header.stream_id);
+            }
             if direction == PacketDirection::ClientToServer {
                 if check_http_method(&info.method).is_err() {
                     return Err(Error::HttpHeaderParseFailed);
                 }
-                self.perf_stats.as_mut().map(|p| p.inc_req());
                 info.req_content_length = content_length;
             } else {
                 if let Some(code) = info.status_code {
@@ -983,20 +996,31 @@ impl HttpLog {
                 } else {
                     return Err(Error::HttpHeaderParseFailed);
                 }
-                self.perf_stats.as_mut().map(|p| p.inc_resp());
                 info.resp_content_length = content_length;
             }
-            info.version = String::from("2");
-            if info.stream_id.is_none() {
-                info.stream_id = Some(httpv2_header.stream_id);
-            }
-            info.cal_rrt(param, None).map(|rrt| {
-                info.rrt = rrt;
-                self.perf_stats.as_mut().map(|p| p.update_rrt(rrt));
-            });
             return Ok(());
         }
         Err(Error::HttpHeaderParseFailed)
+    }
+
+    fn parse_http_v2(
+        &mut self,
+        payload: &[u8],
+        param: &ParseParam,
+        info: &mut HttpInfo,
+    ) -> Result<()> {
+        self.check_http_v2(payload, param, info)?;
+
+        if param.direction == PacketDirection::ClientToServer {
+            self.perf_stats.as_mut().map(|p| p.inc_req());
+        } else {
+            self.perf_stats.as_mut().map(|p| p.inc_resp());
+        }
+        info.cal_rrt(param, None).map(|rrt| {
+            info.rrt = rrt;
+            self.perf_stats.as_mut().map(|p| p.update_rrt(rrt));
+        });
+        Ok(())
     }
 
     fn on_header(


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the problem of http2 statistical error #23623
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Not calculates perf_stats when check_payload
#### Affected branches
- main
- v6.4 
- v6.3
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
