### PR TITLE
[querier] add allow time gap for prom cache -64

### DIFF
--- a/server/querier/app/prometheus/cache/response_cache.go
+++ b/server/querier/app/prometheus/cache/response_cache.go
@@ -66,7 +66,7 @@ func dataSizeOf(r *item[promql.Result]) uint64 {
 }
 
 type Cacher struct {
-	entries *lru.Cache[string, item[promql.Result]]
+	entries *lru.Cache[string, *item[promql.Result]]
 	lock    *sync.RWMutex
 
 	cleanUpCache *time.Ticker
@@ -75,7 +75,7 @@ type Cacher struct {
 func NewCacher() *Cacher {
 	c := &Cacher{
 		lock:    &sync.RWMutex{},
-		entries: lru.NewCache[string, item[promql.Result]](config.Cfg.Prometheus.Cache.CacheMaxCount),
+		entries: lru.NewCache[string, *item[promql.Result]](config.Cfg.Prometheus.Cache.CacheMaxCount),
 	}
 	go c.startUpCleanCache(config.Cfg.Prometheus.Cache.CacheCleanInterval)
 	return c
@@ -101,19 +101,23 @@ func (c *Cacher) cleanCache() {
 		if !ok {
 			continue
 		}
-		size := dataSizeOf(&item)
+		size := dataSizeOf(item)
 		if size > config.Cfg.Prometheus.Cache.CacheItemSize {
 			log.Infof("cache item remove: %s, real size: %d", k, size)
+			c.lock.Lock()
 			c.entries.Remove(k)
+			c.lock.Unlock()
 		}
 	}
 }
 
 func (c *Cacher) Fetch(key string, start, end int64) (r promql.Result, fixedStart int64, fixedEnd int64, queryRequired bool) {
+	c.lock.RLock()
 	entry, ok := c.entries.Get(key)
+	c.lock.RUnlock()
 	if !ok {
 		c.lock.Lock()
-		c.entries.Add(key, item[promql.Result]{vType: parser.ValueTypeNone, loadCompleted: make(chan struct{})})
+		c.entries.Add(key, &item[promql.Result]{vType: parser.ValueTypeNone, loadCompleted: make(chan struct{})})
 		c.lock.Unlock()
 
 		return promql.Result{Err: fmt.Errorf("key %s not found", key)}, start, end, true
@@ -137,10 +141,10 @@ func (c *Cacher) Fetch(key string, start, end int64) (r promql.Result, fixedStar
 	defer c.lock.RUnlock()
 
 	if entry.vType == parser.ValueTypeVector {
-		r, queryRequired = c.fetchInstant(&entry, start, end)
+		r, queryRequired = c.fetchInstant(entry, start, end)
 		return r, start, end, queryRequired
 	} else if entry.vType == parser.ValueTypeMatrix {
-		return c.fetchRange(&entry, start, end)
+		return c.fetchRange(entry, start, end)
 	}
 
 	return promql.Result{Err: fmt.Errorf("value Type %s not found", key)}, start, end, true
@@ -162,25 +166,27 @@ func (c *Cacher) fetchInstant(entry *item[promql.Result], start, end int64) (r p
 	if err != nil {
 		return promql.Result{Err: err}, true
 	}
-	result := make(promql.Vector, 0, samples.Len())
-
-	// only when end == Points.T, can be added (time completely equal)
-	for i := 0; i < samples.Len(); i++ {
-		findEndTimeAt := sort.Search(len(samples[i].Points), func(j int) bool {
-			return samples[i].Points[j].T == end
-		})
-		if findEndTimeAt == len(samples[i].Points) {
-			// not found
-			// fmt.Errorf("time %v not found", end)
-			continue
+	if samples.Len() > 0 {
+		result := make(promql.Vector, 0, samples.Len())
+		sampleCount := 0
+		// only when end == Points.T, can be added (time completely equal)
+		for i := 0; i < samples.Len(); i++ {
+			findEndTimeAt := sort.Search(len(samples[i].Points), func(j int) bool {
+				return samples[i].Points[j].T >= end && samples[i].Points[j].T <= end+int64(config.Cfg.Prometheus.Cache.CacheAllowTimeGap*1e3)
+			})
+			if findEndTimeAt < len(samples[i].Points) {
+				sampleCount++
+				if samples[i].Metric != nil {
+					// when Metric == nil, means it's null result
+					result = append(result, promql.Sample{Metric: samples[i].Metric, Point: samples[i].Points[findEndTimeAt]})
+				}
+			} // else not found
 		}
-
-		result = append(result, promql.Sample{Metric: samples[i].Metric, Point: samples[i].Points[findEndTimeAt]})
+		if sampleCount > 0 {
+			return promql.Result{Value: result}, false
+		}
 	}
-	if len(result) < samples.Len() {
-		return promql.Result{}, true
-	}
-	return promql.Result{Value: result}, false
+	return promql.Result{}, true
 }
 
 func (c *Cacher) validateQueryTs(start, end int64, cacheStart, cacheEnd int64) (int64, int64) {
@@ -204,7 +210,11 @@ func (c *Cacher) validateQueryTs(start, end int64, cacheStart, cacheEnd int64) (
 	}
 
 	if end > cacheEnd {
-		return cacheEnd, end
+		if end-cacheEnd <= int64(config.Cfg.Prometheus.Cache.CacheAllowTimeGap*1e3) {
+			return 0, 0
+		} else {
+			return cacheEnd, end
+		}
 	}
 
 	// cache hit, not query anything, return cache data
@@ -235,6 +245,15 @@ func (c *Cacher) extractSubData(r promql.Result, start, end int64) promql.Result
 	return promql.Result{Value: result}
 }
 
+func (c *Cacher) Remove(key string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if entry, ok := c.entries.Peek(key); ok && entry.vType == parser.ValueTypeNone {
+		c.entries.Remove(key)
+	}
+}
+
 func (c *Cacher) Merge(key string, start, end, step int64, res promql.Result) (promql.Result, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -252,12 +271,12 @@ func (c *Cacher) Merge(key string, start, end, step int64, res promql.Result) (p
 		if item.data.Value.Type() == parser.ValueTypeVector {
 			v, err := res.Vector()
 			if err == nil {
-				item.data.Value = vectorTomatrix(&v)
+				item.data.Value = vectorTomatrix(&v, end)
 				item.vType = parser.ValueTypeVector // mark origin value type
 			}
 			// else not vector, merge directly
 		}
-		c.entries.Add(key, item)
+		c.entries.Add(key, &item)
 		return res, nil
 	}
 
@@ -274,12 +293,19 @@ func (c *Cacher) Merge(key string, start, end, step int64, res promql.Result) (p
 		}
 	case parser.ValueTypeMatrix:
 		// replace
+		// cached: [   ]
+		// result:       [   ]
+
+		// cached:       [   ]
+		// result: [   ]
 		if start > entry.end || end < entry.start {
 			entry.start = start
 			entry.end = end
 			entry.data = res
 		}
 
+		// cached:  [   ]
+		// result: [     ]
 		if start < entry.start && end > entry.end {
 			entry.start = start
 			entry.end = end
@@ -322,76 +348,105 @@ func (c *Cacher) matrixMerge(resp promql.Matrix, cache *promql.Result) (promql.R
 	if err != nil {
 		return promql.Result{Err: err}, err
 	}
-	output := make(promql.Matrix, 0, len(cacheMatrix))
-	for _, cachedTs := range cacheMatrix {
-		newSeries := promql.Series{Metric: cachedTs.Metric}
-		newSeries.Points = cachedTs.Points
-		for _, series := range resp {
-			if promLabelsEqual(&cachedTs.Metric, &series.Metric) {
-				existsStartT := newSeries.Points[0].T
-				existsEndT := newSeries.Points[len(newSeries.Points)-1].T
+	// avoid slice growth, but it maybe waste of memory
+	appendMatrix := make([]promql.Series, 0, len(resp))
+	for _, series := range resp {
+		labelsMismatch := 0
+		for _, cachedTs := range cacheMatrix {
+			if cachedTs.Metric != nil && promLabelsEqual(&cachedTs.Metric, &series.Metric) {
+				existsStartT := cachedTs.Points[0].T
+				existsEndT := cachedTs.Points[len(cachedTs.Points)-1].T
 
 				if existsEndT < series.Points[0].T {
-					newSeries.Points = append(newSeries.Points, series.Points...)
+					// cached: [   ]
+					// result:       [   ]
+					cachedTs.Points = append(cachedTs.Points, series.Points...)
 				} else if existsStartT > series.Points[len(series.Points)-1].T {
-					newSeries.Points = append(series.Points, newSeries.Points...)
+					// cached:       [   ]
+					// result: [   ]
+					cachedTs.Points = append(series.Points, cachedTs.Points...)
 				} else if existsEndT >= series.Points[0].T && existsEndT < series.Points[len(series.Points)-1].T {
+					// cached: [   ]
+					// result:   [   ]
 					// cached data & resp overlap
 					overlapPointAt := sort.Search(len(series.Points), func(i int) bool {
 						return series.Points[i].T > existsEndT
 					})
-					newSeries.Points = append(newSeries.Points, series.Points[overlapPointAt:]...)
+					cachedTs.Points = append(cachedTs.Points, series.Points[overlapPointAt:]...)
 				} else if existsStartT <= series.Points[len(series.Points)-1].T && existsStartT > series.Points[0].T {
+					// cached:   [   ]
+					// result: [   ]
 					overlapPointAt := sort.Search(len(series.Points), func(i int) bool {
 						return series.Points[i].T >= existsStartT
 					})
-					newSeries.Points = append(series.Points[:overlapPointAt], newSeries.Points...)
+					cachedTs.Points = append(series.Points[:overlapPointAt], cachedTs.Points...)
 				}
-
-				sort.Slice(newSeries.Points, func(i, j int) bool {
-					return newSeries.Points[i].T < newSeries.Points[j].T
-				})
+			} else {
+				labelsMismatch++
 			}
 		}
-		output = append(output, newSeries)
+		if labelsMismatch == len(cacheMatrix) {
+			appendMatrix = append(appendMatrix, series)
+		}
 	}
-
-	return promql.Result{Value: output}, nil
+	if len(appendMatrix) > 0 {
+		cacheMatrix = append(cacheMatrix, appendMatrix...)
+	}
+	return promql.Result{Value: cacheMatrix}, nil
 }
 
-func (c *Cacher) vectorMerge(resp promql.Vector, cached *promql.Result) (promql.Result, error) {
-	cacheMatrix, err := cached.Matrix()
+func (c *Cacher) vectorMerge(resp promql.Vector, cache *promql.Result) (promql.Result, error) {
+	cacheMatrix, err := cache.Matrix()
 	if err != nil {
 		return promql.Result{Err: err}, err
 	}
-	output := make(promql.Matrix, 0, len(cacheMatrix))
-	for _, cachedTs := range cacheMatrix {
-		newSeries := promql.Series{Metric: cachedTs.Metric}
-		newSeries.Points = cachedTs.Points
-		for _, samples := range resp {
-			if promLabelsEqual(&cachedTs.Metric, &samples.Metric) {
-				insertedPointAt := sort.Search(len(newSeries.Points), func(i int) bool {
-					return newSeries.Points[i].T >= samples.Point.T
+	// resp as outside
+	// avoid slice growth, but it maybe waste of memory
+	appendMatrix := make([]promql.Series, 0, len(resp))
+	for _, samples := range resp {
+		labelsMismatch := 0
+		for _, cachedTs := range cacheMatrix {
+			if cachedTs.Metric != nil && promLabelsEqual(&cachedTs.Metric, &samples.Metric) {
+				insertedPointAt := sort.Search(len(cachedTs.Points), func(i int) bool {
+					return cachedTs.Points[i].T >= samples.Point.T
 				})
-				newSeries.Points = append(newSeries.Points, promql.Point{})
-				copy(newSeries.Points[insertedPointAt+1:], newSeries.Points[insertedPointAt:])
-				newSeries.Points[insertedPointAt] = samples.Point
-
-				sort.Slice(newSeries.Points, func(i, j int) bool {
-					return newSeries.Points[i].T < newSeries.Points[j].T
-				})
+				if insertedPointAt == len(cachedTs.Points) {
+					cachedTs.Points = append(cachedTs.Points, samples.Point)
+				} else {
+					if cachedTs.Points[insertedPointAt].T != samples.Point.T {
+						cachedTs.Points = append(cachedTs.Points, promql.Point{})
+						copy(cachedTs.Points[insertedPointAt+1:], cachedTs.Points[insertedPointAt:])
+						cachedTs.Points[insertedPointAt] = samples.Point
+					}
+				}
+			} else {
+				labelsMismatch++
 			}
 		}
+		if labelsMismatch == len(cacheMatrix) {
+			// when labels mismatch in all cache, means that's a new Series
+			appendMatrix = append(appendMatrix, promql.Series{Metric: samples.Metric, Points: []promql.Point{samples.Point}})
+		}
 	}
-	return promql.Result{Value: output}, nil
+	if len(appendMatrix) > 0 {
+		cacheMatrix = append(cacheMatrix, appendMatrix...)
+	}
+	return promql.Result{Value: cacheMatrix}, nil
 }
 
-func vectorTomatrix(v *promql.Vector) promql.Matrix {
+func vectorTomatrix(v *promql.Vector, time int64) promql.Matrix {
 	output := make(promql.Matrix, 0, len(*v))
 	for _, m := range *v {
 		output = append(output, promql.Series{
 			Metric: m.Metric,
 			Points: []promql.Point{m.Point},
+		})
+	}
+	if (len(*v)) == 0 {
+		// when query result = 0, mark an empty result, telling that there's no data at the point
+		output = append(output, promql.Series{
+			Metric: nil,                             // nil labels, MARK for null result
+			Points: []promql.Point{{T: time, V: 0}}, // time = query end
 		})
 	}
 	return output

--- a/server/querier/app/prometheus/config/config.go
+++ b/server/querier/app/prometheus/config/config.go
@@ -37,4 +37,5 @@ type PrometheusCache struct {
 	CacheMaxCount      int    `default:"1024" yaml:"cache-max-count"`      // cache-max-count for list of cache size
 	CacheFirstTimeout  int    `default:"10" yaml:"cache-first-timeout"`    // time out for first cache item load, unit: s, default: 10s
 	CacheCleanInterval int    `default:"3600" yaml:"cache-clean-interval"` // clean interval for cache, unit: s, default: 1h
+	CacheAllowTimeGap  int    `default:"1" yaml:"cache-allow-time-gap"`    // when query end time - cache end time <= allow gap: not update cache, unit: s, default: 1s
 }

--- a/server/querier/app/prometheus/model/common.go
+++ b/server/querier/app/prometheus/model/common.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+const (
+	CACHE_LABEL_STRING_TAG  = "__cache_label_string__"
+	PROMETHEUS_LABELS_INDEX = "__labels_index__"
+)
+
+var RelabelFunctions = []string{"sum", "avg", "count", "min", "max", "group", "stddev", "stdvar", "count_values", "quantile"}
+
+var MatrixCallFunctions = []string{"topk", "bottomk",
+	"avg_over_time", "count_over_time", "last_over_time", "max_over_time", "min_over_time", "stddev_over_time", "sum_over_time", "present_over_time", "quantile_over_time",
+	"idelta", "delta", "increase", "irate", "rate"}

--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -119,9 +119,9 @@ var QueryFuncCall = map[string]QueryFunc{
 	"sum": simpleCallFunc("sum", "Sum"),
 	"min": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
 		resetQueryInterval(query, 1, 0)
-		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
+		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, model.PROMETHEUS_LABELS_INDEX))
 		*query = append(*query, fmt.Sprintf("%s(%s)", "Min", metric))
-		*group = append(*group, PROMETHEUS_LABELS_INDEX)
+		*group = append(*group, model.PROMETHEUS_LABELS_INDEX)
 
 		for _, tag := range req.GetGrouping("min") {
 			*group = append(*group, handleLabelsMatch(tag))
@@ -144,8 +144,8 @@ var QueryFuncCall = map[string]QueryFunc{
 	"bottomk": nil, // don't use Min(%s), because min will fill zero as default value
 
 	"quantile": func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		*group = append(*group, PROMETHEUS_LABELS_INDEX)
-		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
+		*group = append(*group, model.PROMETHEUS_LABELS_INDEX)
+		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, model.PROMETHEUS_LABELS_INDEX))
 
 		quantile_param := req.GetFuncParam("quantile")
 		*query = append(*query, fmt.Sprintf("Percentile(%s, %g)", metric, quantile_param))
@@ -209,9 +209,9 @@ func resetQueryInterval(query *[]string, interval, offset int64) {
 
 func simpleSelection(oriFunc string, aftFunc string) QueryFunc {
 	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
+		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, model.PROMETHEUS_LABELS_INDEX))
 		*query = append(*query, aftFunc)
-		*group = append(*group, PROMETHEUS_LABELS_INDEX)
+		*group = append(*group, model.PROMETHEUS_LABELS_INDEX)
 		for _, tag := range req.GetGrouping(oriFunc) {
 			*group = append(*group, handleLabelsMatch(tag))
 		}
@@ -220,9 +220,9 @@ func simpleSelection(oriFunc string, aftFunc string) QueryFunc {
 
 func simpleCallFunc(oriFunc string, aftFunc string) QueryFunc {
 	return func(metric string, query, order, group *[]string, req model.QueryRequest, queryType model.QueryType, handleLabelsMatch func(string) string) {
-		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, PROMETHEUS_LABELS_INDEX))
+		*query = append(*query, fmt.Sprintf("%s as %s", _prometheus_tag_key, model.PROMETHEUS_LABELS_INDEX))
 		*query = append(*query, fmt.Sprintf("%s(%s)", aftFunc, metric))
-		*group = append(*group, PROMETHEUS_LABELS_INDEX)
+		*group = append(*group, model.PROMETHEUS_LABELS_INDEX)
 		for _, tag := range req.GetGrouping(oriFunc) {
 			*group = append(*group, handleLabelsMatch(tag))
 		}

--- a/server/querier/app/prometheus/service/promql.go
+++ b/server/querier/app/prometheus/service/promql.go
@@ -281,6 +281,12 @@ func (p *prometheusExecutor) offloadRangeQueryExecute(ctx context.Context, args 
 				return &model.PromQueryResponse{Data: &model.PromQueryData{ResultType: cached.Value.Type(), Result: cached.Value}, Status: _SUCCESS}, nil
 			}
 		}
+
+		defer func() {
+			if result == nil || err != nil || result.Error != "" || result.Data == nil {
+				p.cacher.Remove(cachedKey)
+			}
+		}()
 	}
 
 	var queriable model.Querierable
@@ -414,6 +420,12 @@ func (p *prometheusExecutor) offloadInstantQueryExecute(ctx context.Context, arg
 				return &model.PromQueryResponse{Data: &model.PromQueryData{ResultType: cached.Value.Type(), Result: cached.Value}, Status: _SUCCESS}, nil
 			}
 		}
+
+		defer func() {
+			if result == nil || err != nil || result.Error != "" || result.Data == nil {
+				p.cacher.Remove(cachedKey)
+			}
+		}()
 	}
 
 	var queriable model.Querierable

--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -54,7 +54,9 @@ func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.Re
 	var response *prompb.ReadResponse
 	// clear cache if data not found
 	defer func(r *prompb.ReadRequest) {
-		if response == nil || len(response.Results) == 0 || len(response.Results[0].Timeseries) == 0 {
+		// when error occurs, means query not finished yet, remove the first query placeholder
+		// if error is nil, means query finished, don't clean key
+		if err != nil || response == nil {
 			cache.PromReadResponseCache().Remove(r)
 		}
 	}(req)

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -336,6 +336,7 @@ querier:
       cache-max-count: 1024 # max capacity of cache list
       cache-first-timeout: 10 # time out for first cache item load, uint: s
       cache-clean-interval: 3600 # clean interval for cache, unit: s
+      cache-allow-time-gap: 1 # when query end - cache end < gap, not update cache, unit: s
 
   auto-custom-tag:
     tag-name: 


### PR DESCRIPTION
- optimize labels map compare, use string instead of map

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### promql query cache optimize
#### Steps to reproduce the bug
- in some scene, cache is not run as expect
#### Changes to fix the bug
- add `cache-allow-time-gap` config, it allows not updated cache (directly hit) instead of query database, default 5seconds.
- fixes when cache not effective:
  - when query result is null, not caching it before, cause repeted query to the database. Now will record its time when result contains nothing.
  - when merge cache to slow cause performance issue, fixes and not use map[k,v] to match cache series.
  - when use `operator-offloding`, instant query cache is invalid.Now fixes.
#### Affected branches
- main
- v6.4

