### PR TITLE
[Agent] Fixes the problem of continuous rise of SessionQueue cached

### DIFF
--- a/agent/src/common/l7_protocol_info.rs
+++ b/agent/src/common/l7_protocol_info.rs
@@ -410,6 +410,10 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
     fn get_request_domain(&self) -> String {
         String::default()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        0
+    }
 }
 
 impl L7ProtocolInfo {

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -499,6 +499,7 @@ pub struct YamlConfig {
     pub grpc_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub tap_mac_script: String,
     pub cloud_gateway_traffic: bool,
     pub kubernetes_namespace: String,
@@ -637,6 +638,10 @@ impl YamlConfig {
         // L7Log Session timeout must more than or equal 10s to keep window
         if c.l7_log_session_aggr_timeout.as_secs() < 10 {
             c.l7_log_session_aggr_timeout = Duration::from_secs(10);
+        }
+
+        if c.l7_log_session_slot_capacity < 1024 {
+            c.l7_log_session_slot_capacity = 1024;
         }
 
         if c.external_metrics_sender_queue_size == 0 {
@@ -881,6 +886,7 @@ impl Default for YamlConfig {
             analyzer_ip: "".into(),
             grpc_buffer_size: 5,
             l7_log_session_aggr_timeout: Duration::from_secs(120),
+            l7_log_session_slot_capacity: 1024,
             tap_mac_script: "".into(),
             cloud_gateway_traffic: false,
             kubernetes_namespace: "".into(),

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -688,6 +688,7 @@ impl From<&HttpEndpointExtraction> for HttpEndpointTrie {
 pub struct LogParserConfig {
     pub l7_log_collect_nps_threshold: u64,
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub l7_log_dynamic: L7LogDynamicConfig,
     pub l7_log_ignore_tap_sides: [bool; TapSide::MAX as usize + 1],
     pub http_endpoint_disabled: bool,
@@ -700,6 +701,7 @@ impl Default for LogParserConfig {
         Self {
             l7_log_collect_nps_threshold: 0,
             l7_log_session_aggr_timeout: Duration::ZERO,
+            l7_log_session_slot_capacity: 1024,
             l7_log_dynamic: L7LogDynamicConfig::default(),
             l7_log_ignore_tap_sides: [false; TapSide::MAX as usize + 1],
             http_endpoint_disabled: false,
@@ -719,6 +721,10 @@ impl fmt::Debug for LogParserConfig {
             .field(
                 "l7_log_session_aggr_timeout",
                 &self.l7_log_session_aggr_timeout,
+            )
+            .field(
+                "l7_log_session_slot_capacity",
+                &self.l7_log_session_slot_capacity,
             )
             .field("l7_log_dynamic", &self.l7_log_dynamic)
             .field(
@@ -1385,6 +1391,7 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
             log_parser: LogParserConfig {
                 l7_log_collect_nps_threshold: conf.l7_log_collect_nps_threshold,
                 l7_log_session_aggr_timeout: conf.yaml_config.l7_log_session_aggr_timeout,
+                l7_log_session_slot_capacity: conf.yaml_config.l7_log_session_slot_capacity,
                 l7_log_dynamic: L7LogDynamicConfig::new(
                     conf.http_log_proxy_client.to_string().to_ascii_lowercase(),
                     conf.http_log_x_request_id

--- a/agent/src/flow_generator/protocol_logs/dns.rs
+++ b/agent/src/flow_generator/protocol_logs/dns.rs
@@ -88,6 +88,17 @@ impl L7ProtocolInfoInterface for DnsInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_endpoint(&self) -> Option<String> {
+        if self.query_name.is_empty() {
+            return None;
+        }
+        Some(self.query_name.clone())
+    }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.query_name.len()
+    }
 }
 
 impl DnsInfo {

--- a/agent/src/flow_generator/protocol_logs/fastcgi.rs
+++ b/agent/src/flow_generator/protocol_logs/fastcgi.rs
@@ -135,6 +135,10 @@ impl L7ProtocolInfoInterface for FastCGIInfo {
     fn get_request_domain(&self) -> String {
         self.host.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.path.len()
+    }
 }
 
 impl FastCGIInfo {

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -325,6 +325,10 @@ impl L7ProtocolInfoInterface for HttpInfo {
     fn get_request_domain(&self) -> String {
         self.host.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.path.len()
+    }
 }
 
 impl HttpInfo {

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -113,6 +113,10 @@ impl L7ProtocolInfoInterface for KafkaInfo {
             Some(self.topic_name.clone())
         }
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.topic_name.len()
+    }
 }
 
 impl KafkaInfo {

--- a/agent/src/flow_generator/protocol_logs/parser.rs
+++ b/agent/src/flow_generator/protocol_logs/parser.rs
@@ -16,8 +16,8 @@
 
 use std::{
     cmp::min,
-    collections::{hash_map::Entry, HashMap},
     fmt,
+    num::NonZeroUsize,
     sync::{
         atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Mutex,
@@ -29,6 +29,7 @@ use std::{
 
 use arc_swap::access::Access;
 use log::{info, warn};
+use lru::LruCache;
 use rand::prelude::{Rng, SeedableRng, SmallRng};
 use serde::Serialize;
 
@@ -308,8 +309,10 @@ pub struct SessionAggrCounter {
     send_before_window: AtomicU64,
     receive: AtomicU64,
     merge: AtomicU64,
-    cached: AtomicU64,
+    cached: AtomicU64, // It is used to record the number of logs that exist in session queue
+    cached_request_resource: AtomicU64, // It is used to record the cache request-resource occupation space, the unit is B
     throttle_drop: AtomicU64,
+    over_limit: AtomicU64, // It is used to record the number of logs that exceed the limit to the forced flush
 }
 
 impl RefCountable for SessionAggrCounter {
@@ -336,9 +339,19 @@ impl RefCountable for SessionAggrCounter {
                 CounterValue::Unsigned(self.cached.load(Ordering::Relaxed)),
             ),
             (
+                "cached-request-resource",
+                CounterType::Counted,
+                CounterValue::Unsigned(self.cached_request_resource.load(Ordering::Relaxed)),
+            ),
+            (
                 "throttle-drop",
                 CounterType::Counted,
                 CounterValue::Unsigned(self.throttle_drop.swap(0, Ordering::Relaxed)),
+            ),
+            (
+                "over-limit",
+                CounterType::Counted,
+                CounterValue::Unsigned(self.over_limit.swap(0, Ordering::Relaxed)),
             ),
         ]
     }
@@ -399,7 +412,8 @@ struct SessionQueue {
     last_flush_time: Duration,
 
     window_size: usize,
-    time_window: Option<Vec<HashMap<u64, Box<MetaAppProto>>>>,
+    l7_log_session_slot_capacity: usize,
+    time_window: Option<Vec<LruCache<u64, Box<MetaAppProto>>>>,
 
     throttle: Throttle,
 
@@ -416,10 +430,14 @@ impl SessionQueue {
         config: LogParserAccess,
         ntp_diff: Arc<AtomicI64>,
     ) -> Self {
+        let conf = config.load();
         //l7_log_session_timeout 20s-300s ，window_size = 4-60，所以 SessionQueue.time_window 预分配内存
-        let window_size =
-            (config.load().l7_log_session_aggr_timeout.as_secs() / SLOT_WIDTH) as usize;
-        let time_window = vec![HashMap::new(); window_size];
+        let window_size = (conf.l7_log_session_aggr_timeout.as_secs() / SLOT_WIDTH) as usize;
+        let slot_capacity = conf.l7_log_session_slot_capacity;
+        let mut time_window = Vec::new();
+        for _ in 0..window_size {
+            time_window.push(LruCache::new(NonZeroUsize::new(slot_capacity).unwrap()));
+        }
         let throttle = Throttle::new(config.clone(), SLOT_WIDTH);
         Self {
             aggregate_start_time: Duration::ZERO,
@@ -428,6 +446,7 @@ impl SessionQueue {
             config,
             ntp_diff,
             window_size,
+            l7_log_session_slot_capacity: slot_capacity,
 
             throttle,
 
@@ -482,19 +501,24 @@ impl SessionQueue {
                 if slot_time < aggregate_start_time {
                     return;
                 }
-                let mut slot = ((slot_time - aggregate_start_time) / SLOT_WIDTH) as usize;
+                let mut slot_index = ((slot_time - aggregate_start_time) / SLOT_WIDTH) as usize;
                 let mut time_window = match self.time_window.take() {
                     Some(t) => t,
                     None => return,
                 };
-                if slot >= self.window_size {
-                    self.flush_window(slot - self.window_size + 1, &mut time_window);
-                    slot = self.window_size - 1;
+                if slot_index >= self.window_size {
+                    self.flush_window(slot_index - self.window_size + 1, &mut time_window);
+                    slot_index = self.window_size - 1;
                 }
-                let time_map = time_window.get_mut(slot).unwrap();
+                let slot = time_window.get_mut(slot_index).unwrap();
                 // If receive the socket close event, flush the log in the queue as soon as possible
-                if let Some(log) = time_map.remove(&p.session_key) {
-                    self.send(log);
+                if let Some(p) = slot.pop(&p.session_key) {
+                    self.counter.cached.fetch_sub(1, Ordering::Relaxed);
+                    self.counter.cached_request_resource.fetch_sub(
+                        p.l7_info.get_request_resource_length() as u64,
+                        Ordering::Relaxed,
+                    );
+                    self.send(p);
                 }
                 self.time_window.replace(time_window);
                 return;
@@ -545,70 +569,80 @@ impl SessionQueue {
             return;
         }
 
-        let mut slot = ((slot_time - self.aggregate_start_time.as_secs()) / SLOT_WIDTH) as usize;
+        let mut slot_index =
+            ((slot_time - self.aggregate_start_time.as_secs()) / SLOT_WIDTH) as usize;
         let mut time_window = match self.time_window.take() {
             Some(t) => t,
             None => return,
         };
         // 使time window维持在固定的长度
-        if slot >= self.window_size {
+        if slot_index >= self.window_size {
             // flush过期的几个slot的数据
-            self.flush_window(slot - self.window_size + 1, &mut time_window);
-            slot = self.window_size - 1;
+            self.flush_window(slot_index - self.window_size + 1, &mut time_window);
+            slot_index = self.window_size - 1;
         }
 
         // 因为数组提前分配hashmap, slot < self.window_size 所以必然存在
-        let time_map = time_window.get_mut(slot).unwrap();
+        let slot = time_window.get_mut(slot_index).unwrap();
         let key = if item.base_info.signal_source == SignalSource::EBPF {
             // if the l7 log from ebpf, use AppProtoLogsData::ebpf_flow_session_id()
             item.ebpf_flow_session_id()
         } else {
             Self::calc_key(&item)
         };
-        self.merge_log(time_map, item, key);
+        self.merge_log(slot, item, key);
 
         self.time_window.replace(time_window);
     }
 
     fn merge_log(
         &mut self,
-        time_map: &mut HashMap<u64, Box<MetaAppProto>>,
+        slot: &mut LruCache<u64, Box<MetaAppProto>>,
         mut item: Box<MetaAppProto>,
         key: u64,
     ) {
-        match time_map.entry(key) {
-            Entry::Occupied(mut v) if item.need_protocol_merge() => {
-                let _ = v.get_mut().session_merge(&mut item);
-                if v.get_mut().l7_info.is_session_end() {
-                    let p = v.remove();
+        match slot.pop(&key) {
+            Some(mut v) if item.need_protocol_merge() => {
+                let _ = v.session_merge(&mut item);
+                if v.l7_info.is_session_end() {
                     self.counter.cached.fetch_sub(1, Ordering::Relaxed);
-                    self.send(p);
+                    self.counter.cached_request_resource.fetch_sub(
+                        v.l7_info.get_request_resource_length() as u64,
+                        Ordering::Relaxed,
+                    );
+                    self.send(v);
+                } else {
+                    slot.put(key, v);
                 }
             }
-            Entry::Occupied(mut v) => match item.base_info.head.msg_type {
+            Some(mut v) => match item.base_info.head.msg_type {
                 // normal order, but if can not merge, send req and resp directly.
                 LogMessageType::Response
-                    if v.get().is_request()
-                        && item.base_info.start_time > v.get().base_info.start_time =>
+                    if v.is_request() && item.base_info.start_time > v.base_info.start_time =>
                 {
-                    let mut p = v.remove();
-                    if let Err(_) = p.session_merge(&mut item) {
+                    if let Err(_) = v.session_merge(&mut item) {
                         self.send(item);
                     }
                     self.counter.cached.fetch_sub(1, Ordering::Relaxed);
+                    self.counter.cached_request_resource.fetch_sub(
+                        v.l7_info.get_request_resource_length() as u64,
+                        Ordering::Relaxed,
+                    );
                     self.counter.merge.fetch_add(1, Ordering::Relaxed);
-                    self.send(p);
+                    self.send(v);
                 }
                 // 若乱序，已存在响应，则可以匹配为会话，则聚合响应发送
                 // If the order is out of order and there is a response, it can be matched as a session, and the aggregated response is sent
                 LogMessageType::Request
-                    if v.get().is_response()
-                        && v.get().base_info.start_time > item.base_info.start_time =>
+                    if v.is_response() && v.base_info.start_time > item.base_info.start_time =>
                 {
                     // if can not merge, send req and resp directly.
-                    let mut p = v.remove();
-                    if let Err(_) = item.session_merge(&mut p) {
-                        self.send(p);
+                    self.counter.cached_request_resource.fetch_sub(
+                        v.l7_info.get_request_resource_length() as u64,
+                        Ordering::Relaxed,
+                    );
+                    if let Err(_) = item.session_merge(&mut v) {
+                        self.send(v);
                     }
                     self.counter.cached.fetch_sub(1, Ordering::Relaxed);
                     self.counter.merge.fetch_add(1, Ordering::Relaxed);
@@ -616,15 +650,24 @@ impl SessionQueue {
                 }
                 // if entry and item cannot merge, send the early one and cache the other
                 _ => {
-                    if v.get().base_info.start_time > item.base_info.start_time {
+                    if v.base_info.start_time > item.base_info.start_time {
                         self.send(item);
                     } else {
                         // swap out old item and send
-                        self.send(v.insert(item));
+                        self.counter.cached_request_resource.fetch_sub(
+                            v.l7_info.get_request_resource_length() as u64,
+                            Ordering::Relaxed,
+                        );
+                        self.send(v);
+                        self.counter.cached_request_resource.fetch_add(
+                            item.l7_info.get_request_resource_length() as u64,
+                            Ordering::Relaxed,
+                        );
+                        slot.put(key, item);
                     }
                 }
             },
-            Entry::Vacant(v) => {
+            None => {
                 if item.need_protocol_merge() {
                     let (req_end, resp_end) = item.l7_info.is_req_resp_end();
                     // http2 uprobe 有可能会重复收到resp_end, 直接忽略，防止堆积
@@ -634,14 +677,28 @@ impl SessionQueue {
                     }
                 }
 
-                if self.counter.cached.load(Ordering::Relaxed)
-                    >= self.window_size as u64 * SLOT_CACHED_COUNT
-                {
-                    self.send(item); // Prevent too many logs from being cached
-                } else {
-                    v.insert(item);
-                    self.counter.cached.fetch_add(1, Ordering::Relaxed);
+                self.counter.cached_request_resource.fetch_add(
+                    item.l7_info.get_request_resource_length() as u64,
+                    Ordering::Relaxed,
+                );
+                if slot.len() >= self.l7_log_session_slot_capacity {
+                    let flush_size = (self.l7_log_session_slot_capacity / 10) as u64;
+                    // Prevent too many logs from being cached
+                    for _ in 0..flush_size {
+                        if let Some((_, p)) = slot.pop_lru() {
+                            self.counter.cached_request_resource.fetch_sub(
+                                p.l7_info.get_request_resource_length() as u64,
+                                Ordering::Relaxed,
+                            );
+                            self.send(p);
+                        }
+                    }
+                    self.counter.cached.fetch_sub(flush_size, Ordering::Relaxed);
+                    self.counter.over_limit.fetch_add(1, Ordering::Relaxed);
                 }
+                self.counter.cached.fetch_add(1, Ordering::Relaxed);
+
+                slot.put(key, item);
             }
         }
     }
@@ -652,11 +709,11 @@ impl SessionQueue {
             None => return,
         };
         let mut batch = Vec::with_capacity(QUEUE_BATCH_SIZE);
-        'outer: for map in time_window.drain(..) {
+        'outer: for mut slot in time_window.drain(..) {
             self.counter
                 .cached
-                .fetch_sub(map.len() as u64, Ordering::Relaxed);
-            for item in map.into_values() {
+                .fetch_sub(slot.len() as u64, Ordering::Relaxed);
+            while let Some((_, item)) = slot.pop_lru() {
                 if batch.len() >= QUEUE_BATCH_SIZE {
                     if let Err(queue::Error::Terminated(..)) =
                         self.output_queue.send_all(&mut batch)
@@ -666,8 +723,14 @@ impl SessionQueue {
                         break 'outer;
                     }
                 }
+                self.counter.cached_request_resource.fetch_sub(
+                    item.l7_info.get_request_resource_length() as u64,
+                    Ordering::Relaxed,
+                );
                 batch.push(BoxAppProtoLogsData(item));
             }
+            // shrink
+            slot.resize(NonZeroUsize::new(self.l7_log_session_slot_capacity).unwrap());
         }
         if !batch.is_empty() {
             if let Err(queue::Error::Terminated(..)) = self.output_queue.send_all(&mut batch) {
@@ -690,15 +753,22 @@ impl SessionQueue {
         get_uniq_flow_id_in_one_minute(item.base_info.flow_id) << 32 | (request_id as u64)
     }
 
-    fn flush_window(&mut self, n: usize, time_window: &mut Vec<HashMap<u64, Box<MetaAppProto>>>) {
+    fn flush_window(&mut self, n: usize, time_window: &mut Vec<LruCache<u64, Box<MetaAppProto>>>) {
         let delete_num = min(n, self.window_size);
         for i in 0..delete_num {
-            let map = time_window.get_mut(i).unwrap();
+            let slot = time_window.get_mut(i).unwrap();
             self.counter
                 .cached
-                .fetch_sub(map.len() as u64, Ordering::Relaxed);
-            self.send_all(map.drain().map(|(_, item)| item).collect());
-            map.shrink_to_fit();
+                .fetch_sub(slot.len() as u64, Ordering::Relaxed);
+            while let Some((_, item)) = slot.pop_lru() {
+                self.counter.cached_request_resource.fetch_sub(
+                    item.l7_info.get_request_resource_length() as u64,
+                    Ordering::Relaxed,
+                );
+                self.send(item);
+            }
+            // shrink
+            slot.resize(NonZeroUsize::new(self.l7_log_session_slot_capacity).unwrap());
         }
         let mut maps = time_window.drain(0..delete_num).collect();
         time_window.append(&mut maps);

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -154,6 +154,10 @@ impl L7ProtocolInfoInterface for DubboInfo {
     fn get_request_domain(&self) -> String {
         self.service_name.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.method_name.len()
+    }
 }
 
 impl From<DubboInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/mongo.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mongo.rs
@@ -98,6 +98,10 @@ impl L7ProtocolInfoInterface for MongoDBInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request.len()
+    }
 }
 
 // 协议文档: https://www.mongodb.com/docs/manual/reference/mongodb-wire-protocol/

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -112,6 +112,10 @@ impl L7ProtocolInfoInterface for MysqlInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl MysqlInfo {

--- a/agent/src/flow_generator/protocol_logs/sql/oracle.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/oracle.rs
@@ -110,6 +110,10 @@ impl L7ProtocolInfoInterface for OracleInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.sql.len()
+    }
 }
 
 impl From<OracleInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -130,6 +130,10 @@ impl L7ProtocolInfoInterface for PostgreInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl From<PostgreInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/redis.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis.rs
@@ -99,6 +99,10 @@ impl L7ProtocolInfoInterface for RedisInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request.len()
+    }
 }
 
 pub fn vec_u8_to_string<S>(v: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>

--- a/agent/src/flow_generator/protocol_logs/tls.rs
+++ b/agent/src/flow_generator/protocol_logs/tls.rs
@@ -288,6 +288,10 @@ impl L7ProtocolInfoInterface for TlsInfo {
     fn get_request_domain(&self) -> String {
         self.request_domain.clone()
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request_resource.len()
+    }
 }
 
 impl TlsInfo {

--- a/server/controller/model/agent_group_config.go
+++ b/server/controller/model/agent_group_config.go
@@ -70,6 +70,7 @@ type StaticConfig struct {
 	IngressFlavour                     *string                     `yaml:"ingress-flavour,omitempty"`
 	GrpcBufferSize                     *int                        `yaml:"grpc-buffer-size,omitempty"`            // 单位：M
 	L7LogSessionAggrTimeout            *string                     `yaml:"l7-log-session-aggr-timeout,omitempty"` // 单位: s
+	L7LogSessionQueueSize              *int                        `yaml:"l7-log-session-queue-size,omitempty"`
 	TapMacScript                       *string                     `yaml:"tap-mac-script,omitempty"`
 	BpfDisabled                        *bool                       `yaml:"bpf-disabled,omitempty"`
 	L7ProtocolInferenceMaxFailCount    *uint64                     `yaml:"l7-protocol-inference-max-fail-count,omitempty"`

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -737,6 +737,17 @@ vtap_group_id: g-xxxxxx
   ## Example: 1s, 2m, 10h
   #l7-log-session-aggr-timeout: 120s
 
+  ## The capacity of each l7_flow_log session slot
+  ## Default: 1024. Range: [1024, +oo)
+  ## If the number of data cached by session slot exceeds it's capacity,
+  ## the following impact will have:
+  ## - l7_flow_log cannot be aggregated into session, and flush l7_flow_log will be forced to lose data.
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.cached-request-resource 
+  ##   is used to record the cache request-resource occupation space, the unit is B
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.over-limit 
+  ##   is used to record the number of logs that exceed the limit to the forced flush
+  #l7-log-session-slot-capacity: 1024
+
   ##########
   ## PCAP ##
   ##########


### PR DESCRIPTION
### This PR is for:

- Agent
- Server

### Fixes the problem of continuous rise of SessionQueue cached
#### Steps to reproduce the bug
- ./app-traffic -p {$mysql_password} -e mysql -h {$mysql_host:mysql_port}  -d 600 -r 20000 -t 50 -c 20 -complexity 50
#### Changes to fix the bug
- Add l7-log-session-queue-size to limit the number of cached of SessionQueue
- Add the cached-resource indicator to statistical cache resource data
- Add the over-limit indicator to count the number of more than l7-log-session-queue-size
#### Affected branches
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
