### PR TITLE
[ingester] fix up lost time accuracy - 6.4

### DIFF
--- a/server/ingester/profile/decoder/decoder.go
+++ b/server/ingester/profile/decoder/decoder.go
@@ -275,8 +275,14 @@ func (d *Decoder) buildMetaData(profile *pb.Profile) ingestion.Metadata {
 		labels = segment.NewKey(labelKey)
 		labels.Add("__name__", profileName)
 	}
+	// use app-profile with `from` params
+	startTime := time.Unix(int64(profile.From), 0)
+	// using ebpf-profile with `timestamp` nanoseconds parse
+	if profile.Timestamp > 0 {
+		startTime = time.Unix(0, int64(profile.Timestamp))
+	}
 	return ingestion.Metadata{
-		StartTime:       time.Unix(int64(profile.From), 0),
+		StartTime:       startTime,
 		EndTime:         time.Unix(int64(profile.Until), 0),
 		SpyName:         profile.SpyName,
 		Key:             labels,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes lost time accuracy in profile parser
#### Steps to reproduce the bug
- use ebpf profile
#### Changes to fix the bug
- add profile timestamp parse ( when use app profile, `profile.timestamp` = 0 )
#### Affected branches
- v6.4