### PR TITLE
[Querier] fix stddev query

### DIFF
--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -88,7 +88,12 @@ var QueryFuncCall = map[string]QueryFunc{
 			}
 			*query = append(*query, fmt.Sprintf("%s(%s)", "Stddev", metric))
 		} else if queryType == model.Range {
-			resetQueryInterval(query, 1, 0)
+			// stddev is special calculation, it calculs all points in specific time range
+			if len(*query) > 0 {
+				(*query)[0] = fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)
+			} else {
+				*query = append(*query, fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS))
+			}
 			*query = append(*query, fmt.Sprintf("%s(%s)", "Last", metric))
 		}
 	},


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes stddev calculation
#### Steps to reproduce the bug
- use stddev_over_time calculation
#### Changes to fix the bug
- use timestamp to aggragate time
#### Affected branches
- main