### PR TITLE
[Agent] fix mqtt flow log empty request_domain #23835

### DIFF
--- a/agent/src/common/flow.rs
+++ b/agent/src/common/flow.rs
@@ -1213,7 +1213,7 @@ impl From<Flow> for flow_log::Flow {
             last_keepalive_ack: f.last_keepalive_ack,
             acl_gids: f.acl_gids.into_iter().map(|g| g as u32).collect(),
             direction_score: f.direction_score as u32,
-            request_domain: f.request_domain.clone(),
+            request_domain: f.request_domain,
         }
     }
 }

--- a/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
@@ -98,6 +98,10 @@ impl L7ProtocolInfoInterface for MqttInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_domain(&self) -> String {
+        self.client_id.clone().unwrap_or_default()
+    }
 }
 
 pub fn topics_format<S>(t: &Option<Vec<MqttTopic>>, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes mqtt flow log empty request_domain #23835
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     