### PR TITLE
Optimize prom query 64

### DIFF
--- a/server/querier/app/prometheus/cache/response_cache.go
+++ b/server/querier/app/prometheus/cache/response_cache.go
@@ -19,13 +19,12 @@ package cache
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/deepflowio/deepflow/server/libs/lru"
 	"github.com/deepflowio/deepflow/server/querier/config"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 )
@@ -47,24 +46,28 @@ func dataSizeOf(r *item[promql.Result]) uint64 {
 	if r == nil {
 		return 0
 	}
-	size := uint64(unsafe.Sizeof(r.start) + unsafe.Sizeof(r.end) + unsafe.Sizeof(r.step) + unsafe.Sizeof(r.vType))
+	var size uintptr
+	size = unsafe.Sizeof(r.start) + unsafe.Sizeof(r.end) + unsafe.Sizeof(r.step) + unsafe.Sizeof(r.vType)
 	matrix, err := r.data.Matrix()
 	if err != nil {
 		totalPoints := 0
 		for _, m := range matrix {
 			for _, v := range m.Metric {
-				size += uint64(unsafe.Sizeof(v))
+				size += uintptr(len(v.Name) + len(v.Value))
+				size += unsafe.Sizeof((*string)(unsafe.Pointer(&v.Name))) + unsafe.Sizeof((*string)(unsafe.Pointer(&v.Value)))
 			}
 			totalPoints += len(m.Points)
 		}
-		size += uint64(totalPoints*pointSize + totalPoints*pointPtrSize)
+		size += uintptr(totalPoints*pointSize + totalPoints*pointPtrSize)
 	}
-	return size
+	return uint64(size)
 }
 
 type Cacher struct {
 	entries *lru.Cache[string, item[promql.Result]]
 	lock    *sync.RWMutex
+
+	cleanUpCache *time.Ticker
 }
 
 func NewCacher() *Cacher {
@@ -72,7 +75,36 @@ func NewCacher() *Cacher {
 		lock:    &sync.RWMutex{},
 		entries: lru.NewCache[string, item[promql.Result]](config.Cfg.Prometheus.Cache.CacheMaxCount),
 	}
+	go c.startUpCleanCache(config.Cfg.Prometheus.Cache.CacheCleanInterval)
 	return c
+}
+
+func (c *Cacher) startUpCleanCache(cleanUpInterval int) {
+	c.cleanUpCache = time.NewTicker(time.Duration(cleanUpInterval) * time.Second)
+	defer func() {
+		c.cleanUpCache.Stop()
+		if err := recover(); err != nil {
+			go c.startUpCleanCache(cleanUpInterval)
+		}
+	}()
+	for range c.cleanUpCache.C {
+		c.cleanCache()
+	}
+}
+
+func (c *Cacher) cleanCache() {
+	keys := c.entries.Keys()
+	for _, k := range keys {
+		item, ok := c.entries.Peek(k)
+		if !ok {
+			continue
+		}
+		size := dataSizeOf(&item)
+		if size > config.Cfg.Prometheus.Cache.CacheItemSize {
+			log.Infof("cache item remove: %s, real size: %d", k, size)
+			c.entries.Remove(k)
+		}
+	}
 }
 
 func (c *Cacher) Fetch(key string, start, end int64) (r promql.Result, fixedStart int64, fixedEnd int64, queryRequired bool) {
@@ -186,13 +218,6 @@ func (c *Cacher) extractSubData(r promql.Result, start, end int64) promql.Result
 func (c *Cacher) Merge(key string, cached promql.Result, start, end, step int64, res promql.Result) (promql.Result, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	defer func(k string) {
-		// over size
-		val, _ := c.entries.Peek(k)
-		if dataSizeOf(&val) > config.Cfg.Prometheus.Cache.CacheItemSize {
-			c.entries.Remove(k)
-		}
-	}(key)
 
 	entry, ok := c.entries.Get(key)
 	if !ok {
@@ -270,12 +295,10 @@ func (c *Cacher) matrixMerge(resp promql.Matrix, cache *promql.Result) (promql.R
 	}
 	output := make(promql.Matrix, 0, len(cacheMatrix))
 	for _, cachedTs := range cacheMatrix {
-		cachedSeries := genSeriesLabelString(&cachedTs.Metric)
 		newSeries := promql.Series{Metric: cachedTs.Metric}
 		newSeries.Points = cachedTs.Points
 		for _, series := range resp {
-			respSeries := genSeriesLabelString(&series.Metric)
-			if respSeries == cachedSeries {
+			if promLabelsEqual(&cachedTs.Metric, &series.Metric) {
 				existsStartT := newSeries.Points[0].T
 				existsEndT := newSeries.Points[len(newSeries.Points)-1].T
 
@@ -304,7 +327,6 @@ func (c *Cacher) matrixMerge(resp promql.Matrix, cache *promql.Result) (promql.R
 		output = append(output, newSeries)
 	}
 
-	sort.Sort(output)
 	return promql.Result{Value: output}, nil
 }
 
@@ -315,12 +337,10 @@ func (c *Cacher) vectorMerge(resp promql.Vector, cached *promql.Result) (promql.
 	}
 	output := make(promql.Matrix, 0, len(cacheMatrix))
 	for _, cachedTs := range cacheMatrix {
-		cachedSeries := genSeriesLabelString(&cachedTs.Metric)
 		newSeries := promql.Series{Metric: cachedTs.Metric}
 		newSeries.Points = cachedTs.Points
 		for _, samples := range resp {
-			respSeries := genSeriesLabelString(&samples.Metric)
-			if respSeries == cachedSeries {
+			if promLabelsEqual(&cachedTs.Metric, &samples.Metric) {
 				insertedPointAt := sort.Search(len(newSeries.Points), func(i int) bool {
 					return newSeries.Points[i].T >= samples.Point.T
 				})
@@ -334,7 +354,6 @@ func (c *Cacher) vectorMerge(resp promql.Vector, cached *promql.Result) (promql.
 			}
 		}
 	}
-	sort.Sort(output)
 	return promql.Result{Value: output}, nil
 }
 
@@ -347,12 +366,4 @@ func vectorTomatrix(v *promql.Vector) promql.Matrix {
 		})
 	}
 	return output
-}
-
-func genSeriesLabelString(lb *labels.Labels) string {
-	lbs := make([]string, 0, len(*lb))
-	for i := 0; i < len(*lb); i++ {
-		lbs = append(lbs, fmt.Sprintf("%s=%s", (*lb)[i].Name, (*lb)[i].Value))
-	}
-	return strings.Join(lbs, ",")
 }

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -35,6 +35,6 @@ type PrometheusCache struct {
 	ResponseCache      bool   `default:"false" yaml:"response-cache"`      // cache for query response (only operator offloading mode)
 	CacheItemSize      uint64 `default:"51200000" yaml:"cache-item-size"`  // cache-item-size for each cache item, default: 50M
 	CacheMaxCount      int    `default:"1024" yaml:"cache-max-count"`      // cache-max-count for list of cache size
-	CacheFirstTimeout  int    `default:"10000" yaml:"cache-first-timeout"` // time out for first cache item load, unit: ms, default: 10s
+	CacheFirstTimeout  int    `default:"10" yaml:"cache-first-timeout"`    // time out for first cache item load, unit: s, default: 10s
 	CacheCleanInterval int    `default:"3600" yaml:"cache-clean-interval"` // clean interval for cache, unit: s, default: 1h
 }

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -31,9 +31,10 @@ type Prometheus struct {
 }
 
 type PrometheusCache struct {
-	RemoteReadCache        bool    `default:"false" yaml:"remote-read-cache"`  // cache for database quering
-	ResponseCache          bool    `default:"false" yaml:"response-cache"`     // cache for query response (only operator offloading mode)
-	CacheItemSize          uint64  `default:"51200000" yaml:"cache-item-size"` // cache-item-size for each cache item, default: 50M
-	CacheMaxCount          int     `default:"1024" yaml:"cache-max-count"`     // cache-max-count for list of cache size
-	CacheMaxAllowDeviation float64 `default:"3600" yaml:"cache-max-allow-deviation"`
+	RemoteReadCache    bool   `default:"false" yaml:"remote-read-cache"`   // cache for database quering
+	ResponseCache      bool   `default:"false" yaml:"response-cache"`      // cache for query response (only operator offloading mode)
+	CacheItemSize      uint64 `default:"51200000" yaml:"cache-item-size"`  // cache-item-size for each cache item, default: 50M
+	CacheMaxCount      int    `default:"1024" yaml:"cache-max-count"`      // cache-max-count for list of cache size
+	CacheFirstTimeout  int    `default:"10000" yaml:"cache-first-timeout"` // time out for first cache item load, unit: ms, default: 10s
+	CacheCleanInterval int    `default:"3600" yaml:"cache-clean-interval"` // clean interval for cache, unit: s, default: 1h
 }

--- a/server/querier/app/prometheus/model/query_request.go
+++ b/server/querier/app/prometheus/model/query_request.go
@@ -53,6 +53,9 @@ type QueryRequest interface {
 
 	// GetFuncParam returns query params of query function, only for 'topk'/'quantile'/'bottomk'
 	GetFuncParam(f string) float64
+
+	// GetSubStep returns query step in subQuery, like [15m:1m], get `1m` (60000ms) from this
+	GetSubStep(f string) int64
 }
 
 /*

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -48,6 +49,10 @@ const (
 
 	FUNCTION_TOPK    = "topk"
 	FUNCTION_BOTTOMK = "bottomk"
+
+	PROMETHEUS_WINDOW_FIRST_TIME  = "_first_timestamp"
+	PROMETHEUS_WINDOW_FIRST_VALUE = "_first_value"
+	PROMETHEUS_WINDOW_LAST_TIME   = "_last_timestamp"
 )
 
 const (
@@ -59,6 +64,17 @@ const (
 	VTAP_FLOW_PORT_TABLE      = "vtap_flow_port"
 	VTAP_APP_EDGE_PORT_TABLE  = "vtap_app_edge_port"
 	VTAP_FLOW_EDGE_PORT_TABLE = "vtap_flow_edge_port"
+)
+
+// indexes to column indexes
+const (
+	TIME_INDEX int = iota
+	TAG_INDEX
+	METRICS_INDEX
+	LABELS_INDEX
+	WINDOW_FIRST_TIME_INDEX
+	WINDOW_FIRST_VALUE_INDEX
+	WINDOW_LAST_TIME_INDEX
 )
 
 const (
@@ -95,6 +111,12 @@ var aggFunctions = map[string]string{
 	"count_values": view.FUNCTION_COUNT, // equals count() group by value in ck
 	"quantile":     "",                  // not supported, FIXME: should support histogram in querier, and calcul Pxx by histogram
 }
+
+var _relabelFunctions = []string{"sum", "avg", "count", "min", "max", "group", "stddev", "stdvar", "count_values", "quantile"}
+
+var _matrixCallFunctions = []string{"topk", "bottomk",
+	"avg_over_time", "count_over_time", "last_over_time", "max_over_time", "min_over_time", "stddev_over_time", "sum_over_time", "present_over_time", "quantile_over_time",
+	"idelta", "delta", "increase", "irate", "rate"}
 
 // define `showtag` flag, it passed when and only [api/v1/series] been called
 type CtxKeyShowTag struct{}
@@ -244,7 +266,7 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		// append metricName `value`
 		metricsArray = append(metricsArray, metricAlias)
 		// append `tag` only for prometheus & ext_metrics & deepflow_system
-		if q.Hints.Func == "" || q.Hints.Func == "series" || q.Hints.Func == FUNCTION_TOPK || q.Hints.Func == FUNCTION_BOTTOMK || filterMatrixArgTypes(q.Hints.Func) {
+		if !common.IsValueInSliceString(q.Hints.Func, _relabelFunctions) {
 			// `tag` should be append into `Select` with:
 			// 1. not any aggregations, try get all `tag`
 			// 2. topk(n)/bottomk(n) get all `tag`
@@ -540,43 +562,55 @@ func parseToQuerierSQL(ctx context.Context, db string, table string, metrics []s
 	return sqlBuilder.String()
 }
 
+func isValueInArray(v int, col []int) bool {
+	for _, value := range col {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
 // querier result trans to Prom Response
 func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName string, start, end int64, result *common.Result) (resp *prompb.ReadResponse, err error) {
 	if result == nil || len(result.Values) == 0 {
 		return &prompb.ReadResponse{Results: []*prompb.QueryResult{{}}}, nil
 	}
 	log.Debugf("resTransToProm: result length: %d", len(result.Values))
-	tagIndex := -1
-	metricsIndex := -1
-	timeIndex := -1
+	columnIndexes := []int{-1, -1, -1, -1, -1, -1, -1}
 	otherTagCount := 0
-	labelsIndex := -1
 	tagsFieldIndex := make(map[int]bool, len(result.Columns))
 	prefix, _ := ctx.Value(ctxKeyPrefixType{}).(prefix) // ignore if key not exist
 	for i, tag := range result.Columns {
 		if tag == PROMETHEUS_NATIVE_TAG_NAME {
-			tagIndex = i
+			columnIndexes[TAG_INDEX] = i
 		} else if strings.HasPrefix(tag.(string), "tag.") {
 			tagsFieldIndex[i] = true
 		} else if tag == PROMETHEUS_METRIC_VALUE {
-			metricsIndex = i
+			columnIndexes[METRICS_INDEX] = i
 		} else if tag == PROMETHEUS_TIME_COLUMNS {
-			timeIndex = i
+			columnIndexes[TIME_INDEX] = i
 		} else if tag == PROMETHEUS_LABELS_INDEX {
-			labelsIndex = i
+			columnIndexes[LABELS_INDEX] = i
+		} else if tag == PROMETHEUS_WINDOW_FIRST_VALUE {
+			columnIndexes[WINDOW_FIRST_VALUE_INDEX] = i
+		} else if tag == PROMETHEUS_WINDOW_FIRST_TIME {
+			columnIndexes[WINDOW_FIRST_TIME_INDEX] = i
+		} else if tag == PROMETHEUS_WINDOW_LAST_TIME {
+			columnIndexes[WINDOW_LAST_TIME_INDEX] = i
 		} else {
 			otherTagCount++
 		}
 	}
-	if metricsIndex < 0 || timeIndex < 0 {
-		return nil, fmt.Errorf("metricsIndex(%d), timeIndex(%d) get failed", metricsIndex, timeIndex)
+	if columnIndexes[METRICS_INDEX] < 0 || columnIndexes[TIME_INDEX] < 0 {
+		return nil, fmt.Errorf("metricsIndex(%d), timeIndex(%d) get failed", columnIndexes[METRICS_INDEX], columnIndexes[TIME_INDEX])
 	}
-	metricsType := result.Schemas[metricsIndex].ValueType
+	metricsType := result.Schemas[columnIndexes[METRICS_INDEX]].ValueType
 
 	// append other deepflow native tag into results
 	allDeepFlowNativeTags := make([]int, 0, otherTagCount)
 	for i := range result.Columns {
-		if i == tagIndex || i == metricsIndex || i == timeIndex || i == labelsIndex || tagsFieldIndex[i] {
+		if tagsFieldIndex[i] || isValueInArray(i, columnIndexes) {
 			continue
 		}
 		allDeepFlowNativeTags = append(allDeepFlowNativeTags, i)
@@ -594,12 +628,15 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 	sampleSeriesIndex := make([]int32, len(result.Values))          // the index in seriesArray, for each sample
 	seriesSampleCount := make([]int32, maxPossibleSeries)           // number of samples of each series
 	initialSeriesIndex := int32(0)
-
+	promJsonMap := make(map[string]map[string]string)
 	tagsStrList := make([]string, 0, len(allDeepFlowNativeTags))
+	promTagStrList := make([]string, 0)
+	promTagWriter := strings.Builder{}
+
 	for i, v := range result.Values {
 		values := v.([]interface{})
 		// don't append series if it's outside query time range
-		currentTimestamp := int64(values[timeIndex].(int))
+		currentTimestamp := int64(values[columnIndexes[TIME_INDEX]].(int))
 		if currentTimestamp < start || currentTimestamp > end {
 			continue
 		}
@@ -608,66 +645,80 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 		var deepflowNativeTagString, promTagJson string
 		var filterTagMap map[string]string
 		// merge prometheus tags
-		if tagIndex > -1 {
-			promTagJson = values[tagIndex].(string)
-			tagMap := make(map[string]string)
-			json.Unmarshal([]byte(promTagJson), &tagMap)
-			filterTagMap = make(map[string]string, len(tagMap))
-			for k, v := range tagMap {
+		if columnIndexes[TAG_INDEX] > -1 {
+			promTagJson = values[columnIndexes[TAG_INDEX]].(string)
+			var ok bool
+			if filterTagMap, ok = promJsonMap[promTagJson]; !ok {
+				filterTagMap = make(map[string]string)
+				json.Unmarshal([]byte(promTagJson), &filterTagMap)
+			}
+			if cap(promTagStrList) < len(filterTagMap) {
+				promTagStrList = make([]string, 0, len(filterTagMap))
+			}
+			for k, v := range filterTagMap {
 				if k == "" || v == "" {
 					continue
 				}
 				// ignore replica labels if passed
 				if config.Cfg.Prometheus.ThanosReplicaLabels != nil && common.IsValueInSliceString(k, config.Cfg.Prometheus.ThanosReplicaLabels) {
+					filterTagMap[k] = ""
 					continue
 				}
 				filterTagMap[k] = v
+				promTagStrList = append(promTagStrList, k)
 			}
-			promFilterTagJson, _ := json.Marshal(filterTagMap)
-			deepflowNativeTagString = string(promFilterTagJson)
-		} else if labelsIndex > -1 {
-			labelsArray, ok := values[labelsIndex].([]uint32)
+			promJsonMap[promTagJson] = filterTagMap
+			sort.Strings(promTagStrList)
+			for i := 0; i < len(promTagStrList); i++ {
+				promTagWriter.WriteString(promTagStrList[i])
+				promTagWriter.WriteByte(':')
+				promTagWriter.WriteString(filterTagMap[promTagStrList[i]])
+			}
+			deepflowNativeTagString = promTagWriter.String()
+			promTagWriter.Reset()
+			promTagStrList = promTagStrList[:0]
+		} else if columnIndexes[LABELS_INDEX] > -1 {
+			labelsArray, ok := values[columnIndexes[LABELS_INDEX]].([]uint32)
 			if !ok {
-				log.Errorf("parse app_label_index_x failed, real type is: %s", reflect.TypeOf(values[labelsIndex]).Kind())
+				log.Errorf("parse app_label_index_x failed, real type is: %s", reflect.TypeOf(values[columnIndexes[LABELS_INDEX]]).Kind())
 				continue
 			}
 			labelString := strings.Builder{}
-			for j, labelidx := range labelsArray {
+			for j := 0; j < len(labelsArray); j++ {
 				labelString.WriteString(strconv.Itoa(j))
-				labelString.WriteString(strconv.Itoa(int(labelidx)))
+				labelString.WriteString(strconv.Itoa(int(labelsArray[j])))
 			}
 			deepflowNativeTagString = labelString.String()
 			filterTagMap = make(map[string]string, len(tagsFieldIndex)+1)
 			filterTagMap[PROMETHEUS_LABELS_INDEX] = deepflowNativeTagString
+			// agg prometheus query, directly get tag.x
+			for idx := range tagsFieldIndex {
+				name := removePrometheusTagPrefix(result.Columns[idx].(string))
+				val := values[idx].(string)
 
-			if len(tagsFieldIndex) > 0 {
-				// agg prometheus query, directly get tag.x
-				for idx := range tagsFieldIndex {
-					name := removePrometheusTagPrefix(result.Columns[idx].(string))
-					val := values[idx].(string)
-
-					if name == "" || val == "" {
-						continue
-					}
-					// ignore replica labels if passed
-					if config.Cfg.Prometheus.ThanosReplicaLabels != nil && common.IsValueInSliceString(name, config.Cfg.Prometheus.ThanosReplicaLabels) {
-						continue
-					}
-					filterTagMap[name] = val
+				if name == "" || val == "" {
+					continue
 				}
+				// ignore replica labels if passed
+				if config.Cfg.Prometheus.ThanosReplicaLabels != nil && common.IsValueInSliceString(name, config.Cfg.Prometheus.ThanosReplicaLabels) {
+					continue
+				}
+				filterTagMap[name] = val
 			}
-		} else {
+		}
+
+		if deepflowNativeTagString == "" {
 			// if tagIndex = -1 and len(tagsFieldIndex) = 0, append metric name
-			filterTagMap = map[string]string{PROMETHEUS_METRICS_NAME: metricsName}
-			promFilterTagJson, _ := json.Marshal(filterTagMap)
-			deepflowNativeTagString = string(promFilterTagJson)
+			// if all tags were filterd by `replica label`, append metric name
+			deepflowNativeTagString = fmt.Sprintf("%s:%s", PROMETHEUS_METRICS_NAME, metricsName)
+			filterTagMap[PROMETHEUS_METRICS_NAME] = metricsName
 		}
 
 		// merge deepflow autotagging tags
 		if len(allDeepFlowNativeTags) > 0 {
-			for _, idx := range allDeepFlowNativeTags {
-				tagsStrList = append(tagsStrList, strconv.Itoa(idx))
-				tagsStrList = append(tagsStrList, getValue(values[idx]))
+			for i := 0; i < len(allDeepFlowNativeTags); i++ {
+				tagsStrList = append(tagsStrList, strconv.Itoa(allDeepFlowNativeTags[i]))
+				tagsStrList = append(tagsStrList, getValue(values[allDeepFlowNativeTags[i]]))
 			}
 			deepflowNativeTagString += strings.Join(tagsStrList, "-")
 			tagsStrList = tagsStrList[:0]
@@ -690,18 +741,15 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			if len(filterTagMap) > 0 { // has any prometheus tag
 				pairs = make([]prompb.Label, 0, 1+len(filterTagMap)+len(allDeepFlowNativeTags))
 				for k, v := range filterTagMap {
+					if v == "" {
+						continue
+					}
 					if prefix == prefixTag {
 						// prometheus tag for deepflow metrics
-						pairs = append(pairs, prompb.Label{
-							Name:  appendPrometheusPrefix(k),
-							Value: v,
-						})
+						pairs = append(pairs, prompb.Label{Name: appendPrometheusPrefix(k), Value: v})
 					} else {
 						// no prefix, use prometheus native tag
-						pairs = append(pairs, prompb.Label{
-							Name:  k,
-							Value: v,
-						})
+						pairs = append(pairs, prompb.Label{Name: k, Value: v})
 					}
 				}
 
@@ -716,21 +764,13 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 				if isZero(values[idx]) {
 					continue
 				}
+				formatTag := formatTagName(result.Columns[idx].(string))
+				p.addExternalTagCache(formatTag, result.Columns[idx].(string))
 				if (len(filterTagMap) > 0) && prefix == prefixDeepFlow {
 					// deepflow tag for prometheus metrics
-					formatTag := formatTagName(result.Columns[idx].(string))
-					pairs = append(pairs, prompb.Label{
-						Name:  appendDeepFlowPrefix(extractEnumTag(formatTag)),
-						Value: getValue(values[idx]),
-					})
-					p.addExternalTagCache(formatTag, result.Columns[idx].(string))
+					pairs = append(pairs, prompb.Label{Name: appendDeepFlowPrefix(extractEnumTag(formatTag)), Value: getValue(values[idx])})
 				} else {
-					formatTag := formatTagName(result.Columns[idx].(string))
-					pairs = append(pairs, prompb.Label{
-						Name:  extractEnumTag(formatTag),
-						Value: getValue(values[idx]),
-					})
-					p.addExternalTagCache(formatTag, result.Columns[idx].(string))
+					pairs = append(pairs, prompb.Label{Name: extractEnumTag(formatTag), Value: getValue(values[idx])})
 				}
 			}
 
@@ -740,10 +780,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			}
 			// avoid duplicated __name__ label
 			if filterTagMap[PROMETHEUS_METRICS_NAME] == "" {
-				pairs = append(pairs, prompb.Label{
-					Name:  PROMETHEUS_METRICS_NAME,
-					Value: metricsName,
-				})
+				pairs = append(pairs, prompb.Label{Name: PROMETHEUS_METRICS_NAME, Value: metricsName})
 			}
 			series = &prompb.TimeSeries{Labels: pairs}
 			seriesArray = append(seriesArray, series)
@@ -764,73 +801,84 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 		// get metrics
 		values := result.Values[i].([]interface{})
 		// don't append series if it's outside query time range
-		currentTimestamp := int64(values[timeIndex].(int))
+		currentTimestamp := int64(values[columnIndexes[TIME_INDEX]].(int))
 		if currentTimestamp < start || currentTimestamp > end {
 			continue
 		}
 		var metricsValue float64
-		if values[metricsIndex] == nil {
-			metricsValue = 0
+		var ok bool
+		if values[columnIndexes[METRICS_INDEX]] == nil {
 			continue
 		}
 
-		switch metricsType {
-		case "Int":
-			metricsValueInt, ok := values[metricsIndex].(int)
-			if !ok {
-				continue
-			}
-			metricsValue = float64(metricsValueInt)
-		case "Float64":
-			// metricsType == "Float64" but typeof(values[metricsIndex]) is `int` ?? for robustness add type assert
-			val, ok := values[metricsIndex].(float64)
-			if ok {
-				metricsValue = val
-			} else {
-				metricsValueInt, ok := values[metricsIndex].(int)
-				if !ok {
-					continue
-				}
-				metricsValue = float64(metricsValueInt)
-			}
-		// for Arrays(use topk() aggregation), it group by timestamp & tag.*, so it won't get multiple values per time & tag, get index [0] is OK
-		case "Array(Int)":
-			metricsArrayInt, ok := values[metricsIndex].(*[]int)
-			if !ok {
-				continue
-			}
-			if len(*metricsArrayInt) > 0 {
-				metricsValue = float64((*metricsArrayInt)[0])
-			}
-		case "Array(Float64)":
-			metricsValueArray, ok := values[metricsIndex].(*[]float64)
-			if !ok {
-				continue
-			}
-			if len(*metricsValueArray) > 0 {
-				metricsValue = (*metricsValueArray)[0]
-			}
-		default:
-			return nil, fmt.Errorf("unknown metrics type %s, value = %v ", metricsType, values[metricsIndex])
+		if metricsType != "Int" && metricsType != "Float64" {
+			return nil, fmt.Errorf("unknown metrics type %s, value = %v ", metricsType, values[columnIndexes[METRICS_INDEX]])
+		}
+
+		metricsValue, ok = parseValue(metricsType, values[columnIndexes[METRICS_INDEX]])
+		if !ok {
+			continue
+		}
+
+		// it's only for `rate`&`increase` calculation
+		var firstValueInTimeWindow float64
+		var firstTimestamp, lastTimestamp int64
+		if columnIndexes[WINDOW_FIRST_VALUE_INDEX] > -1 {
+			// get minvalue, igonre ok
+			valueType := result.Schemas[columnIndexes[WINDOW_FIRST_VALUE_INDEX]].ValueType
+			firstValueInTimeWindow, _ = parseValue(valueType, values[columnIndexes[WINDOW_FIRST_VALUE_INDEX]])
+		}
+
+		if columnIndexes[WINDOW_FIRST_TIME_INDEX] > -1 {
+			// get min timestamp
+			valueType := result.Schemas[columnIndexes[WINDOW_FIRST_TIME_INDEX]].ValueType
+			firstTimeSeconds, _ := parseValue(valueType, values[columnIndexes[WINDOW_FIRST_TIME_INDEX]])
+			firstTimestamp = int64(firstTimeSeconds * 1000)
+		}
+
+		if columnIndexes[WINDOW_LAST_TIME_INDEX] > -1 {
+			valueType := result.Schemas[columnIndexes[WINDOW_LAST_TIME_INDEX]].ValueType
+			lastTimeSeconds, _ := parseValue(valueType, values[columnIndexes[WINDOW_LAST_TIME_INDEX]])
+			lastTimestamp = int64(lastTimeSeconds * 1000)
 		}
 
 		// add a sample for the TimeSeries
 		seriesIndex := sampleSeriesIndex[i]
 		series := seriesArray[seriesIndex]
 		if cap(series.Samples) == 0 {
-			series.Samples = make([]prompb.Sample, 0, seriesSampleCount[seriesIndex])
+			if columnIndexes[WINDOW_FIRST_TIME_INDEX] > -1 {
+				// double cap for multiple values (min & max)
+				series.Samples = make([]prompb.Sample, 0, seriesSampleCount[seriesIndex]*2)
+			} else {
+				series.Samples = make([]prompb.Sample, 0, seriesSampleCount[seriesIndex])
+			}
 		}
+
 		currentTimestampMs := currentTimestamp * 1000
+
+		// only rate/increase offloading have last timestamp, use last timestamp as current
+		if lastTimestamp != currentTimestampMs && lastTimestamp > 0 {
+			currentTimestampMs = lastTimestamp
+		}
+
 		// ignore repeat data points, it may cause calculation error by irate/idelta
 		if len(series.Samples) > 0 && series.Samples[len(series.Samples)-1].Timestamp == currentTimestampMs {
 			continue
 		}
-		series.Samples = append(
-			series.Samples, prompb.Sample{
-				Timestamp: currentTimestampMs,
-				Value:     metricsValue,
-			},
-		)
+
+		// points are order by time ascending, append first time first
+		if firstTimestamp != currentTimestampMs && firstTimestamp > 0 {
+			series.Samples = append(series.Samples, prompb.Sample{
+				Timestamp: firstTimestamp,
+				Value:     firstValueInTimeWindow,
+			})
+		}
+
+		series.Samples = append(series.Samples, prompb.Sample{
+			Timestamp: currentTimestampMs,
+			Value:     metricsValue,
+		})
+		seriesSampleCount[seriesIndex]++
 	}
 
 	// assemble the final prometheus response
@@ -839,6 +887,29 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 	}
 	resp.Results[0].Timeseries = append(resp.Results[0].Timeseries, seriesArray...)
 	return resp, nil
+}
+
+func convertTo[T int | float64](val interface{}) (v T, b bool) {
+	v, b = val.(T)
+	return
+}
+
+func parseValue(valueType string, val interface{}) (v float64, b bool) {
+	switch valueType {
+	case "Int":
+		metricsValueInt, ok := convertTo[int](val)
+		return float64(metricsValueInt), ok
+	case "Float64":
+		// metricsType == "Float64" but typeof(values[metricsIndex]) is `int` ?? for robustness add type assert
+		metricsValueFloat, ok := convertTo[float64](val)
+		if !ok {
+			metricsValueInt, ok := convertTo[int](val)
+			return float64(metricsValueInt), ok
+		}
+		return metricsValueFloat, ok
+	default:
+		return 0, false
+	}
 }
 
 func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq model.QueryRequest, queryType model.QueryType) string {
@@ -905,8 +976,11 @@ func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq 
 	selection := []string{fmt.Sprintf("toUnixTimestamp(time) AS %s", PROMETHEUS_TIME_COLUMNS)}
 	if queryType == model.Range {
 		interval := queryReq.GetStep()
-		offset := queryReq.GetStart()%interval + min_interval.Milliseconds()
-		selection[0] = fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", interval/1e3, offset/1e3, PROMETHEUS_TIME_COLUMNS)
+		subStep := queryReq.GetSubStep(f0)
+		if subStep > 0 && interval > subStep {
+			interval = subStep
+		}
+		selection[0] = fmt.Sprintf("time(time, %d, 1, '', %d) AS %s", interval/1e3, getRangeOffset(queryReq, interval)/1e3, PROMETHEUS_TIME_COLUMNS)
 	}
 
 	// build selection
@@ -942,6 +1016,20 @@ func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq 
 				call_agg(lastQuery, &selection, &orderBy, &groupBy, queryReq, queryType, handleTagFunc)
 			}
 		}
+	} else if common.IsValueInSliceString(f0, _matrixCallFunctions) && common.IsValueInSliceString(f1, _relabelFunctions) {
+		if len(selection) > 2 {
+			// for `_matrixCallFunctions`, [1] MUST storage query `tag`
+			selection[1] = fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX)
+		}
+		if len(groupBy) > 0 {
+			// for `_matrixCallFunctions`, [0] MUST add query `tag`
+			groupBy[0] = PROMETHEUS_LABELS_INDEX
+		}
+
+		// add grouping tags for aggregation in the next function calculation
+		for _, tag := range queryReq.GetGrouping(f1) {
+			groupBy = append(groupBy, handleTagFunc(tag))
+		}
 	}
 
 	// alias
@@ -956,21 +1044,12 @@ func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq 
 		}
 	}
 
-	// timestamp
-	groupBy = append(groupBy, PROMETHEUS_TIME_COLUMNS)
+	if len(groupBy) > 0 {
+		// only when group by any tag, add `time` group
+		groupBy = append(groupBy, PROMETHEUS_TIME_COLUMNS)
+	}
 	sql := parseToQuerierSQL(ctx, chCommon.DB_NAME_PROMETHEUS, queryReq.GetMetric(), selection, filters, groupBy, orderBy)
 	return sql
-}
-
-func filterMatrixArgTypes(f string) bool {
-	if fc, ok := parser.Functions[f]; ok {
-		for _, t := range fc.ArgTypes {
-			if t == parser.ValueTypeMatrix {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func parseMatcherType(t labels.MatchType) prompb.LabelMatcher_Type {

--- a/server/querier/app/prometheus/service/queryable_offload.go
+++ b/server/querier/app/prometheus/service/queryable_offload.go
@@ -192,6 +192,9 @@ func (o *OffloadQuerier) Select(sortSeries bool, hints *storage.SelectHints, mat
 
 	//lint:ignore SA1029 use string as context key, ensure no type reference to app/prometheus
 	ctx := context.WithValue(o.ctx, "remote_read", true)
+	// if use multiple query functions, it will affect query sql building
+	// so we should restore before query, then call back it after query
+	o.querierable.restoreFunctionAfterQueryFinished()
 	querierSql := o.querierable.reader.parseQueryRequestToSQL(ctx, queryReq, o.querierable.queryType)
 	if querierSql != "" {
 		result, sql, duration, err := queryDataExecute(ctx, querierSql, common.DB_NAME_PROMETHEUS, "", o.debug)

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -75,7 +75,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 			loadCompleted := cacheItem.GetLoadCompleteSignal()
 
 			select {
-			case <-time.After(time.Duration(config.Cfg.Prometheus.Cache.CacheFirstTimeout) * time.Millisecond):
+			case <-time.After(time.Duration(config.Cfg.Prometheus.Cache.CacheFirstTimeout) * time.Second):
 				log.Infof("req [%s:%d-%d] wait 10 seconds to get cache result", metricName, start, end)
 				return response, "", "", 0, errors.New("query timeout, retry to get response! ")
 			case <-loadCompleted:

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -46,53 +45,59 @@ type prometheusReader struct {
 
 func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.ReadRequest, debug bool) (resp *prompb.ReadResponse, querierSql, sql string, duration float64, err error) {
 	// promrequest trans to sql
-	// pp.Println(req)
-	var metricName string
+	if req == nil || len(req.Queries) == 0 {
+		return nil, "", "", 0, errors.New("len(req.Queries) == 0, this feature is not yet implemented! ")
+	}
+	start, end := cache.GetPromRequestQueryTime(req.Queries[0])
+	metricName := cache.GetMetricFromLabelMatcher(&req.Queries[0].Matchers)
+
 	var response *prompb.ReadResponse
-	// var queryResult, result *common.Result
+	// clear cache if data not found
+	defer func(r *prompb.ReadRequest) {
+		if response == nil || len(response.Results) == 0 || len(response.Results[0].Timeseries) == 0 {
+			cache.PromReadResponseCache().Remove(r)
+		}
+	}(req)
+
 	// should get cache result immediately
-	item, hit, metricName, storage_query_start, storage_query_end := cache.PromReadResponseCache().Get(req)
-	if item != nil && len(item.Results) > 0 {
-		response = item
-	}
+	// for DeepFlow Native metrics, don't use cache
+	cacheAvailable := config.Cfg.Prometheus.Cache.RemoteReadCache && !strings.Contains(metricName, "__")
+	if cacheAvailable {
+		var hit cache.CacheHit
+		var cacheItem *cache.CacheItem
+		cacheItem, hit, start, end = cache.PromReadResponseCache().Get(req.Queries[0], start, end)
+		if cacheItem != nil {
+			response = cacheItem.Data()
+		}
 
-	if config.Cfg.Prometheus.Cache.RemoteReadCache && hit == cache.CacheKeyFoundNil {
-		cacheLoadingFinished := &sync.WaitGroup{}
-		cacheLoadingFinished.Add(1)
+		if hit == cache.CacheKeyFoundNil && cacheItem != nil {
+			// found item, but is loading by other request
+			loadCompleted := cacheItem.GetLoadCompleteSignal()
 
-		go func() {
-			waitCtx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
-			for {
-				select {
-				case <-waitCtx.Done():
-					cancelFunc()
-					cacheLoadingFinished.Done()
-					return
-				default:
-					if item, hit, metricName, storage_query_start, storage_query_end = cache.PromReadResponseCache().Get(req); item != nil && len(item.Results) > 0 {
-						response = item
-						cacheLoadingFinished.Done()
-						cancelFunc()
-						return
-					}
-					time.Sleep(10 * time.Millisecond)
+			select {
+			case <-time.After(time.Duration(config.Cfg.Prometheus.Cache.CacheFirstTimeout) * time.Millisecond):
+				log.Infof("req [%s:%d-%d] wait 10 seconds to get cache result", metricName, start, end)
+				return response, "", "", 0, errors.New("query timeout, retry to get response! ")
+			case <-loadCompleted:
+				cacheItem, hit, start, end = cache.PromReadResponseCache().Get(req.Queries[0], start, end)
+				if cacheItem != nil {
+					response = cacheItem.Data()
 				}
+				log.Debugf("req [%s:%d-%d] get cached result", metricName, start, end)
 			}
-		}()
+		}
 
-		cacheLoadingFinished.Wait()
-	}
-
-	if hit == cache.CacheHitFull {
-		return response, "", "", 0, nil
+		if hit == cache.CacheHitFull {
+			return response, "", "", 0, nil
+		}
 	}
 
 	// CacheKeyNotFound & CacheHitPart, do query
 	var result *common.Result
 	var db, datasource string
 	var debugInfo map[string]interface{}
-	log.Debugf("metric: [%s] data query range: [%d-%d]", metricName, storage_query_start, storage_query_end)
-	ctx, querierSql, db, datasource, metricName, err = p.promReaderTransToSQL(ctx, req, storage_query_start, storage_query_end, debug)
+	log.Debugf("metric: [%s] data query range: [%d-%d]", metricName, start, end)
+	ctx, querierSql, db, datasource, metricName, err = p.promReaderTransToSQL(ctx, req, start, end, debug)
 	// fmt.Println(sql, db)
 	if err != nil {
 		return nil, "", "", 0, err
@@ -107,12 +112,11 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 		ctx = context.WithValue(ctx, "remote_read", true)
 	}
 	// if `api` pass `debug` or config debug, get debug info from querier
-	debugQuerier := debug || config.Cfg.Prometheus.RequestQueryWithDebug
 	args := common.QuerierParams{
 		DB:         db,
 		Sql:        querierSql,
 		DataSource: datasource,
-		Debug:      strconv.FormatBool(debugQuerier),
+		Debug:      strconv.FormatBool(debug),
 		QueryUUID:  query_uuid.String(),
 		Context:    ctx,
 	}
@@ -121,7 +125,7 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 
 	// start span trace query time of any query uuid
 	var span trace.Span
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
+	if debug {
 		tr := otel.GetTracerProvider().Tracer("querier/prometheus/clickhouseQuery")
 		ctx, span = tr.Start(ctx, "PromReaderExecute",
 			trace.WithSpanKind(trace.SpanKindClient),
@@ -138,12 +142,10 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 		return nil, "", "", 0, err
 	}
 
-	if debugQuerier {
+	if debug {
 		duration = extractQueryTimeFromQueryResponse(debugInfo)
 		sql = extractQuerySQLFromQueryResponse(debugInfo)
-	}
 
-	if config.Cfg.Prometheus.RequestQueryWithDebug {
 		// inject query_time for current span
 		span.SetAttributes(attribute.Float64("query_time", duration))
 
@@ -166,15 +168,11 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 		}
 	}
 
-	if req == nil || len(req.Queries) == 0 {
-		return nil, "", "", 0, errors.New("len(req.Queries) == 0, this feature is not yet implemented! ")
-	}
-
 	api_query_start, api_query_end := cache.GetPromRequestQueryTime(req.Queries[0])
 	// response trans to prom resp
 	resp, err = p.respTransToProm(ctx, metricName, api_query_start, api_query_end, result)
 
-	if config.Cfg.Prometheus.Cache.RemoteReadCache {
+	if cacheAvailable {
 		// merge result into cache
 		response = cache.PromReadResponseCache().AddOrMerge(req, resp)
 	} else {
@@ -233,11 +231,7 @@ func queryDataExecute(ctx context.Context, querierSql string, db string, ds stri
 	ckEngine := &clickhouse.CHEngine{DB: args.DB, DataSource: args.DataSource}
 	ckEngine.Init()
 	result, debugInfo, err := ckEngine.ExecuteQuery(&args)
-	if err != nil {
-		log.Errorf("ExecuteQuery failed, debug info = %v, err info = %v", debug, err)
-		return nil, "", 0, err
-	}
-	if debug {
+	if debug && debugInfo != nil {
 		duration = extractQueryTimeFromQueryResponse(debugInfo)
 		sql = extractQuerySQLFromQueryResponse(debugInfo)
 
@@ -245,5 +239,10 @@ func queryDataExecute(ctx context.Context, querierSql string, db string, ds stri
 		span.SetAttributes(attribute.String("querier_sql", querierSql))
 		span.SetAttributes(attribute.String("sql", sql))
 	}
+	if err != nil {
+		log.Errorf("ExecuteQuery failed, debug info = %v, err info = %v", debug, err)
+		return nil, sql, duration, err
+	}
+
 	return result, sql, duration, err
 }

--- a/server/querier/app/prometheus/service/service.go
+++ b/server/querier/app/prometheus/service/service.go
@@ -34,8 +34,11 @@ import (
 
 var log = logging.MustGetLogger("prometheus")
 
-// equals defaultLookbackDelta in prometheus engine
-const defaultLookbackDelta = 5 * time.Minute
+const (
+	// equals defaultLookbackDelta in prometheus engine
+	defaultLookbackDelta          = 5 * time.Minute
+	defaultNoStepSubQueryInterval = 1 * time.Minute
+)
 
 type PrometheusService struct {
 	// keep only 1 instance of prometheus engine during server lifetime
@@ -53,7 +56,7 @@ func NewPrometheusService() *PrometheusService {
 		MaxSamples:               config.Cfg.Prometheus.MaxSamples,
 		LookbackDelta:            defaultLookbackDelta,
 		Timeout:                  100 * time.Second,
-		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
+		NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(defaultNoStepSubQueryInterval) },
 		EnableAtModifier:         true,
 		EnableNegativeOffset:     true,
 		EnablePerStepStats:       true,

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -334,7 +334,7 @@ querier:
       response-cache: false
       cache-item-size: 512000 # max size of cache item, unit: byte
       cache-max-count: 1024 # max capacity of cache list
-      cache-first-timeout: 10000 # time out for first cache item load, uint: ms
+      cache-first-timeout: 10 # time out for first cache item load, uint: s
       cache-clean-interval: 3600 # clean interval for cache, unit: s
 
   auto-custom-tag:

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -334,7 +334,8 @@ querier:
       response-cache: false
       cache-item-size: 512000 # max size of cache item, unit: byte
       cache-max-count: 1024 # max capacity of cache list
-      cache-max-allow-deviation: 3600 # unit:s 
+      cache-first-timeout: 10000 # time out for first cache item load, uint: ms
+      cache-clean-interval: 3600 # clean interval for cache, unit: s
 
   auto-custom-tag:
     tag-name: 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Improves the performance of promql query
#### Added benchmark
- base on #5462 , add more optimize
- only v6.4+: add `rate` implement for operator-offloading
  - before: when use `rate` to query huge data like `rate(m[3d])` or `rate(m[7d]`, it requires 3d/7d data for calculation.
  - after: consider the `step` in range query, when use `step` for calculation, it's downsampling for data load. So when use `range query` with `step`, NOW we will load the specific calculate data points into memory, lower the data sets for loading.

#### Benchmark result
- base on #5462 , add more tests with `operator-offloading=true`
query range: `1h`, step: `10m`
promql: 
```text
((sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="apiserver",verb=~"LIST|GET"}[1h])) - ((sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="1",scope=~"resource|",verb=~"LIST|GET"}[1h])) or vector(0)) + sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="5",scope="namespace",verb=~"LIST|GET"}[1h])) + sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",le="30",scope="cluster",verb=~"LIST|GET"}[1h])))) + sum by (cluster) (rate(apiserver_request_total{code=~"5..",job="apiserver",verb=~"LIST|GET"}[1h]))) / sum by (cluster) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[1h]))
```

1. use cache ( with mock user 20, ~20qps)
- before test results: ref to #5462 

- after:

|         | avg(ms) | max(ms) | min(ms) | p90 |
|---------|---------|---------|---------|-----|
| range   | 53     | 10126   | 4 | 17 |
| instant | 11     | 4615    | 4 | 15 |

![after-offloading-cache-20](https://github.com/deepflowio/deepflow/assets/45836837/dfd978b2-8936-4d01-93ee-b2978bf4150a)

2. not using cache 
- before test results: ref to #5462 (when query without cache, previous test results could only handle 5 user qps)

- after: (with mock user 5, ~5qps) **compare to previous tests**

| | avg(ms) | max(ms) | min(ms) | p90 |
|---------|---------|---------|---------|-----|
| range   | 6525 | 10395 | 3282 | 8252 |
| instant | 5522 | 8568 | 3000 | 6775 |

![after-offloading-nocache-5](https://github.com/deepflowio/deepflow/assets/45836837/5a16a0a0-70f8-41a4-be23-5879402b5bc5)

---
- additionally, add 4 times of qps for test:

- with mock user 20, ~20qps

| | avg(ms) | max(ms) | min(ms) | p90 |
|---------|---------|---------|---------|-----|
| range   | 15073     | 24327   | 8366      | 19424 |
| instant | 13587     | 23214    | 7976      | 16624 |

![after-offloading-nocache-20](https://github.com/deepflowio/deepflow/assets/45836837/c20d4c87-fc84-4bd2-8217-157ffd810489)

3. conclusion:
` lower avg 40~50% query duration, add about 3~4 times throughput during query`



