### PR TITLE
[eBPF] Adaptive bpf_probe_read{kernel,user}[_str] Interface

### DIFF
--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -37,31 +37,84 @@ struct task_struct;
 /*
  * bpf helpers
  */
-static void *(*bpf_map_lookup_elem) (void *map, const void *key) = (void *)1;
-static long (*bpf_map_update_elem) (void *map, const void *key,
-				    const void *value, __u64 flags) = (void *)2;
-static long (*bpf_map_delete_elem) (void *map, const void *key) = (void *)3;
-static long (*bpf_probe_read) (void *dst, __u32 size, const void *unsafe_ptr) =
+static void
+    __attribute__ ((__unused__)) * (*bpf_map_lookup_elem) (void *map,
+							   const void *key) =
+    (void *)1;
+static long
+    __attribute__ ((__unused__)) (*bpf_map_update_elem) (void *map,
+							 const void *key,
+							 const void *value,
+							 __u64 flags) =
+    (void *)2;
+static long
+    __attribute__ ((__unused__)) (*bpf_map_delete_elem) (void *map,
+							 const void *key) =
+    (void *)3;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read) (void *dst, __u32 size,
+						    const void *unsafe_ptr) =
     (void *)4;
-static __u64(*bpf_ktime_get_ns) (void) = (void *)5;
-static long (*bpf_trace_printk) (const char *fmt, __u32 fmt_size, ...) =
+static __u64 __attribute__ ((__unused__)) (*bpf_ktime_get_ns) (void) =
+    (void *)5;
+static long
+    __attribute__ ((__unused__)) (*bpf_trace_printk) (const char *fmt,
+						      __u32 fmt_size, ...) =
     (void *)6;
-static __u32(*bpf_get_prandom_u32) (void) = (void *)7;
-static __u32(*bpf_get_smp_processor_id) (void) = (void *)8;
-static long (*bpf_tail_call) (void *ctx, void *prog_array_map, __u32 index) =
-    (void *)12;
-static __u64(*bpf_get_current_pid_tgid) (void) = (void *)14;
-static __u64(*bpf_get_current_uid_gid) (void) = (void *)15;
-static long (*bpf_get_current_comm) (void *buf, __u32 size_of_buf) = (void *)16;
-static __u64(*bpf_get_current_task) (void) = (void *)35;
-static long (*bpf_perf_event_output) (void *ctx, void *map, __u64 flags,
-				      void *data, __u64 size) = (void *)25;
-static long (*bpf_probe_read_str) (void *dst, __u32 size,
-				   const void *unsafe_ptr) = (void *)45;
-// bpf_probe_read_user added in Linux 5.5, Instead of bpf_probe_read_user(), use bpf_probe_read() here.
-static long (*bpf_probe_read_user) (void *dst, __u32 size, const void *unsafe_ptr) = (void *)4;	// real value is 112
+static __u32 __attribute__ ((__unused__)) (*bpf_get_prandom_u32) (void) =
+    (void *)7;
+static __u32 __attribute__ ((__unused__)) (*bpf_get_smp_processor_id) (void) =
+    (void *)8;
+static long
+    __attribute__ ((__unused__)) (*bpf_tail_call) (void *ctx,
+						   void *prog_array_map,
+						   __u32 index) = (void *)12;
+static __u64 __attribute__ ((__unused__)) (*bpf_get_current_pid_tgid) (void) =
+    (void *)14;
+static __u64 __attribute__ ((__unused__)) (*bpf_get_current_uid_gid) (void) =
+    (void *)15;
+static long
+    __attribute__ ((__unused__)) (*bpf_get_current_comm) (void *buf,
+							  __u32 size_of_buf) =
+    (void *)16;
+static __u64 __attribute__ ((__unused__)) (*bpf_get_current_task) (void) =
+    (void *)35;
+static long
+    __attribute__ ((__unused__)) (*bpf_perf_event_output) (void *ctx, void *map,
+							   __u64 flags,
+							   void *data,
+							   __u64 size) =
+    (void *)25;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read_str) (void *dst, __u32 size,
+							const void *unsafe_ptr)
+    = (void *)45;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read_user) (void *dst, __u32 size,
+							 const void *unsafe_ptr)
+    = (void *)112;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read_kernel) (void *dst,
+							   __u32 size,
+							   const void
+							   *unsafe_ptr) =
+    (void *)113;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read_user_str) (void *dst,
+							     __u32 size,
+							     const void
+							     *unsafe_ptr) =
+    (void *)114;
+static long
+    __attribute__ ((__unused__)) (*bpf_probe_read_kernel_str) (void *dst,
+							       __u32 size,
+							       const void
+							       *unsafe_ptr) =
+    (void *)115;
 
-static int (*bpf_get_stackid)(void *ctx, void *map, int flags) = (void *)27;
+static int
+    __attribute__ ((__unused__)) (*bpf_get_stackid) (void *ctx, void *map,
+						     int flags) = (void *)27;
 
 #if __GNUC__ && !__clang__
 #define SEC(name) __attribute__((section(name), used))
@@ -221,7 +274,7 @@ _Pragma("GCC error \"PT_GO_REGS_PARM\"");
 #define static_always_inline static inline __attribute__ ((__always_inline__))
 #endif
 
-#define _(P) ({typeof(P) val = 0; bpf_probe_read(&val, sizeof(val), &P); val;})
+#define _(P) ({typeof(P) val = 0; bpf_probe_read_kernel(&val, sizeof(val), &P); val;})
 
 #ifndef CUR_CPU_IDENTIFIER
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
@@ -298,10 +351,10 @@ struct bpf_map_def SEC("maps") __ ## name = \
 
 #define MAP_STACK_TRACE(name, max) \
 struct bpf_map_def SEC("maps") __ ## name = { \
-        .type = BPF_MAP_TYPE_STACK_TRACE, \
-        .key_size = sizeof(__u32), \
-        .value_size = PERF_MAX_STACK_DEPTH * sizeof(__u64), \
-        .max_entries = (max), \
+  .type = BPF_MAP_TYPE_STACK_TRACE, \
+  .key_size = sizeof(__u32), \
+  .value_size = PERF_MAX_STACK_DEPTH * sizeof(__u64), \
+  .max_entries = (max), \
 };
 
 #define MAP_HASH(name, key_type, value_type, max_entries) \

--- a/agent/src/ebpf/kernel/include/task_struct_utils.h
+++ b/agent/src/ebpf/kernel/include/task_struct_utils.h
@@ -30,20 +30,20 @@
 #define USER_HZ		100
 
 #ifdef LINUX_VER_5_2_PLUS
-static __inline void *
-get_socket_file_addr_with_check(struct task_struct *task,
-				int fd_num,
-				int files_off,struct member_fields_offset *offset)
+static __inline void *get_socket_file_addr_with_check(struct task_struct *task,
+						      int fd_num,
+						      int files_off,
+						      struct
+						      member_fields_offset
+						      *offset)
 #else
-static __inline void *
-get_socket_file_addr_with_check(struct task_struct *task,
-				int fd_num,
-				int files_off)
+static __inline void *get_socket_file_addr_with_check(struct task_struct *task,
+						      int fd_num, int files_off)
 #endif
 {
 	void *file = NULL;
 	void *files, *files_ptr = (void *)task + files_off;
-	bpf_probe_read(&files, sizeof(files), files_ptr);
+	bpf_probe_read_kernel(&files, sizeof(files), files_ptr);
 
 	if (files == NULL)
 		return NULL;
@@ -79,18 +79,18 @@ get_socket_file_addr_with_check(struct task_struct *task,
 	 * and BTF.
 	 */
 #ifdef LINUX_VER_5_2_PLUS
-	bpf_probe_read(&fdt, sizeof(fdt),
-		       files + offset->struct_files_struct_fdt_offset);
+	bpf_probe_read_kernel(&fdt, sizeof(fdt),
+			      files + offset->struct_files_struct_fdt_offset);
 #else
-	bpf_probe_read(&fdt, sizeof(fdt),
-		       files + STRUCT_FILES_STRUCT_FDT_OFFSET);
+	bpf_probe_read_kernel(&fdt, sizeof(fdt),
+			      files + STRUCT_FILES_STRUCT_FDT_OFFSET);
 #endif
-	bpf_probe_read(&__fdt, sizeof(__fdt), (void *)fdt);
+	bpf_probe_read_kernel(&__fdt, sizeof(__fdt), (void *)fdt);
 
 	if (fd_num >= (int)__fdt.max_fds)
 		return NULL;
 
-	bpf_probe_read(&file, sizeof(file), __fdt.fd + fd_num);
+	bpf_probe_read_kernel(&file, sizeof(file), __fdt.fd + fd_num);
 
 	return file;
 }
@@ -100,22 +100,21 @@ static __inline void *retry_get_socket_file_addr(struct task_struct *task,
 {
 	void *file = NULL;
 	void *files, *files_ptr = (void *)task + files_off;
-	bpf_probe_read(&files, sizeof(files), files_ptr);
+	bpf_probe_read_kernel(&files, sizeof(files), files_ptr);
 
 	if (files == NULL)
 		return NULL;
 
 	struct fdtable *fdt, __fdt;
-	bpf_probe_read(&fdt, sizeof(fdt),
-		       files + STRUCT_FILES_STRUCT_FDT_OFFSET);
-	bpf_probe_read(&__fdt, sizeof(__fdt), (void *)fdt);
-	bpf_probe_read(&file, sizeof(file), __fdt.fd + fd_num);
+	bpf_probe_read_kernel(&fdt, sizeof(fdt),
+			      files + STRUCT_FILES_STRUCT_FDT_OFFSET);
+	bpf_probe_read_kernel(&__fdt, sizeof(__fdt), (void *)fdt);
+	bpf_probe_read_kernel(&file, sizeof(file), __fdt.fd + fd_num);
 
 	return file;
 }
 
-static __inline void *infer_and_get_socket_from_fd(int fd_num,
-						   struct member_fields_offset
+static __inline void *infer_and_get_socket_from_fd(int fd_num, struct member_fields_offset
 						   *offset, bool debug)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
@@ -125,6 +124,7 @@ static __inline void *infer_and_get_socket_from_fd(int fd_num,
 	struct socket __socket;
 	int i;
 
+/* *INDENT-OFF* */
 	// TAG: STRUCT_TASK_FILES_OFFSET
 	// 成员 files 在 struct task_struct 中的偏移量
 #ifdef LINUX_VER_5_2_PLUS
@@ -159,6 +159,7 @@ static __inline void *infer_and_get_socket_from_fd(int fd_num,
 		0xbf0, 0xbf8, 0xc00, 0xc08, 0xcc8, 0xd08, 0x6b8, 0xb88
 	};
 #endif
+/* *INDENT-ON* */
 
 	if (unlikely(!offset->task__files_offset)) {
 #pragma unroll
@@ -168,15 +169,15 @@ static __inline void *infer_and_get_socket_from_fd(int fd_num,
 						       files_offset_array[i]);
 
 			if (file) {
-				bpf_probe_read(&private_data,
-					       sizeof(private_data),
-					       file +
-					       STRUCT_FILES_PRIVATE_DATA_OFFSET);
+				bpf_probe_read_kernel(&private_data,
+						      sizeof(private_data),
+						      file +
+						      STRUCT_FILES_PRIVATE_DATA_OFFSET);
 				if (private_data != NULL) {
 					socket = private_data;
-					bpf_probe_read(&__socket,
-						       sizeof(__socket),
-						       (void *)socket);
+					bpf_probe_read_kernel(&__socket,
+							      sizeof(__socket),
+							      (void *)socket);
 					if (__socket.file == file
 					    || file == __socket.wq) {
 						offset->task__files_offset =
@@ -196,11 +197,11 @@ static __inline void *infer_and_get_socket_from_fd(int fd_num,
 		return NULL;
 	}
 #ifdef LINUX_VER_5_2_PLUS
-	bpf_probe_read(&private_data, sizeof(private_data),
-		       file + offset->struct_files_private_data_offset);
+	bpf_probe_read_kernel(&private_data, sizeof(private_data),
+			      file + offset->struct_files_private_data_offset);
 #else
-	bpf_probe_read(&private_data, sizeof(private_data),
-		       file + STRUCT_FILES_PRIVATE_DATA_OFFSET);
+	bpf_probe_read_kernel(&private_data, sizeof(private_data),
+			      file + STRUCT_FILES_PRIVATE_DATA_OFFSET);
 #endif
 	if (private_data == NULL) {
 		return NULL;
@@ -210,7 +211,7 @@ static __inline void *infer_and_get_socket_from_fd(int fd_num,
 	short socket_type;
 	void *check_file;
 	void *sk;
-	bpf_probe_read(&__socket, sizeof(__socket), (void *)socket);
+	bpf_probe_read_kernel(&__socket, sizeof(__socket), (void *)socket);
 	socket_type = __socket.type;
 	if (__socket.file != file) {
 		check_file = __socket.wq;	// kernel >= 5.3.0 remove '*wq'
@@ -234,8 +235,9 @@ static __inline void *get_socket_from_fd(int fd_num,
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 	void *file = NULL;
 #ifdef LINUX_VER_5_2_PLUS
-	file = get_socket_file_addr_with_check(
-		task, fd_num, offset->task__files_offset, offset);
+	file =
+	    get_socket_file_addr_with_check(task, fd_num,
+					    offset->task__files_offset, offset);
 #else
 	file =
 	    get_socket_file_addr_with_check(task, fd_num,
@@ -245,11 +247,11 @@ static __inline void *get_socket_from_fd(int fd_num,
 		return NULL;
 	void *private_data = NULL;
 #ifdef LINUX_VER_5_2_PLUS
-	bpf_probe_read(&private_data, sizeof(private_data),
-		       file + offset->struct_files_private_data_offset);
+	bpf_probe_read_kernel(&private_data, sizeof(private_data),
+			      file + offset->struct_files_private_data_offset);
 #else
-	bpf_probe_read(&private_data, sizeof(private_data),
-		       file + STRUCT_FILES_PRIVATE_DATA_OFFSET);
+	bpf_probe_read_kernel(&private_data, sizeof(private_data),
+			      file + STRUCT_FILES_PRIVATE_DATA_OFFSET);
 #endif
 	if (private_data == NULL) {
 		return NULL;
@@ -260,7 +262,7 @@ static __inline void *get_socket_from_fd(int fd_num,
 	void *check_file;
 	void *sk;
 	struct socket __socket;
-	bpf_probe_read(&__socket, sizeof(__socket), (void *)socket);
+	bpf_probe_read_kernel(&__socket, sizeof(__socket), (void *)socket);
 
 	socket_type = __socket.type;
 	if (__socket.file != file) {
@@ -287,16 +289,19 @@ static __inline void *fd_to_file(int fd_num,
 
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task();
 #ifdef LINUX_VER_5_2_PLUS
-	void *file = get_socket_file_addr_with_check(
-		task, fd_num, offset->task__files_offset, offset);
+	void *file =
+	    get_socket_file_addr_with_check(task, fd_num,
+					    offset->task__files_offset, offset);
 #else
-	void *file = get_socket_file_addr_with_check(
-		task, fd_num, offset->task__files_offset);
+	void *file =
+	    get_socket_file_addr_with_check(task, fd_num,
+					    offset->task__files_offset);
 #endif
 	return file;
 }
 
-static __inline __u32 file_to_i_mode(void *file, struct member_fields_offset *offset)
+static __inline __u32 file_to_i_mode(void *file,
+				     struct member_fields_offset *offset)
 {
 	if (!file) {
 		return 0;
@@ -304,8 +309,8 @@ static __inline __u32 file_to_i_mode(void *file, struct member_fields_offset *of
 
 	void *f_inode = NULL;
 
-	bpf_probe_read(&f_inode, sizeof(f_inode),
-		       file + offset->struct_file_f_inode_offset);
+	bpf_probe_read_kernel(&f_inode, sizeof(f_inode),
+			      file + offset->struct_file_f_inode_offset);
 
 	if (!f_inode) {
 		return 0;
@@ -313,8 +318,8 @@ static __inline __u32 file_to_i_mode(void *file, struct member_fields_offset *of
 
 	__u32 i_mode = 0;
 
-	bpf_probe_read(&i_mode, sizeof(i_mode),
-		       f_inode + offset->struct_inode_i_mode_offset);
+	bpf_probe_read_kernel(&i_mode, sizeof(i_mode),
+			      f_inode + offset->struct_inode_i_mode_offset);
 
 	return i_mode;
 }
@@ -327,16 +332,16 @@ static __inline char *file_to_name(void *file,
 	}
 
 	void *dentry = NULL;
-	bpf_probe_read(&dentry, sizeof(dentry),
-		       file + offset->struct_file_dentry_offset);
+	bpf_probe_read_kernel(&dentry, sizeof(dentry),
+			      file + offset->struct_file_dentry_offset);
 
 	if (!dentry) {
 		return 0;
 	}
 
 	char *name = NULL;
-	bpf_probe_read(&name, sizeof(name),
-		       dentry + offset->struct_dentry_name_offset);
+	bpf_probe_read_kernel(&name, sizeof(name),
+			      dentry + offset->struct_dentry_name_offset);
 	return name;
 }
 


### PR DESCRIPTION
Conflicts:
	agent/src/ebpf/kernel/socket_trace.c



### This PR is for:


- Agent

#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
