### PR TITLE
[CONTROLLER/TAGRECORDER] fixes ch_vtap_port device name bug

### DIFF
--- a/server/controller/tagrecorder/ch_vtap_port.go
+++ b/server/controller/tagrecorder/ch_vtap_port.go
@@ -568,8 +568,10 @@ func formatVTapVInterfaces(vifs *simplejson.Json, filter map[string]interface{},
 				case common.VIF_DEVICE_TYPE_HOST:
 					vtapVIF.DeviceName = toolDS.hostIDToName[vtapVIF.DeviceID]
 				case common.VIF_DEVICE_TYPE_VM:
-					if toolDS.vmIDToPodNodeID[vtapVIF.DeviceID] != 0 {
-						vtapVIF.DeviceName = toolDS.podNodeIDToName[vtapVIF.DeviceID]
+					if podNodeID, ok := toolDS.vmIDToPodNodeID[vtapVIF.DeviceID]; ok {
+						vtapVIF.DeviceType = common.VIF_DEVICE_TYPE_POD_NODE
+						vtapVIF.DeviceID = podNodeID
+						vtapVIF.DeviceName = toolDS.podNodeIDToName[podNodeID]
 					} else {
 						vtapVIF.DeviceName = toolDS.vmIDToName[vtapVIF.DeviceID]
 					}


### PR DESCRIPTION
### This PR is for:

- Server

### fixes ch_vtap_port device name bug
#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
