### PR TITLE
[eBPF] Support for UPROBE HTTP/2 H2C type data capture

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -390,6 +390,12 @@ static __inline enum message_type parse_http2_headers_frame(const char *buf_src,
 		offset = HTTP2_MAGIC_SIZE;
 	}
 
+	/*
+	 * Use '#pragma unroll' to avoid the following error during the
+	 * loading process in Linux 5.2.x:
+	 * bpf load "socket-trace-bpf-linux-5.2_plus" failed, error:Invalid argument (22)
+	 */
+#pragma unroll
 	for (i = 0; i < HTTPV2_LOOP_MAX; i++) {
 
 		/*

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -600,23 +600,13 @@ static int resolve_bin_file(const char *path, int pid,
 			p_info->info.offsets[off->idx] = offset;
 		}
 
-		if (p_info->info.version < GO_VERSION(1, 20, 0)) {
-			p_info->info.net_TCPConn_itab =
-				get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
-			p_info->info.crypto_tls_Conn_itab =
-				get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
-			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-				binary_path,
-				"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
-		} else {
-			p_info->info.net_TCPConn_itab =
-				get_symbol_addr_from_binary(binary_path, "go:itab.*net.TCPConn,net.Conn");
-			p_info->info.crypto_tls_Conn_itab =
-				get_symbol_addr_from_binary(binary_path, "go:itab.*crypto/tls.Conn,net.Conn");
-			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-				binary_path,
-				"go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
-		}
+		p_info->info.net_TCPConn_itab =
+			get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
+		p_info->info.crypto_tls_Conn_itab =
+			get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
+		p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+			binary_path,
+			"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
 
 		p_info->has_updated = false;
 


### PR DESCRIPTION
Support for UPROBE HTTP/2 H2C type data capture

### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
#### Checklist
- [x] Verified eBPF program runs successfully on linux 3.10.x.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
 


