### PR TITLE
[libs] fix server panic when read podIDInfos map #5738

### DIFF
--- a/server/libs/grpc/grpc_platformdata.go
+++ b/server/libs/grpc/grpc_platformdata.go
@@ -158,7 +158,10 @@ type PlatformInfoTable struct {
 
 	gprocessInfos      map[uint32]uint64
 	vtapIDProcessInfos map[uint64]uint32
-	podIDInfos         map[uint32]*Info
+
+	podIDInfosPlatformData map[uint32]*Info
+	// podIPInfos is first obtained from podIDInfosPlatformData and needs to be supplemented by podIPs information.
+	podIDInfos map[uint32]*Info
 
 	bootTime            uint32
 	moduleName          string
@@ -966,7 +969,7 @@ func (t *PlatformInfoTable) updatePlatformData(platformData *trident.PlatformDat
 	t.containerHitCount = make(map[string]*uint64)
 	t.containerMissCount = make(map[string]*uint64)
 
-	t.podIDInfos = newEpcIDPodInfos
+	t.podIDInfosPlatformData = newEpcIDPodInfos
 }
 
 func (t *PlatformInfoTable) updateOthers(response *trident.SyncResponse) {
@@ -1556,8 +1559,12 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 	containerInfos := make(map[string][]*PodInfo)
 
 	podIDInfos := make(map[uint32]*Info)
-	// save t.podIDInfos first to prevent panic when reading and writing t.podIDInfos at the same time.
-	podIDInfos, t.podIDInfos = t.podIDInfos, podIDInfos
+	if t.podIDInfosPlatformData != nil {
+		podIDInfos = t.podIDInfosPlatformData
+	} else {
+		// save t.podIDInfos first to prevent panic when reading and writing t.podIDInfos at the same time.
+		podIDInfos, t.podIDInfos = t.podIDInfos, podIDInfos
+	}
 	for _, podIp := range podIps {
 		podName := podIp.GetPodName()
 		// podIp.GetEpcId() in range [0,64000], convert to int32, 0 convert to datatype.EPC_FROM_INTERNET
@@ -1629,6 +1636,7 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 	t.podNameInfos = podNameInfos
 	t.containerInfos = containerInfos
 	t.podIDInfos = podIDInfos
+	t.podIDInfosPlatformData = nil
 }
 
 func (t *PlatformInfoTable) podsString() string {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


