### PR TITLE
[AGENT] Fix unaligned pointer deference problem

### DIFF
--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -886,7 +886,7 @@ impl<'a> MetaPacket<'a> {
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub unsafe fn from_ebpf(data: *mut SK_BPF_DATA) -> Result<MetaPacket<'a>, Box<dyn Error>> {
-        let data = &mut (*data);
+        let data = &mut data.read_unaligned();
         let (local_ip, remote_ip) = if data.tuple.addr_len == 4 {
             (
                 {

--- a/agent/src/common/proc_event/linux.rs
+++ b/agent/src/common/proc_event/linux.rs
@@ -147,7 +147,7 @@ impl ProcEvent {
         data: *mut SK_BPF_DATA,
         event_type: EventType,
     ) -> Result<BoxedProcEvents, Error> {
-        let data = &mut (*data);
+        let data = &mut data.read_unaligned();
         let cap_len = data.cap_len as usize;
         let mut raw_data = vec![0u8; cap_len as usize]; // Copy from data.cap_data where stores event's data
         #[cfg(target_arch = "aarch64")]

--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -15,7 +15,7 @@
  */
 
 use std::ffi::{CStr, CString};
-use std::ptr::null_mut;
+use std::ptr::{self, null_mut};
 use std::slice;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -306,8 +306,9 @@ impl EbpfCollector {
                 return;
             }
 
-            let container_id = Self::convert_to_string((*sd).container_id.as_ptr());
-            let event_type = EventType::from((*sd).source);
+            let container_id =
+                Self::convert_to_string(ptr::addr_of!((*sd).container_id) as *const u8);
+            let event_type = EventType::from(ptr::addr_of!((*sd).source).read_unaligned());
             if event_type != EventType::OtherEvent {
                 // EbpfType like TracePoint, TlsUprobe, GoHttp2Uprobe belong to other events
                 let event = ProcEvent::from_ebpf(sd, event_type);

--- a/agent/src/policy/labeler.rs
+++ b/agent/src/policy/labeler.rs
@@ -69,7 +69,7 @@ impl EpcNetIpKey {
     fn clone_by_masklen(&self, masklen: usize, is_ipv4: bool) -> Self {
         let max_prefix = if is_ipv4 { IPV4_BITS } else { IPV6_BITS };
         Self {
-            ip: self.ip & (u128::MAX << (max_prefix - masklen)),
+            ip: self.ip & (u128::MAX << max_prefix.saturating_sub(masklen)),
             epc_id: self.epc_id,
             masklen: masklen as u8,
         }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Pointers in C callbacks may not be aligned, dereferencing them is UB.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


