### PR TITLE
[Agent] fix get hostname

### DIFF
--- a/agent/src/utils/command/mod.rs
+++ b/agent/src/utils/command/mod.rs
@@ -15,12 +15,9 @@
  */
 
 use std::{
-    env,
     io::{Error, ErrorKind, Result},
     process::Command,
 };
-
-use super::environment::K8S_NODE_NAME_FOR_DEEPFLOW;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
@@ -41,15 +38,4 @@ fn exec_command(program: &str, args: &[&str]) -> Result<String> {
         Ok(String::from_utf8(output.stderr)
             .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?)
     }
-}
-
-pub fn get_hostname() -> Result<String> {
-    env::var(K8S_NODE_NAME_FOR_DEEPFLOW).map_or_else(
-        |_| {
-            hostname::get()?
-                .into_string()
-                .map_err(|_| Error::new(ErrorKind::Other, "get hostname failed"))
-        },
-        |name| Ok(name),
-    )
 }

--- a/agent/src/utils/command/windows.rs
+++ b/agent/src/utils/command/windows.rs
@@ -56,3 +56,9 @@ pub fn get_ip_address() -> Result<String, Error> {
     }
     Ok(link_info)
 }
+
+pub fn get_hostname() -> Result<String> {
+    hostname::get()?
+        .into_string()
+        .map_err(|_| Error::new(ErrorKind::Other, "get hostname failed"))
+}


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes get hostname
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- When agent runs in Linux, get the hostname of the root namespace
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
