### PR TITLE
[Agent] Fixes the problem of continuous rise of SessionQueue cached

### DIFF
--- a/agent/src/common/l7_protocol_info.rs
+++ b/agent/src/common/l7_protocol_info.rs
@@ -417,6 +417,10 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
     fn get_request_domain(&self) -> String {
         String::default()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        0
+    }
 }
 
 impl L7ProtocolInfo {

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -499,6 +499,7 @@ pub struct YamlConfig {
     pub grpc_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub tap_mac_script: String,
     pub cloud_gateway_traffic: bool,
     pub kubernetes_namespace: String,
@@ -637,6 +638,10 @@ impl YamlConfig {
         // L7Log Session timeout must more than or equal 10s to keep window
         if c.l7_log_session_aggr_timeout.as_secs() < 10 {
             c.l7_log_session_aggr_timeout = Duration::from_secs(10);
+        }
+
+        if c.l7_log_session_slot_capacity < 1024 {
+            c.l7_log_session_slot_capacity = 1024;
         }
 
         if c.external_metrics_sender_queue_size == 0 {
@@ -881,6 +886,7 @@ impl Default for YamlConfig {
             analyzer_ip: "".into(),
             grpc_buffer_size: 5,
             l7_log_session_aggr_timeout: Duration::from_secs(120),
+            l7_log_session_slot_capacity: 1024,
             tap_mac_script: "".into(),
             cloud_gateway_traffic: false,
             kubernetes_namespace: "".into(),

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -688,6 +688,7 @@ impl From<&HttpEndpointExtraction> for HttpEndpointTrie {
 pub struct LogParserConfig {
     pub l7_log_collect_nps_threshold: u64,
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub l7_log_dynamic: L7LogDynamicConfig,
     pub l7_log_ignore_tap_sides: [bool; TapSide::MAX as usize + 1],
     pub http_endpoint_disabled: bool,
@@ -700,6 +701,7 @@ impl Default for LogParserConfig {
         Self {
             l7_log_collect_nps_threshold: 0,
             l7_log_session_aggr_timeout: Duration::ZERO,
+            l7_log_session_slot_capacity: 1024,
             l7_log_dynamic: L7LogDynamicConfig::default(),
             l7_log_ignore_tap_sides: [false; TapSide::MAX as usize + 1],
             http_endpoint_disabled: false,
@@ -719,6 +721,10 @@ impl fmt::Debug for LogParserConfig {
             .field(
                 "l7_log_session_aggr_timeout",
                 &self.l7_log_session_aggr_timeout,
+            )
+            .field(
+                "l7_log_session_slot_capacity",
+                &self.l7_log_session_slot_capacity,
             )
             .field("l7_log_dynamic", &self.l7_log_dynamic)
             .field(
@@ -1385,6 +1391,7 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
             log_parser: LogParserConfig {
                 l7_log_collect_nps_threshold: conf.l7_log_collect_nps_threshold,
                 l7_log_session_aggr_timeout: conf.yaml_config.l7_log_session_aggr_timeout,
+                l7_log_session_slot_capacity: conf.yaml_config.l7_log_session_slot_capacity,
                 l7_log_dynamic: L7LogDynamicConfig::new(
                     conf.http_log_proxy_client.to_string().to_ascii_lowercase(),
                     conf.http_log_x_request_id

--- a/agent/src/flow_generator/protocol_logs/dns.rs
+++ b/agent/src/flow_generator/protocol_logs/dns.rs
@@ -95,6 +95,10 @@ impl L7ProtocolInfoInterface for DnsInfo {
         }
         Some(self.query_name.clone())
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.query_name.len()
+    }
 }
 
 impl DnsInfo {

--- a/agent/src/flow_generator/protocol_logs/fastcgi.rs
+++ b/agent/src/flow_generator/protocol_logs/fastcgi.rs
@@ -139,6 +139,10 @@ impl L7ProtocolInfoInterface for FastCGIInfo {
     fn get_endpoint(&self) -> Option<String> {
         self.endpoint.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.path.len()
+    }
 }
 
 impl FastCGIInfo {

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -325,6 +325,10 @@ impl L7ProtocolInfoInterface for HttpInfo {
     fn get_request_domain(&self) -> String {
         self.host.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.path.len()
+    }
 }
 
 impl HttpInfo {

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -113,6 +113,10 @@ impl L7ProtocolInfoInterface for KafkaInfo {
             Some(self.topic_name.clone())
         }
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.topic_name.len()
+    }
 }
 
 impl KafkaInfo {

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -154,6 +154,10 @@ impl L7ProtocolInfoInterface for DubboInfo {
     fn get_request_domain(&self) -> String {
         self.service_name.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.method_name.len()
+    }
 }
 
 impl From<DubboInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/mongo.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mongo.rs
@@ -98,6 +98,10 @@ impl L7ProtocolInfoInterface for MongoDBInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request.len()
+    }
 }
 
 // 协议文档: https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -114,6 +114,10 @@ impl L7ProtocolInfoInterface for MysqlInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl MysqlInfo {

--- a/agent/src/flow_generator/protocol_logs/sql/oracle.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/oracle.rs
@@ -110,6 +110,10 @@ impl L7ProtocolInfoInterface for OracleInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.sql.len()
+    }
 }
 
 impl From<OracleInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -130,6 +130,10 @@ impl L7ProtocolInfoInterface for PostgreInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl From<PostgreInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/redis.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis.rs
@@ -99,6 +99,10 @@ impl L7ProtocolInfoInterface for RedisInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request.len()
+    }
 }
 
 pub fn vec_u8_to_string<S>(v: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>

--- a/agent/src/flow_generator/protocol_logs/tls.rs
+++ b/agent/src/flow_generator/protocol_logs/tls.rs
@@ -288,6 +288,10 @@ impl L7ProtocolInfoInterface for TlsInfo {
     fn get_request_domain(&self) -> String {
         self.request_domain.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request_resource.len()
+    }
 }
 
 impl TlsInfo {

--- a/server/controller/model/agent_group_config.go
+++ b/server/controller/model/agent_group_config.go
@@ -70,6 +70,7 @@ type StaticConfig struct {
 	IngressFlavour                     *string                     `yaml:"ingress-flavour,omitempty"`
 	GrpcBufferSize                     *int                        `yaml:"grpc-buffer-size,omitempty"`            // 单位：M
 	L7LogSessionAggrTimeout            *string                     `yaml:"l7-log-session-aggr-timeout,omitempty"` // 单位: s
+	L7LogSessionQueueSize              *int                        `yaml:"l7-log-session-queue-size,omitempty"`
 	TapMacScript                       *string                     `yaml:"tap-mac-script,omitempty"`
 	BpfDisabled                        *bool                       `yaml:"bpf-disabled,omitempty"`
 	L7ProtocolInferenceMaxFailCount    *uint64                     `yaml:"l7-protocol-inference-max-fail-count,omitempty"`

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -734,6 +734,17 @@ vtap_group_id: g-xxxxxx
   ## Example: 1s, 2m, 10h
   #l7-log-session-aggr-timeout: 120s
 
+  ## The capacity of each l7_flow_log session slot
+  ## Default: 1024. Range: [1024, +oo)
+  ## If the number of data cached by session slot exceeds it's capacity,
+  ## the following impact will have:
+  ## - l7_flow_log cannot be aggregated into session, and flush l7_flow_log will be forced to lose data.
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.cached-request-resource 
+  ##   is used to record the cache request-resource occupation space, the unit is B
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.over-limit 
+  ##   is used to record the number of logs that exceed the limit to the forced flush
+  #l7-log-session-slot-capacity: 1024
+
   ##########
   ## PCAP ##
   ##########


### PR DESCRIPTION
### This PR is for:

- Agent
- Server

### Fixes the problem of continuous rise of SessionQueue cached
#### Steps to reproduce the bug
- ./app-traffic -p {$mysql_password} -e mysql -h {$mysql_host:mysql_port}  -d 600 -r 20000 -t 50 -c 20 -complexity 50
#### Changes to fix the bug
- Add l7-log-session-queue-size to limit the number of cached of SessionQueue
- Add the cached-resource indicator to statistical cache resource data
- Add the over-limit indicator to count the number of more than l7-log-session-queue-size
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
