### PR TITLE
[Querier] fix range query for _over_time wrong

### DIFF
--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -905,7 +905,7 @@ func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq 
 	selection := []string{fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)}
 	if queryType == model.Range {
 		interval := queryReq.GetStep()
-		offset := queryReq.GetStart() % interval
+		offset := queryReq.GetStart()%interval + min_interval.Milliseconds()
 		selection[0] = fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", interval/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS)
 	}
 

--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -56,26 +56,17 @@ type QueryFunc func(metric string, query, order, group *[]string, req model.Quer
 // NOTICE: query `value` should be LAST index of `query`, it will append `query` as value outside of QueryFuncCall
 var QueryFuncCall = map[string]QueryFunc{
 	// Vector
-	"avg_over_time": simpleCallMatrixFunc("AAvg"),
-	"count_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
-		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
-		*query = append(*query, "Count(row)") // change to sum in range query
-	},
-	"last_over_time": simpleCallMatrixFunc("Last"),
-	"max_over_time":  simpleCallMatrixFunc("Max"),
+	"avg_over_time":   simpleCallMatrixFunc("avg_over_time", "AAvg"),
+	"count_over_time": simpleSelectMatrix("count_over_time", "Count(row)"),
+	"last_over_time":  simpleCallMatrixFunc("last_over_time", "Last"),
+	"max_over_time":   simpleCallMatrixFunc("max_over_time", "Max"),
 	"min_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
 		// `Min` in querier will try get min(value, 0) in the query time window
 		// when use instant query, toUnixTimestamp will use [5m] time window, it required 5m/10s +1=31 data points in time window, otherwise it will get `0`
 		// if(count(`_sum_value`)=31, min(`_sum_value`), 0)
 		// so we specific time window=1s here
 
-		if len(*query) > 0 {
-			(*query)[0] = fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS)
-		} else {
-			*query = append(*query, fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS))
-		}
-
+		resetQueryInterval(query, 1, 0)
 		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 
@@ -90,49 +81,44 @@ var QueryFuncCall = map[string]QueryFunc{
 		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 
 		if queryType == model.Instant {
-			// timeWindow := req.GetEnd() - req.GetStart()
-			// offset := (req.GetStart() % timeWindow) / 1e3
 			if len(*query) > 0 {
 				(*query)[0] = fmt.Sprintf("%d AS %s", req.GetEnd()/1e3, PROMETHEUS_TIME_COLUMNS)
-				// fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", timeWindow/1e3, offset, PROMETHEUS_TIME_COLUMNS)
 			} else {
 				*query = append(*query, fmt.Sprintf("%d AS %s", req.GetEnd()/1e3, PROMETHEUS_TIME_COLUMNS))
 			}
 			*query = append(*query, fmt.Sprintf("%s(%s)", "Stddev", metric))
 		} else if queryType == model.Range {
-			*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+			resetQueryInterval(query, 1, 0)
+			*query = append(*query, fmt.Sprintf("%s(%s)", "Last", metric))
 		}
 	},
-	"sum_over_time": simpleCallMatrixFunc("Sum"),
-	"present_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		// get 1
-		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
-		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
-		*query = append(*query, "1")
-	},
+	"sum_over_time":     simpleCallMatrixFunc("sum_over_time", "Sum"),
+	"present_over_time": simpleSelectMatrix("count_over_time", "1"),
 	"quantile_over_time": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
 		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 
-		quantile_param := req.GetFuncParam("quantile_over_time")
-		if queryType == model.Instant {
-			*query = append(*query, fmt.Sprintf("%s(%s, %g)", "Percentile", metric, quantile_param))
-		} else if queryType == model.Range {
-			*query = append(*query, fmt.Sprintf("%s(%s)", "Last", metric))
+		if queryType == model.Range {
+			step := req.GetStep()
+			timeRange := req.GetRange("quantile_over_time") // unit:ms
+			interval := int64(math.Min(float64(step), float64(timeRange)))
+			offset := req.GetStart()%interval + min_interval.Milliseconds()
+
+			resetQueryInterval(query, interval/1e3, offset/1e3)
 		}
+
+		quantile_param := req.GetFuncParam("quantile_over_time")
+		*query = append(*query, fmt.Sprintf("%s(%s, %g)", "Percentile", metric, quantile_param))
 	},
 
 	// aggregation operators
 	"sum": simpleCallFunc("sum", "Sum"),
 	"min": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		if len(*query) > 0 {
-			(*query)[0] = fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS)
-		} else {
-			*query = append(*query, fmt.Sprintf("time(time, 1) AS %s", PROMETHEUS_TIME_COLUMNS))
-		}
+		resetQueryInterval(query, 1, 0)
 		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
 		*query = append(*query, fmt.Sprintf("%s(%s)", "Min", metric))
 		*group = append(*group, PROMETHEUS_LABELS_INDEX)
+
 		for _, tag := range req.GetGrouping("min") {
 			*group = append(*group, handleLabelsMatch(tag))
 		}
@@ -175,7 +161,7 @@ var QueryFuncCall = map[string]QueryFunc{
 			// NOTICE: for irate, `range` is meaningless, it always calculate the last 2 points
 			// e.g.: irate(m[5m]) == irate(m[15m]) == irate(m[1h])
 
-			// use toUnixTimestamp will change to time(time, 15) as default interval grouping
+			// use toUnixTimestamp will change to time(time, 15) as default interval grouping when using Derivative func
 			if len(*query) > 0 {
 				(*query)[0] = fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)
 			} else {
@@ -234,6 +220,18 @@ var QueryFuncCall = map[string]QueryFunc{
 	// },
 }
 
+func resetQueryInterval(query *[]string, interval, offset int64) {
+	timeCol := fmt.Sprintf("time(time, %d) AS %s", interval, PROMETHEUS_TIME_COLUMNS)
+	if offset > 0 {
+		timeCol = fmt.Sprintf("time(time, %d, 1,'', %d) AS %s", interval, offset, PROMETHEUS_TIME_COLUMNS)
+	}
+	if len(*query) > 0 {
+		(*query)[0] = timeCol
+	} else {
+		*query = append(*query, timeCol)
+	}
+}
+
 func simpleSelection(oriFunc string, aftFunc string) QueryFunc {
 	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
 		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
@@ -256,15 +254,46 @@ func simpleCallFunc(oriFunc string, aftFunc string) QueryFunc {
 	}
 }
 
-func simpleCallMatrixFunc(f string) QueryFunc {
+/*
+in matrix selector, we need to + min_interval to avoid duplicated calculation here
+i.e.: for points in [01:01, 02:02, 03:03, 04:04, 05:05]
+in clickhouse, we aggregated to [01:00, 02:00, 03:00, 04:00, 05:00]
+when we use sum_over_time at [05:00], it sum 01-05 points, but 01-04 it expected (05:05>05:00)
+so we make + min_interval to bring 05:00 point to the next point
+*/
+func simpleCallMatrixFunc(oriFunc string, aftFunc string) QueryFunc {
 	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
 		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
 
-		if queryType == model.Instant {
-			*query = append(*query, fmt.Sprintf("%s(%s)", f, metric))
-		} else if queryType == model.Range {
-			*query = append(*query, fmt.Sprintf("Last(%s)", metric))
+		if queryType == model.Range {
+			step := req.GetStep()
+			timeRange := req.GetRange(oriFunc) // unit:ms
+			// use min(step, range) as interval
+			// if range < step, it will downsampling data
+			// if step < range, aggregate to step, then calculate range in engine
+			interval := int64(math.Min(float64(step), float64(timeRange)))
+			offset := req.GetStart()%interval + min_interval.Milliseconds()
+
+			resetQueryInterval(query, interval/1e3, offset/1e3)
 		}
+
+		*query = append(*query, fmt.Sprintf("%s(%s)", aftFunc, metric))
+	}
+}
+
+func simpleSelectMatrix(oriFunc string, q string) QueryFunc {
+	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
+		if queryType == model.Range {
+			step := req.GetStep()
+			timeRange := req.GetRange(oriFunc) // unit:ms
+			interval := int64(math.Min(float64(step), float64(timeRange)))
+			offset := req.GetStart()%interval + min_interval.Milliseconds()
+
+			resetQueryInterval(query, interval/1e3, offset/1e3)
+		}
+		*query = append(*query, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
+		*group = append(*group, fmt.Sprintf("`%s`", PROMETHEUS_NATIVE_TAG_NAME))
+		*query = append(*query, q)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes calculation in range query
#### Steps to reproduce the bug
- use range query with different time step with offloading, the value is greater than it should be
- i.e.: for points in [01:01, 02:02, 03:03, 04:04, 05:05] in database
- when query step = 1m, in clickhouse, it will aggregated to [01:00, 02:00, 03:00, 04:00, 05:00] with toIntervalSeconds() function
- when promql query data at [05:00], it get [05:05] , but [04:04] is the expected point (05:05>05:00, it's not the expected point)
- [min_interval] bring [05:05] point to the next point, make it not scrapeable at [05:00]
#### Changes to fix the bug
- when use range query, add [min_interval] for aggregation points
#### Affected branches
- main
