### PR TITLE
[libs] fix podInfosMap concurrent read/write failed #5738

### DIFF
--- a/server/libs/grpc/grpc_platformdata.go
+++ b/server/libs/grpc/grpc_platformdata.go
@@ -1563,12 +1563,11 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 	containerInfos := make(map[string][]*PodInfo)
 
 	podIDInfos := make(map[uint32]*Info)
-	if t.podIDInfosPlatformData != nil {
-		podIDInfos = t.podIDInfosPlatformData
-	} else {
-		// save t.podIDInfos first to prevent panic when reading and writing t.podIDInfos at the same time.
-		podIDInfos, t.podIDInfos = t.podIDInfos, podIDInfos
+	// deep copy podIDInfos from t.podIDInfosPlatformData, prevent map read/write panic
+	for k, v := range t.podIDInfosPlatformData {
+		podIDInfos[k] = v
 	}
+
 	for _, podIp := range podIps {
 		podName := podIp.GetPodName()
 		// podIp.GetEpcId() in range [0,64000], convert to int32, 0 convert to datatype.EPC_FROM_INTERNET
@@ -1640,7 +1639,6 @@ func (t *PlatformInfoTable) updatePodIps(podIps []*trident.PodIp) {
 	t.podNameInfos = podNameInfos
 	t.containerInfos = containerInfos
 	t.podIDInfos = podIDInfos
-	t.podIDInfosPlatformData = nil
 }
 
 func (t *PlatformInfoTable) podsString() string {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Libs


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


