### PR TITLE
fix compile agent error

### DIFF
--- a/agent/build.md
+++ b/agent/build.md
@@ -9,7 +9,7 @@ The easiest way is to use our docker image:
 git clone --recursive https://github.com/deepflowio/deepflow.git 
 cd deepflow 
 docker run --privileged --rm -it -v \
-    $(pwd):/deepflow -v ~/.cargo:/usr/local/cargo hub.deepflow.yunshan.net/public/rust-build bash -c \
+    $(pwd):/deepflow hub.deepflow.yunshan.net/public/rust-build bash -c \
     "cd /deepflow/agent && cargo build"
 
 # binary file directory: ./agent/target/debug/deepflow-agent


### PR DESCRIPTION
### This PR is for:
- Documents

### Fixes
the command to compile agent in build.md is wrong.

#### Steps to reproduce the bug
/deepflow]#docker run --privileged --rm -it -v     $(pwd):/deepflow -v ~/.cargo:/usr/local/cargo hub.deepflow.yunshan.net/public/rust-build bash -c     "cd /deepflow/agent && cargo build"
bash: cargo: command not found

#### Changes to fix the bug
rm `-v ~/.cargo:/usr/local/cargo` param

#### Affected branches
- main