### PR TITLE
[Agent] Fixed the statistical problem of different endpoints of the same flow #23684

### DIFF
--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -64,6 +64,7 @@ pub struct QgCounter {
 struct AppMeterWithL7Protocol {
     app_meter: AppMeter,
     endpoint: Option<String>,
+    endpoint_hash: u32,
     l7_protocol: L7Protocol,
 }
 
@@ -251,6 +252,7 @@ impl SubQuadGen {
                     app_meter: *app_meter,
                     l7_protocol: l7_stats.l7_protocol,
                     endpoint: l7_stats.endpoint.clone(),
+                    endpoint_hash,
                 };
                 meters.push(meter);
             }
@@ -265,7 +267,7 @@ impl SubQuadGen {
                         app_meter: meter.app_meter,
                         flow: flow.clone(),
                         l7_protocol: meter.l7_protocol,
-                        endpoint_hash,
+                        endpoint_hash: meter.endpoint_hash,
                         endpoint: meter.endpoint,
                         is_active_host0,
                         is_active_host1,
@@ -300,6 +302,7 @@ impl SubQuadGen {
                     app_meter: *app_meter,
                     l7_protocol: l7_stats.l7_protocol,
                     endpoint: l7_stats.endpoint.clone(),
+                    endpoint_hash,
                 };
                 let _ = stash.l7_stats.insert(l7_stats.flow_id, vec![meter]);
             }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixed the statistical problem of different endpoints of the same flow #23684
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Add an endpoint_hash field to the struct AppMeterWithL7Protocol to distinguish between different endpoints in the same flow
#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
