### PR TITLE
[Agent] Fixes the exception of deploying collector in docker-compose mode #23744

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "hpack"
 version = "0.3.0"
-source = "git+https://github.com/deepflowio/hpack-rs/#230591a8255598370cf0fc8f2a86b2754baab9c5"
+source = "git+https://github.com/deepflowio/hpack-rs/#425e7345839db81e0fea8cca03084b23d57b16f3"
 dependencies = [
  "log 0.3.9",
 ]

--- a/agent/src/config/mod.rs
+++ b/agent/src/config/mod.rs
@@ -19,7 +19,7 @@ pub mod handler;
 
 pub use config::{
     AgentIdType, Config, ConfigError, KubernetesPollerType, OracleParseConfig, PcapConfig,
-    PrometheusExtraConfig, RuntimeConfig, YamlConfig,
+    PrometheusExtraConfig, RuntimeConfig, YamlConfig, K8S_CA_CRT_PATH,
 };
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use config::{

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -90,7 +90,7 @@ use crate::{
         environment::{
             check, controller_ip_check, free_memory_check, free_space_checker, get_ctrl_ip_and_mac,
             get_env, kernel_check, running_in_container, tap_interface_check,
-            trident_process_check, K8S_MEM_LIMIT_FOR_DEEPFLOW,
+            trident_process_check,
         },
         guard::Guard,
         logger::{LogLevelWriter, LogWriterAdapter, RemoteLogWriter},
@@ -412,9 +412,7 @@ impl Trident {
                 "use K8S_NODE_IP_FOR_DEEPFLOW env ip as destination_ip({})",
                 ctrl_ip
             );
-            if env::var(K8S_MEM_LIMIT_FOR_DEEPFLOW).is_err() {
-                warn!("the environment variable K8S_MEM_LIMIT_FOR_DEEPFLOW is not set in the container , use the limit value from server instead");
-            }
+            warn!("When running in a container, the cpu and memory limits notified by deepflow-server will be ignored, please make sure to use K8s or docker for resource limits.");
         }
 
         #[cfg(target_os = "linux")]
@@ -491,8 +489,8 @@ impl Trident {
                     .static_config
                     .kubernetes_cluster_name
                     .as_ref(),
-            );
-            warn!("When running in a K8s pod, the cpu and memory limits notified by deepflow-server will be ignored, please make sure to use K8s for resource limits.");
+            )
+            .unwrap_or_default();
         }
 
         let (agent_id_tx, _) = broadcast::channel::<AgentId>(1);

--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -42,6 +42,7 @@ use winapi::{
 };
 
 use crate::common::PROCESS_NAME;
+use crate::config::K8S_CA_CRT_PATH;
 use crate::error::{Error, Result};
 use crate::exception::ExceptionHandler;
 use public::proto::{common::TridentType, trident::Exception};
@@ -456,7 +457,25 @@ pub fn running_in_container() -> bool {
     env::var_os(IN_CONTAINER).is_some()
 }
 
-pub fn k8s_mem_limit_for_deepflow() -> Option<u64> {
+fn running_in_k8s() -> bool {
+    // Judge whether Agent is running in k8s according to the existence of K8S_CA_CRT_PATH
+    fs::metadata(K8S_CA_CRT_PATH).is_ok()
+}
+
+fn container_mem_limit() -> Option<u64> {
+    let limit_files = [
+        "/sys/fs/cgroup/memory.max", // If the docker image uses cgroups v2
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes", // If the docker image uses cgroups v1
+    ];
+
+    limit_files.iter().find_map(|limit_file| {
+        fs::read_to_string(limit_file)
+            .ok()
+            .and_then(|content| content.trim().parse().ok())
+    })
+}
+
+fn k8s_mem_limit() -> Option<u64> {
     // Environment variable "K8S_MEM_LIMIT_FOR_DEEPFLOW" is set from container fields
     // https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-container-fields-as-values-for-environment-variables
     env::var(K8S_MEM_LIMIT_FOR_DEEPFLOW).ok().and_then(|v| {
@@ -469,6 +488,14 @@ pub fn k8s_mem_limit_for_deepflow() -> Option<u64> {
             }
         })
     })
+}
+
+pub fn get_container_mem_limit() -> Option<u64> {
+    if running_in_k8s() {
+        k8s_mem_limit()
+    } else {
+        container_mem_limit()
+    }
 }
 
 pub fn get_env() -> String {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the exception of deploying collector in docker-compose mode #23744
#### Steps to reproduce the bug
- remove the container env "IN_CONTAINER: yes"
- it will print some logs about "check cgroups" and report the exception
#### Changes to fix the bug
- restore env "IN_CONTAINER: yes"
- if agent is not running in K8s, do not get kubernetes_cluster_id
- get max_memory from the cgroups limit files when agent is running in a container
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
