### PR TITLE
[eBPF] Fix gotls not capturing data

### DIFF
--- a/agent/src/ebpf/kernel/go_tls_bpf.c
+++ b/agent/src/ebpf/kernel/go_tls_bpf.c
@@ -31,6 +31,32 @@ struct bpf_map_def SEC("maps") tls_conn_map = {
 	.max_entries = MAX_SYSTEM_THREADS,
 };
 
+#ifdef TLS_DEBUG
+#define DEFINE_DBG_DATA(x) struct debug_data x = {}
+#define submit_debug(F, N, L)  \
+do { \
+  dbg_data.magic = 0xffff;\
+  dbg_data.fun = (F); \
+  dbg_data.num = (N); \
+  dbg_data.len = (L); \
+  bpf_perf_event_output(ctx, &NAME(socket_data), BPF_F_CURRENT_CPU, &dbg_data, sizeof(dbg_data)); \
+} while(0)
+
+#define submit_debug_str(F, N, P)  \
+do { \
+  dbg_data.magic = 0xfffe;\
+  dbg_data.fun = (F); \
+  dbg_data.num = (N); \
+  __builtin_memset(dbg_data.buf, 0, sizeof(dbg_data.buf)); \
+  bpf_probe_read(dbg_data.buf, sizeof(dbg_data.buf), (P)); \
+  bpf_perf_event_output(ctx, &NAME(socket_data), BPF_F_CURRENT_CPU, &dbg_data, sizeof(dbg_data)); \
+} while(0)
+#else
+#define DEFINE_DBG_DATA(x)
+#define submit_debug(F, N, L)
+#define submit_debug_str(F, N, P)
+#endif
+
 /*
  *  uprobe_go_tls_write_enter  (In tls_conn_map record A(tcp_seq) before syscall)
  *               |
@@ -38,37 +64,41 @@ struct bpf_map_def SEC("maps") tls_conn_map = {
  *               |
  *  uprobe_go_tls_write_exit(return)  lookup A(tcp_seq) from tls_conn_map
  *     send to user finally tcp sequence is "A(tcp_seq) + bytes_count"
- */
+#ifdef TLS_DEBUG */
 SEC("uprobe/go_tls_write_enter")
 int uprobe_go_tls_write_enter(struct pt_regs *ctx)
 {
+	DEFINE_DBG_DATA(dbg_data);
+	submit_debug(1, 0, 0);
 	struct tls_conn c = {};
 	struct tls_conn_key key = {};
-
 	__u64 id = bpf_get_current_pid_tgid();
 	pid_t pid = id >> 32;
 
 	struct ebpf_proc_info *info = bpf_map_lookup_elem(&proc_info_map, &pid);
 	if (!info) {
+		submit_debug(1, 1, 0);
 		return 0;
 	}
 
 	c.sp = (void *)PT_REGS_SP(ctx);
 
 	if (is_register_based_call(info)) {
-		c.fd = get_fd_from_tls_conn_struct(
+		c.fd = get_fd_from_tcp_or_tls_conn_interface(
 			(void *)PT_GO_REGS_PARM1(ctx), info);
 		c.buffer = (char *)PT_GO_REGS_PARM2(ctx);
 	} else {
 		void *conn;
 		bpf_probe_read(&conn, sizeof(conn), (void *)(c.sp + 8));
-		c.fd = get_fd_from_tls_conn_struct(conn, info);
+		c.fd = get_fd_from_tcp_or_tls_conn_interface(conn, info);
 		bpf_probe_read(&c.buffer, sizeof(c.buffer),
 			       (void *)(c.sp + 16));
 	}
 
-	if (c.fd < 0)
+	if (c.fd < 0) {
+		submit_debug(1, 2, 0);
 		return 0;
+	}
 	c.tcp_seq = get_tcp_write_seq_from_fd(c.fd);
 
 	key.tgid = pid;
@@ -82,6 +112,8 @@ int uprobe_go_tls_write_enter(struct pt_regs *ctx)
 SEC("uprobe/go_tls_write_exit")
 int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 {
+	DEFINE_DBG_DATA(dbg_data);
+	submit_debug(2, 0, 0);
 	struct tls_conn *c;
 	struct tls_conn_key key = {};
 	ssize_t bytes_count;
@@ -91,6 +123,7 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 
 	struct ebpf_proc_info *info = bpf_map_lookup_elem(&proc_info_map, &pid);
 	if (!info) {
+		submit_debug(2, 1, 0);
 		return 0;
 	}
 
@@ -98,8 +131,10 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 	key.goid = get_current_goroutine();
 
 	c = bpf_map_lookup_elem(&tls_conn_map, &key);
-	if (!c)
+	if (!c) {
+		submit_debug(2, 2, 0);
 		return 0;
+	}
 
 	if (is_register_based_call(info)) {
 		bytes_count = PT_GO_REGS_PARM1(ctx);
@@ -107,9 +142,13 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 		bpf_probe_read(&bytes_count, sizeof(bytes_count),
 			       (void *)(c->sp + 40));
 	}
+
 	if (bytes_count == 0) {
+		submit_debug(2, 3, 0);
 		bpf_map_delete_elem(&tls_conn_map, &key);
 		return 0;
+	} else {
+		submit_debug(2, 3, bytes_count);
 	}
 
 	struct data_args_t write_args = {
@@ -126,10 +165,13 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 		.is_go_process = true,
 	};
 
+	submit_debug_str(2, 4, c->buffer);
 	bpf_map_delete_elem(&tls_conn_map, &key);
 	active_write_args_map__update(&id, &write_args);
+	
 	if (!process_data((struct pt_regs *)ctx, id, T_EGRESS, &write_args,
 			  bytes_count, &extra)) {
+		submit_debug(2, 5, 0);
 		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
 			      PROG_DATA_SUBMIT_KP_IDX);
 	}
@@ -148,11 +190,14 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 SEC("uprobe/go_tls_read_enter")
 int uprobe_go_tls_read_enter(struct pt_regs *ctx)
 {
+	DEFINE_DBG_DATA(dbg_data);
+	submit_debug(3, 0, 0);
 	__u64 id = bpf_get_current_pid_tgid();
 	pid_t pid = id >> 32;
 
 	struct ebpf_proc_info *info = bpf_map_lookup_elem(&proc_info_map, &pid);
 	if (!info) {
+		submit_debug(3, 1, 0);
 		return 0;
 	}
 
@@ -162,19 +207,21 @@ int uprobe_go_tls_read_enter(struct pt_regs *ctx)
 	c.sp = (void *)PT_REGS_SP(ctx);
 
 	if (is_register_based_call(info)) {
-		c.fd = get_fd_from_tls_conn_struct(
+		c.fd = get_fd_from_tcp_or_tls_conn_interface(
 			(void *)PT_GO_REGS_PARM1(ctx), info);
 		c.buffer = (char *)PT_GO_REGS_PARM2(ctx);
 	} else {
 		void *conn;
 		bpf_probe_read(&conn, sizeof(conn), (void *)(c.sp + 8));
-		c.fd = get_fd_from_tls_conn_struct(conn, info);
+		c.fd = get_fd_from_tcp_or_tls_conn_interface(conn, info);
 		bpf_probe_read(&c.buffer, sizeof(c.buffer),
 			       (void *)(c.sp + 16));
 	}
 
-	if (c.fd < 0)
+	if (c.fd < 0) {
+		submit_debug(3, 2, 0);
 		return 0;
+	}
 	c.tcp_seq = get_tcp_read_seq_from_fd(c.fd);
 
 	key.tgid = bpf_get_current_pid_tgid() >> 32;
@@ -188,11 +235,15 @@ int uprobe_go_tls_read_enter(struct pt_regs *ctx)
 SEC("uprobe/go_tls_read_exit")
 int uprobe_go_tls_read_exit(struct pt_regs *ctx)
 {
+	DEFINE_DBG_DATA(dbg_data);
+	submit_debug(4, 0, 0);
+
 	__u64 id = bpf_get_current_pid_tgid();
 	pid_t pid = id >> 32;
 
 	struct ebpf_proc_info *info = bpf_map_lookup_elem(&proc_info_map, &pid);
 	if (!info) {
+		submit_debug(4, 1, 0);
 		return 0;
 	}
 
@@ -204,8 +255,10 @@ int uprobe_go_tls_read_exit(struct pt_regs *ctx)
 	key.goid = get_current_goroutine();
 
 	c = bpf_map_lookup_elem(&tls_conn_map, &key);
-	if (!c)
+	if (!c) {
+		submit_debug(4, 2, 0);
 		return 0;
+	}
 
 	struct http2_tcp_seq_key tcp_seq_key = {
 		.tgid = key.tgid,
@@ -225,8 +278,11 @@ int uprobe_go_tls_read_exit(struct pt_regs *ctx)
 	}
 
 	if (bytes_count == 0) {
+		submit_debug(4, 3, 0);
 		bpf_map_delete_elem(&tls_conn_map, &key);
 		return 0;
+	} else {
+		submit_debug(4, 3, bytes_count);
 	}
 
 	struct data_args_t read_args = {
@@ -243,10 +299,12 @@ int uprobe_go_tls_read_exit(struct pt_regs *ctx)
 		.is_go_process = true,
 	};
 
+	submit_debug_str(4, 4, c->buffer);
 	bpf_map_delete_elem(&tls_conn_map, &key);
 	active_read_args_map__update(&id, &read_args);
 	if (!process_data((struct pt_regs *)ctx, id, T_INGRESS, &read_args,
 			  bytes_count, &extra)) {
+		submit_debug(4, 5, 0);
 		bpf_tail_call(ctx, &NAME(progs_jmp_kp_map),
 			      PROG_DATA_SUBMIT_KP_IDX);
 	}

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -238,6 +238,16 @@ struct process_event_t {
 	__u8 name[TASK_COMM_LEN]; // process name
 };
 
+struct debug_data {
+	__u16 magic;
+	__u8 fun;
+	__u8 num;
+	union {
+		__u32 len;
+		__u8 buf[4];
+	};
+};
+
 #define GO_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
 
 #endif /* BPF_SOCKET_TRACE_COMMON */

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -598,13 +598,23 @@ static int resolve_bin_file(const char *path, int pid,
 			p_info->info.offsets[off->idx] = offset;
 		}
 
-		p_info->info.net_TCPConn_itab =
-			get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
-		p_info->info.crypto_tls_Conn_itab =
-			get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
-		p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-			binary_path,
-			"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		if (p_info->info.version < GO_VERSION(1, 20, 0)) {
+			p_info->info.net_TCPConn_itab =
+				get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
+			p_info->info.crypto_tls_Conn_itab =
+				get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
+			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+				binary_path,
+				"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		} else {
+			p_info->info.net_TCPConn_itab =
+				get_symbol_addr_from_binary(binary_path, "go:itab.*net.TCPConn,net.Conn");
+			p_info->info.crypto_tls_Conn_itab =
+				get_symbol_addr_from_binary(binary_path, "go:itab.*crypto/tls.Conn,net.Conn");
+			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+				binary_path,
+				"go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
+		}
 
 		p_info->has_updated = false;
 

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -598,23 +598,13 @@ static int resolve_bin_file(const char *path, int pid,
 			p_info->info.offsets[off->idx] = offset;
 		}
 
-		if (p_info->info.version < GO_VERSION(1, 20, 0)) {
-			p_info->info.net_TCPConn_itab =
-				get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
-			p_info->info.crypto_tls_Conn_itab =
-				get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
-			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-				binary_path,
-				"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
-		} else {
-			p_info->info.net_TCPConn_itab =
-				get_symbol_addr_from_binary(binary_path, "go:itab.*net.TCPConn,net.Conn");
-			p_info->info.crypto_tls_Conn_itab =
-				get_symbol_addr_from_binary(binary_path, "go:itab.*crypto/tls.Conn,net.Conn");
-			p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-				binary_path,
-				"go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
-		}
+		p_info->info.net_TCPConn_itab =
+			get_symbol_addr_from_binary(binary_path, "go.itab.*net.TCPConn,net.Conn");
+		p_info->info.crypto_tls_Conn_itab =
+			get_symbol_addr_from_binary(binary_path, "go.itab.*crypto/tls.Conn,net.Conn");
+		p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
+			binary_path,
+			"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn");
 
 		p_info->has_updated = false;
 


### PR DESCRIPTION
e.g.: (golang program)
```
// Create a listener
listener, err := net.Listen("tcp", ":18880")
if err != nil {
    panic(err)
}
// Use Proxy Protocol to create a listener
listener = &proxyproto.Listener{Listener: listener}

// Create an HTTP server
server := &http.Server{
    Addr:      ":8080",
    Handler:   redirect,
    TLSConfig: tlsConfig,
}

// Start the TLS service using ServeTLS method
err = server.ServeTLS(listener, certFile, keyFile)
```
Debugging interface (`crypto/tls.(*Conn).Read`), saw the following data:
```
*crypto/tls.Conn {
	conn: net.Conn(*github.com/armon/go-proxyproto.Conn) *{
		bufReader: *(*bufio.Reader)(0xc00007e8a0),
		conn: net.Conn(*net.TCPConn) ...,

```
Due to the lack of support for 'github.com/armon/go-proxyproto.Conn', unable to obtain the file descriptor (fd). This patch fixes it.

### This PR is for:

- Agent



#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.
