### PR TITLE
[Agent] Fixes the problem of continuous rise of SessionQueue cached

### DIFF
--- a/agent/src/common/l7_protocol_info.rs
+++ b/agent/src/common/l7_protocol_info.rs
@@ -175,8 +175,8 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
                         .swap(perf_cache.rrt_cache.len() as u64, Ordering::Relaxed);
                     f.l7_timeout_cache_len
                         .swap(perf_cache.timeout_cache.len() as u64, Ordering::Relaxed)
-
                 });
+
                 return None;
             };
 
@@ -269,6 +269,10 @@ pub trait L7ProtocolInfoInterface: Into<L7ProtocolSendLog> {
             error!("flow_id: {}, packet time 0", param.flow_id);
             None
         }
+    }
+
+    fn get_request_resource_length(&self) -> usize {
+        0
     }
 }
 

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -374,6 +374,7 @@ pub struct YamlConfig {
     pub grpc_buffer_size: usize,
     #[serde(with = "humantime_serde")]
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub tap_mac_script: String,
     pub cloud_gateway_traffic: bool,
     pub kubernetes_namespace: String,
@@ -496,6 +497,10 @@ impl YamlConfig {
         // L7Log Session timeout must more than or equal 10s to keep window
         if c.l7_log_session_aggr_timeout.as_secs() < 10 {
             c.l7_log_session_aggr_timeout = Duration::from_secs(10);
+        }
+
+        if c.l7_log_session_slot_capacity < 1024 {
+            c.l7_log_session_slot_capacity = 1024;
         }
 
         if c.external_metrics_sender_queue_size == 0 {
@@ -697,6 +702,7 @@ impl Default for YamlConfig {
             ingress_flavour: IngressFlavour::Kubernetes,
             grpc_buffer_size: 5,
             l7_log_session_aggr_timeout: Duration::from_secs(120),
+            l7_log_session_slot_capacity: 1024,
             tap_mac_script: "".into(),
             cloud_gateway_traffic: false,
             kubernetes_namespace: "".into(),

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -462,6 +462,7 @@ impl fmt::Debug for FlowConfig {
 pub struct LogParserConfig {
     pub l7_log_collect_nps_threshold: u64,
     pub l7_log_session_aggr_timeout: Duration,
+    pub l7_log_session_slot_capacity: usize,
     pub l7_log_dynamic: L7LogDynamicConfig,
 }
 
@@ -991,6 +992,7 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
             log_parser: LogParserConfig {
                 l7_log_collect_nps_threshold: conf.l7_log_collect_nps_threshold,
                 l7_log_session_aggr_timeout: conf.yaml_config.l7_log_session_aggr_timeout,
+                l7_log_session_slot_capacity: conf.yaml_config.l7_log_session_slot_capacity,
                 l7_log_dynamic: L7LogDynamicConfig::new(
                     conf.http_log_proxy_client.to_string().to_ascii_lowercase(),
                     conf.http_log_x_request_id.to_string().to_ascii_lowercase(),

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -509,7 +509,8 @@ impl FlowMap {
                     // 没有找到严格匹配的 FlowNode，插入新 Node
                     let node = self.new_flow_node(config, meta_packet);
                     if let Some(node) = node {
-                        time_set[node.timestamp_key as usize & (self.time_window_size - 1)].insert(pkt_key);
+                        time_set[node.timestamp_key as usize & (self.time_window_size - 1)]
+                            .insert(pkt_key);
                         nodes.push(node);
                         max_depth += 1;
                     }
@@ -1983,6 +1984,7 @@ pub fn _new_flow_map_and_receiver(
             l7_log_collect_nps_threshold: 0,
             l7_log_session_aggr_timeout: Duration::new(0, 0),
             l7_log_dynamic: L7LogDynamicConfig::default(),
+            l7_log_session_slot_capacity: 1024,
         },
         ..Default::default()
     };

--- a/agent/src/flow_generator/protocol_logs/dns.rs
+++ b/agent/src/flow_generator/protocol_logs/dns.rs
@@ -82,6 +82,10 @@ impl L7ProtocolInfoInterface for DnsInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.query_name.len()
+    }
 }
 
 impl DnsInfo {

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -139,6 +139,10 @@ impl L7ProtocolInfoInterface for HttpInfo {
     fn is_req_resp_end(&self) -> (bool, bool) {
         (self.is_req_end, self.is_resp_end)
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.path.len()
+    }
 }
 
 impl HttpInfo {
@@ -1240,6 +1244,7 @@ mod tests {
             l7_log_collect_nps_threshold: 10,
             l7_log_session_aggr_timeout: Duration::from_secs(10),
             l7_log_dynamic: config,
+            l7_log_session_slot_capacity: 1024,
         };
         for packet in packets.iter_mut() {
             packet.lookup_key.direction = if packet.lookup_key.dst_port == first_dst_port {
@@ -1325,6 +1330,7 @@ mod tests {
             l7_log_collect_nps_threshold: 0,
             l7_log_session_aggr_timeout: Duration::default(),
             l7_log_dynamic: L7LogDynamicConfig::default(),
+            l7_log_session_slot_capacity: 1024,
         };
         let param = &ParseParam {
             l4_protocol: IpProtocol::Tcp,
@@ -1515,6 +1521,7 @@ mod tests {
             l7_log_collect_nps_threshold: 0,
             l7_log_session_aggr_timeout: Duration::ZERO,
             l7_log_dynamic: L7LogDynamicConfig::default(),
+            l7_log_session_slot_capacity: 1024,
         };
 
         for packet in packets.iter_mut() {

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -119,6 +119,10 @@ impl L7ProtocolInfoInterface for DubboInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.method_name.len()
+    }
 }
 
 impl From<DubboInfo> for L7ProtocolSendLog {
@@ -639,6 +643,7 @@ mod tests {
                         TraceType::Sw8,
                     ],
                 ),
+                l7_log_session_slot_capacity: 1024,
             };
             let mut dubbo = DubboLog::default();
             let param =
@@ -720,6 +725,7 @@ mod tests {
                     TraceType::Sw8,
                 ],
             ),
+            l7_log_session_slot_capacity: 1024,
         };
 
         let first_dst_port = packets[0].lookup_key.dst_port;

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -94,6 +94,10 @@ impl L7ProtocolInfoInterface for MysqlInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl MysqlInfo {

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -126,6 +126,10 @@ impl L7ProtocolInfoInterface for PostgreInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.context.len()
+    }
 }
 
 impl From<PostgreInfo> for L7ProtocolSendLog {

--- a/agent/src/flow_generator/protocol_logs/sql/redis.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/redis.rs
@@ -95,6 +95,10 @@ impl L7ProtocolInfoInterface for RedisInfo {
     fn is_tls(&self) -> bool {
         self.is_tls
     }
+
+    fn get_request_resource_length(&self) -> usize {
+        self.request.len()
+    }
 }
 
 pub fn vec_u8_to_string<S>(v: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>

--- a/agent/src/plugin/wasm/test.rs
+++ b/agent/src/plugin/wasm/test.rs
@@ -141,6 +141,7 @@ fn test_wasm_http_req() {
         l7_log_collect_nps_threshold: 0,
         l7_log_session_aggr_timeout: Duration::ZERO,
         l7_log_dynamic: L7LogDynamicConfig::default(),
+        l7_log_session_slot_capacity: 1024,
     };
     let rrt_cache = Rc::new(RefCell::new(L7PerfCache::new(100)));
 
@@ -200,6 +201,7 @@ fn test_wasm_http_resp() {
         l7_log_collect_nps_threshold: 0,
         l7_log_session_aggr_timeout: Duration::ZERO,
         l7_log_dynamic: L7LogDynamicConfig::default(),
+        l7_log_session_slot_capacity: 1024,
     };
     let rrt_cache = Rc::new(RefCell::new(L7PerfCache::new(100)));
 

--- a/server/controller/model/agent_group_config.go
+++ b/server/controller/model/agent_group_config.go
@@ -69,6 +69,7 @@ type StaticConfig struct {
 	IngressFlavour                   *string                `yaml:"ingress-flavour,omitempty"`
 	GrpcBufferSize                   *int                   `yaml:"grpc-buffer-size,omitempty"`            // 单位：M
 	L7LogSessionAggrTimeout          *string                `yaml:"l7-log-session-aggr-timeout,omitempty"` // 单位: s
+	L7LogSessionQueueSize            *int                   `yaml:"l7-log-session-queue-size,omitempty"`
 	TapMacScript                     *string                `yaml:"tap-mac-script,omitempty"`
 	BpfDisabled                      *bool                  `yaml:"bpf-disabled,omitempty"`
 	L7ProtocolInferenceMaxFailCount  *uint64                `yaml:"l7-protocol-inference-max-fail-count,omitempty"`

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -634,6 +634,17 @@ vtap_group_id: g-xxxxxx
   ## Format: $number$time_unit
   ## Example: 1s, 2m, 10h
   #l7-log-session-aggr-timeout: 120s
+  
+  ## The capacity of each l7_flow_log session slot
+  ## Default: 1024. Range: [1024, +oo)
+  ## If the number of data cached by session slot exceeds it's capacity,
+  ## the following impact will have:
+  ## - l7_flow_log cannot be aggregated into session, and flush l7_flow_log will be forced to lose data.
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.cached-request-resource 
+  ##   is used to record the cache request-resource occupation space, the unit is B
+  ## - Indicator: deepflow_system.deepflow_agent_l7_session_aggr.over-limit 
+  ##   is used to record the number of logs that exceed the limit to the forced flush
+  #l7-log-session-slot-capacity: 1024
 
   ##########
   ## PCAP ##


### PR DESCRIPTION
### This PR is for:

- Agent
- Server

### Fixes the problem of continuous rise of SessionQueue cached
#### Steps to reproduce the bug
- ./app-traffic -p {$mysql_password} -e mysql -h {$mysql_host:mysql_port}  -d 600 -r 20000 -t 50 -c 20 -complexity 50
#### Changes to fix the bug
- Add l7-log-session-queue-size to limit the number of cached of SessionQueue
- Add the cached-resource indicator to statistical cache resource data
- Add the over-limit indicator to count the number of more than l7-log-session-queue-size
#### Affected branches
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
