### PR TITLE
[Agent] Support merging tap-interface-regex and src-interfaces

### DIFF
--- a/agent/src/flow_generator/packet_sequence/parser.rs
+++ b/agent/src/flow_generator/packet_sequence/parser.rs
@@ -89,4 +89,19 @@ impl PacketSequenceParser {
         self.thread.lock().unwrap().replace(thread);
         info!("packet sequence parser (id={}) started", self.id);
     }
+
+    pub fn stop(&mut self) {
+        if !self.running.swap(false, Ordering::Relaxed) {
+            warn!(
+                "packet sequence parser id: {} already stopped, do nothing.",
+                self.id
+            );
+            return;
+        }
+        info!("stopping packet sequence parser: {}", self.id);
+        if let Some(t) = self.thread.lock().unwrap().take() {
+            let _ = t.join();
+        }
+        info!("stopped packet sequence parser: {}", self.id);
+    }
 }

--- a/agent/src/policy/fast_path.rs
+++ b/agent/src/policy/fast_path.rs
@@ -16,12 +16,15 @@
 
 use std::cmp::max;
 use std::net::IpAddr;
-use std::sync::{Arc, RwLock};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, RwLock,
+};
 use std::thread;
 use std::time::Duration;
 
 use ipnet::{IpNet, Ipv4Net};
-use log::{info, warn};
+use log::warn;
 use lru::LruCache;
 
 use crate::common::endpoint::{EndpointData, EndpointStore};
@@ -53,24 +56,26 @@ pub struct FastPath {
     // Use the first 16 bits of the IPv4 address to query the table and obtain the corresponding netmask.
     netmask_table: RwLock<Vec<u32>>,
 
-    policy_table_flush_flags: [bool; super::MAX_QUEUE_COUNT + 1],
+    policy_table_flush_flags: [AtomicBool; super::MAX_QUEUE_COUNT + 1],
 
     mask_from_interface: RwLock<Vec<u32>>,
     mask_from_ipgroup: RwLock<Vec<u32>>,
     mask_from_cidr: RwLock<Vec<u32>>,
 
     map_size: usize,
-    queue_count: usize,
 
     // 统计计数
     policy_count: usize,
 }
 
+const FLUSH_FLAGS: AtomicBool = AtomicBool::new(false);
 impl FastPath {
     // 策略相关等内容更新后必须执行该函数以清空策略表
     pub fn flush(&mut self) {
         self.generate_mask_table();
-        self.policy_table_flush_flags = [true; super::MAX_QUEUE_COUNT + 1];
+        self.policy_table_flush_flags.iter_mut().for_each(|f| {
+            f.store(true, Ordering::Relaxed);
+        });
         self.policy_count = 0;
     }
 
@@ -261,30 +266,15 @@ impl FastPath {
         key.dst_port = table[key.dst_port as usize].min();
     }
 
-    pub fn update_map_size(&mut self, map_size: usize) {
-        if self.map_size == map_size {
-            return;
-        }
-        info!(
-            "fastpath map size change from {} to {}",
-            self.map_size, map_size
-        );
-        self.map_size = map_size;
-
-        for i in 0..self.queue_count {
-            self.policy_table_flush_flags[i] = true
-        }
-    }
-
     fn table_flush_check(&mut self, key: &LookupKey) -> bool {
         let start_index = key.fast_index * MAX_TAP_TYPE;
-        if self.policy_table_flush_flags[key.fast_index] {
+        if self.policy_table_flush_flags[key.fast_index].load(Ordering::Relaxed) {
             for i in 0..MAX_TAP_TYPE {
                 if let Some(t) = &mut self.policy_table[start_index + i] {
                     t.clear();
                 }
             }
-            self.policy_table_flush_flags[key.fast_index] = false
+            self.policy_table_flush_flags[key.fast_index].store(false, Ordering::Relaxed);
         }
 
         if self.policy_table[start_index + u16::from(key.tap_type) as usize].is_none() {
@@ -426,7 +416,6 @@ impl FastPath {
         );
         FastPath {
             map_size,
-            queue_count,
 
             mask_from_interface: RwLock::new(
                 std::iter::repeat(0).take(u16::MAX as usize + 1).collect(),
@@ -451,11 +440,21 @@ impl FastPath {
                 table
             },
 
-            policy_table_flush_flags: [false; super::MAX_QUEUE_COUNT + 1],
+            policy_table_flush_flags: [FLUSH_FLAGS; super::MAX_QUEUE_COUNT + 1],
 
             // 统计计数
             policy_count: 0,
         }
+    }
+
+    pub fn reset_queue_size(&mut self, queue_count: usize) {
+        assert!(
+            queue_count <= super::MAX_QUEUE_COUNT,
+            "Fastpath queue count over limit."
+        );
+        self.policy_table_flush_flags.iter_mut().for_each(|f| {
+            f.store(true, Ordering::Relaxed);
+        });
     }
 }
 

--- a/agent/src/policy/first_path.rs
+++ b/agent/src/policy/first_path.rs
@@ -247,7 +247,6 @@ pub struct FirstPath {
     fast: FastPath,
 
     fast_disable: bool,
-    queue_count: usize,
 
     memory_limit: AtomicU64,
 }
@@ -280,14 +279,9 @@ impl FirstPath {
             current_level: level,
 
             fast: FastPath::new(queue_count, map_size),
-            queue_count,
             fast_disable,
             memory_limit: AtomicU64::new(0),
         }
-    }
-
-    pub fn update_map_size(&mut self, map_size: usize) {
-        self.fast.update_map_size(map_size)
     }
 
     pub fn update_interfaces(&mut self, ifaces: &Vec<Arc<PlatformData>>) {
@@ -720,6 +714,10 @@ impl FirstPath {
 
     pub fn set_memory_limit(&self, limit: u64) {
         self.memory_limit.store(limit, Ordering::Relaxed);
+    }
+
+    pub fn reset_queue_size(&mut self, queue_count: usize) {
+        self.fast.reset_queue_size(queue_count);
     }
 }
 

--- a/agent/src/policy/forward.rs
+++ b/agent/src/policy/forward.rs
@@ -114,7 +114,6 @@ pub struct Forward {
     mac_ip_tables: RwLock<TableLruCache>,
     vip_device_tables: RwLock<AHashMap<u64, bool>>,
 
-    queue_count: usize,
     capacity: usize,
 }
 
@@ -124,7 +123,6 @@ impl Forward {
         Self {
             mac_ip_tables: RwLock::new(TableLruCache::new(NonZeroUsize::new(capacity).unwrap())),
             vip_device_tables: RwLock::new(AHashMap::new()),
-            queue_count,
             capacity,
         }
     }

--- a/agent/src/policy/policy.rs
+++ b/agent/src/policy/policy.rs
@@ -94,7 +94,6 @@ pub struct Policy {
 
     nat: RwLock<Vec<AHashMap<u128, GpidEntry>>>,
 
-    queue_count: usize,
     first_hit: usize,
     fast_hit: usize,
 
@@ -116,7 +115,6 @@ impl Policy {
             table: FirstPath::new(queue_count, level, map_size, fast_disable),
             forward: Forward::new(queue_count, forward_capacity),
             nat: RwLock::new(vec![AHashMap::new(), AHashMap::new()]),
-            queue_count,
             first_hit: 0,
             fast_hit: 0,
             monitor: None,
@@ -511,6 +509,10 @@ impl Policy {
     pub fn set_memory_limit(&self, limit: u64) {
         self.table.set_memory_limit(limit);
     }
+
+    pub fn reset_queue_size(&mut self, queue_count: usize) {
+        self.table.reset_queue_size(queue_count);
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -615,10 +617,6 @@ impl PolicySetter {
         unsafe { &mut *self.policy }
     }
 
-    pub fn update_map_size(&mut self, map_size: usize) {
-        self.policy().table.update_map_size(map_size);
-    }
-
     pub fn update_local_epc(&mut self, local_epc: i32) {
         self.policy().labeler.update_local_epc(local_epc);
     }
@@ -679,6 +677,10 @@ impl PolicySetter {
 
     pub fn set_memory_limit(&self, limit: u64) {
         self.policy().set_memory_limit(limit)
+    }
+
+    pub fn reset_queue_size(&self, queue_count: usize) {
+        self.policy().reset_queue_size(queue_count);
     }
 }
 

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -33,7 +33,7 @@ use anyhow::{anyhow, Result};
 use arc_swap::access::Access;
 use dns_lookup::lookup_host;
 use flexi_logger::{colored_opt_format, Age, Cleanup, Criterion, FileSpec, Logger, Naming};
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::broadcast;
 
@@ -81,7 +81,7 @@ use crate::{
     metric::document::BoxedDocument,
     monitor::Monitor,
     platform::PlatformSynchronizer,
-    policy::{Policy, PolicySetter},
+    policy::{Policy, PolicyGetter, PolicySetter},
     rpc::{Session, Synchronizer, DEFAULT_TIMEOUT},
     sender::{npb_sender::NpbArpTable, uniform_sender::UniformSenderThread},
     utils::{
@@ -114,7 +114,7 @@ use public::{
     buffer::BatchedBox,
     debug::QueueDebugger,
     packet::MiniPacket,
-    proto::trident::{self, Exception, IfMacSource, SocketType, TapMode},
+    proto::trident::{self, Exception, SocketType, TapMode},
     queue::{self, DebugSender},
     utils::net::{get_route_src_ip, Link, MacAddr},
     LeakyBucket,
@@ -720,8 +720,8 @@ impl Trident {
                                 callback(&config_handler, c);
                             }
 
-                            for listener in c.dispatcher_listeners.iter_mut() {
-                                listener
+                            for d in c.dispatcher_components.iter_mut() {
+                                d.dispatcher_listener
                                     .on_config_change(&config_handler.candidate_config.dispatcher);
                             }
                         } else {
@@ -849,20 +849,24 @@ impl Trident {
                     components.config = config_handler.candidate_config.clone();
                     components.start();
 
-                    dispatcher_listener_callback(
-                        &config_handler.candidate_config.dispatcher,
+                    component_on_config_change(
+                        &config_handler,
                         components,
                         blacklist,
                         vm_mac_addrs,
                         gateway_vmac_addrs,
                         tap_types,
+                        &synchronizer,
+                        #[cfg(target_os = "linux")]
+                        libvirt_xml_extractor.clone(),
                     );
                     for callback in callbacks {
                         callback(&config_handler, components);
                     }
 
-                    for listener in components.dispatcher_listeners.iter_mut() {
-                        listener.on_config_change(&config_handler.candidate_config.dispatcher);
+                    for d in components.dispatcher_components.iter_mut() {
+                        d.dispatcher_listener
+                            .on_config_change(&config_handler.candidate_config.dispatcher);
                     }
                 }
                 _ => {
@@ -947,55 +951,121 @@ fn get_listener_links(
     }
 }
 
-fn dispatcher_listener_callback(
-    conf: &DispatcherConfig,
+fn component_on_config_change(
+    config_handler: &ConfigHandler,
     components: &mut AgentComponents,
     blacklist: Vec<u64>,
     vm_mac_addrs: Vec<MacAddr>,
     gateway_vmac_addrs: Vec<MacAddr>,
     tap_types: Vec<trident::TapType>,
+    synchronizer: &Arc<Synchronizer>,
+    #[cfg(target_os = "linux")] libvirt_xml_extractor: Arc<LibvirtXmlExtractor>,
 ) {
+    let conf = &config_handler.candidate_config.dispatcher;
     match conf.tap_mode {
         TapMode::Local => {
             let if_mac_source = conf.if_mac_source;
-            for listener in components.dispatcher_listeners.iter() {
+            for d in components.dispatcher_components.iter() {
                 let interfaces = get_listener_links(
                     conf,
                     #[cfg(target_os = "linux")]
-                    listener.netns(),
+                    d.dispatcher_listener.netns(),
                 );
-                listener.on_tap_interface_change(
+                d.dispatcher_listener.on_tap_interface_change(
                     &interfaces,
                     if_mac_source,
                     conf.trident_type,
                     &blacklist,
                 );
-                listener.on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
+                d.dispatcher_listener
+                    .on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
             }
         }
-        TapMode::Mirror => {
-            for listener in components.dispatcher_listeners.iter() {
-                listener.on_tap_interface_change(
-                    &vec![],
-                    IfMacSource::IfMac,
-                    conf.trident_type,
-                    &blacklist,
-                );
-                listener.on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
+        TapMode::Mirror | TapMode::Analyzer => {
+            // Obtain the currently configured network interfaces
+            let mut current_interfaces = get_listener_links(
+                conf,
+                #[cfg(target_os = "linux")]
+                &netns::NsFile::Root,
+            );
+            current_interfaces.sort();
+
+            if current_interfaces == components.tap_interfaces {
+                return;
             }
-        }
-        TapMode::Analyzer => {
-            for listener in components.dispatcher_listeners.iter() {
-                listener.on_tap_interface_change(
-                    &vec![],
-                    IfMacSource::IfMac,
-                    conf.trident_type,
-                    &blacklist,
-                );
-                listener.on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
+
+            // By comparing current_interfaces and components.tap_interfaces, we can determine which
+            // dispatcher_components should be closed and which dispatcher_components should be built
+            let interfaces_to_build: Vec<_> = current_interfaces
+                .iter()
+                .filter(|i| !components.tap_interfaces.contains(i))
+                .cloned()
+                .collect();
+
+            components.dispatcher_components.retain_mut(|d| {
+                let retain = current_interfaces.contains(&d.src_link);
+                if !retain {
+                    d.stop();
+                }
+                retain
+            });
+
+            let mut id = components.last_dispatcher_component_id;
+            components
+                .policy_setter
+                .reset_queue_size(id + interfaces_to_build.len() + 1);
+            let debugger_queue = components.debugger.clone_queue();
+            for i in interfaces_to_build {
+                id += 1;
+                match build_dispatchers(
+                    id,
+                    vec![i],
+                    components.stats_collector.clone(),
+                    config_handler,
+                    debugger_queue.clone(),
+                    components.is_ce_version,
+                    synchronizer,
+                    components.npb_bps_limit.clone(),
+                    components.npb_arp_table.clone(),
+                    components.rx_leaky_bucket.clone(),
+                    components.policy_getter,
+                    components.exception_handler.clone(),
+                    0,
+                    components.bpf_options.clone(),
+                    components.packet_sequence_uniform_output.clone(),
+                    components.proto_log_sender.clone(),
+                    components.pcap_batch_sender.clone(),
+                    components.tap_typer.clone(),
+                    vm_mac_addrs.clone(),
+                    gateway_vmac_addrs.clone(),
+                    components.toa_info_sender.clone(),
+                    components.l4_flow_aggr_sender.clone(),
+                    components.metrics_sender.clone(),
+                    #[cfg(target_os = "linux")]
+                    netns::NsFile::Root,
+                    #[cfg(target_os = "linux")]
+                    components.kubernetes_poller.clone(),
+                    #[cfg(target_os = "linux")]
+                    libvirt_xml_extractor.clone(),
+                ) {
+                    Ok(mut d) => {
+                        d.start();
+                        components.dispatcher_components.push(d);
+                    }
+                    Err(e) => {
+                        warn!("build dispatcher_component failed: {}", e);
+                        thread::sleep(Duration::from_secs(1));
+                        crate::utils::notify_exit(1);
+                    }
+                }
             }
-            parse_tap_type(components, tap_types);
+            components.last_dispatcher_component_id = id;
+            if conf.tap_mode == TapMode::Analyzer {
+                parse_tap_type(components, tap_types);
+            }
+            components.tap_interfaces = current_interfaces;
         }
+
         _ => {}
     }
 }
@@ -1224,16 +1294,100 @@ impl WatcherComponents {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub struct EbpfDispatcherComponent {
+    pub ebpf_collector: Box<EbpfCollector>,
+    pub session_aggregator: SessionAggregator,
+    pub collector: CollectorThread,
+    pub l7_collector: L7CollectorThread,
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl EbpfDispatcherComponent {
+    pub fn start(&mut self) {
+        self.session_aggregator.start();
+        self.collector.start();
+        self.l7_collector.start();
+        self.ebpf_collector.start();
+    }
+
+    pub fn stop(&mut self) {
+        self.session_aggregator.stop();
+        self.collector.stop();
+        self.l7_collector.stop();
+        self.ebpf_collector.notify_stop();
+    }
+}
+
+pub struct MetricsServerComponent {
+    pub external_metrics_server: MetricServer,
+    pub l7_collector: L7CollectorThread,
+}
+
+impl MetricsServerComponent {
+    pub fn start(&mut self) {
+        self.external_metrics_server.start();
+        self.l7_collector.start();
+    }
+
+    pub fn stop(&mut self) {
+        self.external_metrics_server.stop();
+        self.l7_collector.stop();
+    }
+}
+
+pub struct DispatcherComponent {
+    pub id: usize,
+    pub dispatcher: Dispatcher,
+    pub dispatcher_listener: DispatcherListener,
+    pub session_aggregator: SessionAggregator,
+    pub collector: CollectorThread,
+    pub l7_collector: L7CollectorThread,
+    pub packet_sequence_parser: PacketSequenceParser,
+    pub pcap_assembler: PcapAssembler,
+    pub handler_builders: Arc<Mutex<Vec<PacketHandlerBuilder>>>,
+    pub src_link: Link, // The original src_interface
+}
+
+impl DispatcherComponent {
+    pub fn start(&mut self) {
+        self.dispatcher.start();
+        self.session_aggregator.start();
+        self.collector.start();
+        self.l7_collector.start();
+        self.packet_sequence_parser.start();
+        self.pcap_assembler.start();
+        self.handler_builders
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .for_each(|y| {
+                y.start();
+            });
+    }
+    pub fn stop(&mut self) {
+        self.dispatcher.stop();
+        self.session_aggregator.stop();
+        self.collector.stop();
+        self.l7_collector.stop();
+        self.packet_sequence_parser.stop();
+        self.pcap_assembler.stop();
+        self.handler_builders
+            .lock()
+            .unwrap()
+            .iter_mut()
+            .for_each(|y| {
+                y.stop();
+            });
+    }
+}
+
 pub struct AgentComponents {
     pub config: ModuleConfig,
     pub rx_leaky_bucket: Arc<LeakyBucket>,
     pub tap_typer: Arc<TapTyper>,
     pub cur_tap_types: Vec<trident::TapType>,
-    pub dispatchers: Vec<Dispatcher>,
-    pub dispatcher_listeners: Vec<DispatcherListener>,
-    pub session_aggrs: Vec<SessionAggregator>,
-    pub collectors: Vec<CollectorThread>,
-    pub l7_collectors: Vec<L7CollectorThread>,
+    pub dispatcher_components: Vec<DispatcherComponent>,
     pub l4_flow_uniform_sender: UniformSenderThread<BoxedTaggedFlow>,
     pub metrics_uniform_sender: UniformSenderThread<BoxedDocument>,
     pub l7_flow_uniform_sender: UniformSenderThread<BoxAppProtoLogsData>,
@@ -1247,26 +1401,34 @@ pub struct AgentComponents {
     pub prometheus_targets_watcher: Arc<TargetsWatcher>,
     pub debugger: Debugger,
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub ebpf_collector: Option<Box<EbpfCollector>>,
+    pub ebpf_dispatcher_component: Option<EbpfDispatcherComponent>,
     pub running: AtomicBool,
     pub stats_collector: Arc<stats::Collector>,
-    pub external_metrics_server: MetricServer,
+    pub metrics_server_component: MetricsServerComponent,
     pub otel_uniform_sender: UniformSenderThread<OpenTelemetry>,
     pub prometheus_uniform_sender: UniformSenderThread<BoxedPrometheusExtra>,
     pub telegraf_uniform_sender: UniformSenderThread<TelegrafMetric>,
     pub profile_uniform_sender: UniformSenderThread<Profile>,
-    pub packet_sequence_parsers: Vec<PacketSequenceParser>, // Enterprise Edition Feature: packet-sequence
+    pub packet_sequence_uniform_output: DebugSender<BoxedPacketSequenceBlock>, // Enterprise Edition Feature: packet-sequence
     pub packet_sequence_uniform_sender: UniformSenderThread<BoxedPacketSequenceBlock>, // Enterprise Edition Feature: packet-sequence
     pub proc_event_uniform_sender: UniformSenderThread<BoxedProcEvents>,
     pub exception_handler: ExceptionHandler,
+    pub proto_log_sender: DebugSender<BoxAppProtoLogsData>,
+    pub pcap_batch_sender: DebugSender<BoxedPcapBatch>,
+    pub toa_info_sender: DebugSender<Box<(SocketAddr, SocketAddr)>>,
+    pub l4_flow_aggr_sender: DebugSender<BoxedTaggedFlow>,
+    pub metrics_sender: DebugSender<BoxedDocument>,
     pub npb_bps_limit: Arc<LeakyBucket>,
-    pub handler_builders: Vec<Arc<Mutex<Vec<PacketHandlerBuilder>>>>,
     pub compressed_otel_uniform_sender: UniformSenderThread<OpenTelemetryCompressed>,
-    pub pcap_assemblers: Vec<PcapAssembler>,
     pub pcap_batch_uniform_sender: UniformSenderThread<BoxedPcapBatch>,
     pub policy_setter: PolicySetter,
+    pub policy_getter: PolicyGetter,
     pub npb_bandwidth_watcher: Box<Arc<NpbBandwidthWatcher>>,
     pub npb_arp_table: Arc<NpbArpTable>,
+    pub is_ce_version: bool, // Determine whether the current version is a ce version, CE-AGENT always set pcap-assembler disabled
+    pub tap_interfaces: Vec<Link>,
+    pub bpf_options: Arc<Mutex<BpfOptions>>,
+    pub last_dispatcher_component_id: usize,
 
     max_memory: u64,
     tap_mode: TapMode,
@@ -1550,7 +1712,6 @@ impl AgentComponents {
         let candidate_config = &config_handler.candidate_config;
         let yaml_config = &candidate_config.yaml_config;
         let ctrl_ip = config_handler.ctrl_ip;
-        let ctrl_mac = config_handler.ctrl_mac;
         let max_memory = config_handler.candidate_config.environment.max_memory;
         let process_threshold = config_handler
             .candidate_config
@@ -1598,12 +1759,77 @@ impl AgentComponents {
             exception_handler.clone(),
         ));
 
+        #[cfg(target_os = "linux")]
+        let mut interfaces_and_ns: Vec<(Vec<Link>, netns::NsFile)> = vec![];
+        #[cfg(any(target_os = "windows", target_os = "android"))]
+        let mut interfaces_and_ns: Vec<Vec<Link>> = vec![];
+
+        #[cfg(target_os = "linux")]
+        if candidate_config.dispatcher.extra_netns_regex != "" {
+            if candidate_config.tap_mode == TapMode::Local {
+                let re = regex::Regex::new(&candidate_config.dispatcher.extra_netns_regex).unwrap();
+                let mut nss = netns::find_ns_files_by_regex(&re);
+                nss.sort_unstable();
+                for ns in nss.into_iter() {
+                    interfaces_and_ns
+                        .push((get_listener_links(&candidate_config.dispatcher, &ns), ns));
+                }
+            } else {
+                error!("When the TapMode is not Local, it does not support extra_netns_regex, other modes only support interfaces under the root network namespace");
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        let local_dispatcher_count = if candidate_config.tap_mode == TapMode::Local
+            && candidate_config.dispatcher.extra_netns_regex == ""
+        {
+            yaml_config.local_dispatcher_count
+        } else {
+            1
+        };
+        #[cfg(any(target_os = "windows", target_os = "android"))]
+        let local_dispatcher_count = 1;
+
+        if interfaces_and_ns.is_empty() {
+            let links = get_listener_links(
+                &candidate_config.dispatcher,
+                #[cfg(target_os = "linux")]
+                &netns::NsFile::Root,
+            );
+            if candidate_config.tap_mode != TapMode::Local {
+                for l in links {
+                    #[cfg(target_os = "linux")]
+                    interfaces_and_ns.push((vec![l], netns::NsFile::Root));
+                    #[cfg(any(target_os = "windows", target_os = "android"))]
+                    interfaces_and_ns.push(vec![l]);
+                }
+            } else {
+                for _ in 0..local_dispatcher_count {
+                    #[cfg(target_os = "linux")]
+                    interfaces_and_ns.push((links.clone(), netns::NsFile::Root));
+                    #[cfg(any(target_os = "windows", target_os = "android"))]
+                    interfaces_and_ns.push(links.clone());
+                }
+            }
+        }
+
         match candidate_config.tap_mode {
             TapMode::Analyzer => {
                 info!("Start check kernel...");
                 kernel_check();
                 info!("Start check tap interface...");
-                tap_interface_check(&yaml_config.src_interfaces);
+                #[cfg(target_os = "linux")]
+                let tap_interfaces: Vec<_> = interfaces_and_ns
+                    .iter()
+                    .filter_map(|i| i.0.get(0).map(|l| l.name.clone()))
+                    .collect();
+                #[cfg(any(target_os = "windows", target_os = "android"))]
+                let tap_interfaces: Vec<_> = interfaces_and_ns
+                    .iter()
+                    .filter_map(|i| i.get(0).map(|l| l.name.clone()))
+                    .collect();
+
+                tap_interface_check(&tap_interfaces);
             }
             _ => {
                 // NPF服务检查
@@ -1621,7 +1847,11 @@ impl AgentComponents {
         // =================================================================================
         // 目前仅支持local-mode + ebpf-collector，ebpf-collector不适用fastpath, 所以队列数为1
         let (policy_setter, policy_getter) = Policy::new(
-            1.max(yaml_config.src_interfaces.len()),
+            1.max(if candidate_config.tap_mode != TapMode::Local {
+                interfaces_and_ns.len()
+            } else {
+                1
+            }),
             yaml_config.first_path_level as usize,
             yaml_config.fast_path_map_size,
             yaml_config.forward_capacity,
@@ -1714,12 +1944,7 @@ impl AgentComponents {
         let tap_typer = Arc::new(TapTyper::new());
 
         // TODO: collector enabled
-        let mut dispatchers = vec![];
-        let mut dispatcher_listeners = vec![];
-        let mut collectors = vec![];
-        let mut l7_collectors = vec![];
-        let mut session_aggrs = vec![];
-        let mut packet_sequence_parsers = vec![]; // Enterprise Edition Feature: packet-sequence
+        let mut dispatcher_components = vec![];
 
         // Sender/Collector
         info!(
@@ -1823,101 +2048,15 @@ impl AgentComponents {
                 }
             }
         };
-        let bpf_builder = bpf::Builder {
-            is_ipv6: ctrl_ip.is_ipv6(),
-            vxlan_flags: yaml_config.vxlan_flags,
-            npb_port: yaml_config.npb_port,
-            controller_port: static_config.controller_port,
-            controller_tls_port: static_config.controller_tls_port,
-            proxy_controller_port: candidate_config.dispatcher.proxy_controller_port,
-            analyzer_source_ip: source_ip,
-            analyzer_port: candidate_config.dispatcher.analyzer_port,
-        };
-        let bpf_syntax_str = bpf_builder.build_pcap_syntax_to_str();
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        let bpf_syntax = bpf_builder.build_pcap_syntax();
-
-        // Enterprise Edition Feature: packet-sequence
-        let packet_sequence_queue_name = "2-packet-sequence-block-to-sender";
-        let (packet_sequence_uniform_output, packet_sequence_uniform_input, counter) =
-            queue::bounded_with_debug(
-                yaml_config.packet_sequence_queue_size,
-                packet_sequence_queue_name,
-                &queue_debugger,
-            );
-
-        stats_collector.register_countable(
-            "queue",
-            Countable::Owned(Box::new(counter)),
-            vec![
-                StatsOption::Tag("module", packet_sequence_queue_name.to_string()),
-                StatsOption::Tag("index", "0".to_string()),
-            ],
-        );
-        let packet_sequence_uniform_sender = UniformSenderThread::new(
-            packet_sequence_queue_name,
-            Arc::new(packet_sequence_uniform_input),
-            config_handler.sender(),
-            stats_collector.clone(),
-            exception_handler.clone(),
-            true,
-        );
-
-        let bpf_options = Arc::new(Mutex::new(BpfOptions {
-            capture_bpf: candidate_config.dispatcher.capture_bpf.clone(),
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            bpf_syntax,
-            bpf_syntax_str,
-        }));
 
         let npb_bps_limit = Arc::new(LeakyBucket::new(Some(
             config_handler.candidate_config.sender.npb_bps_threshold,
         )));
-        let mut handler_builders = Vec::new();
         let npb_arp_table = Arc::new(NpbArpTable::new(
             config_handler.candidate_config.npb.socket_type == SocketType::RawUdp,
             exception_handler.clone(),
         ));
 
-        let mut src_interfaces_and_namespaces = vec![];
-        #[cfg(target_os = "linux")]
-        let local_dispatcher_count = if candidate_config.tap_mode == TapMode::Local
-            && candidate_config.dispatcher.extra_netns_regex == ""
-        {
-            yaml_config.local_dispatcher_count
-        } else {
-            1
-        };
-        #[cfg(any(target_os = "windows", target_os = "android"))]
-        let local_dispatcher_count = 1;
-
-        for src_if in yaml_config.src_interfaces.iter() {
-            src_interfaces_and_namespaces.push((
-                src_if.clone(),
-                #[cfg(target_os = "linux")]
-                netns::NsFile::Root,
-            ));
-        }
-        #[cfg(target_os = "linux")]
-        if candidate_config.dispatcher.extra_netns_regex != "" {
-            let re = regex::Regex::new(&candidate_config.dispatcher.extra_netns_regex).unwrap();
-            let mut nss = netns::find_ns_files_by_regex(&re);
-            nss.sort_unstable();
-            for ns in nss {
-                src_interfaces_and_namespaces.push(("".into(), ns));
-            }
-        }
-        if src_interfaces_and_namespaces.is_empty() {
-            for _ in 0..local_dispatcher_count {
-                src_interfaces_and_namespaces.push((
-                    "".into(),
-                    #[cfg(target_os = "linux")]
-                    netns::NsFile::Root,
-                ));
-            }
-        }
-
-        let mut pcap_assemblers = vec![];
         let pcap_batch_queue = "2-pcap-batch-to-sender";
         let (pcap_batch_sender, pcap_batch_receiver, pcap_batch_counter) =
             queue::bounded_with_debug(
@@ -1941,259 +2080,97 @@ impl AgentComponents {
             exception_handler.clone(),
             false,
         );
+        // Enterprise Edition Feature: packet-sequence
+        let packet_sequence_queue_name = "2-packet-sequence-block-to-sender";
+        let (packet_sequence_uniform_output, packet_sequence_uniform_input, counter) =
+            queue::bounded_with_debug(
+                yaml_config.packet_sequence_queue_size,
+                packet_sequence_queue_name,
+                &queue_debugger,
+            );
 
-        for (i, entry) in src_interfaces_and_namespaces.into_iter().enumerate() {
-            let src_interface = entry.0;
+        stats_collector.register_countable(
+            "queue",
+            Countable::Owned(Box::new(counter)),
+            vec![
+                StatsOption::Tag("module", packet_sequence_queue_name.to_string()),
+                StatsOption::Tag("index", "0".to_string()),
+            ],
+        );
+
+        let packet_sequence_uniform_sender = UniformSenderThread::new(
+            packet_sequence_queue_name,
+            Arc::new(packet_sequence_uniform_input),
+            config_handler.sender(),
+            stats_collector.clone(),
+            exception_handler.clone(),
+            true,
+        );
+
+        let bpf_builder = bpf::Builder {
+            is_ipv6: ctrl_ip.is_ipv6(),
+            vxlan_flags: yaml_config.vxlan_flags,
+            npb_port: yaml_config.npb_port,
+            controller_port: static_config.controller_port,
+            controller_tls_port: static_config.controller_tls_port,
+            proxy_controller_port: candidate_config.dispatcher.proxy_controller_port,
+            analyzer_source_ip: source_ip,
+            analyzer_port: candidate_config.dispatcher.analyzer_port,
+        };
+        let bpf_syntax_str = bpf_builder.build_pcap_syntax_to_str();
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let bpf_syntax = bpf_builder.build_pcap_syntax();
+
+        let bpf_options = Arc::new(Mutex::new(BpfOptions {
+            capture_bpf: candidate_config.dispatcher.capture_bpf.clone(),
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            bpf_syntax,
+            bpf_syntax_str,
+        }));
+
+        let mut tap_interfaces = vec![];
+        for (i, entry) in interfaces_and_ns.into_iter().enumerate() {
+            #[cfg(target_os = "linux")]
+            let links = entry.0;
+            #[cfg(any(target_os = "windows", target_os = "android"))]
+            let links = entry;
+            tap_interfaces.extend(links.clone());
             #[cfg(target_os = "linux")]
             let netns = entry.1;
-
-            let (flow_sender, flow_receiver, counter) = queue::bounded_with_debug(
-                yaml_config.flow_queue_size,
-                "1-tagged-flow-to-quadruple-generator",
-                &queue_debugger,
-            );
-            stats_collector.register_countable(
-                "queue",
-                Countable::Owned(Box::new(counter)),
-                vec![
-                    StatsOption::Tag("module", "1-tagged-flow-to-quadruple-generator".to_string()),
-                    StatsOption::Tag("index", i.to_string()),
-                ],
-            );
-
-            let (l7_stats_sender, l7_stats_receiver, counter) = queue::bounded_with_debug(
-                yaml_config.flow_queue_size,
-                "1-l7-stats-to-quadruple-generator",
-                &queue_debugger,
-            );
-            stats_collector.register_countable(
-                "queue",
-                Countable::Owned(Box::new(counter)),
-                vec![
-                    StatsOption::Tag("module", "1-l7-stats-to-quadruple-generator".to_string()),
-                    StatsOption::Tag("index", i.to_string()),
-                ],
-            );
-
-            // create and start app proto logs
-            let (log_sender, log_receiver, counter) = queue::bounded_with_debug(
-                yaml_config.flow_queue_size,
-                "1-tagged-flow-to-app-protocol-logs",
-                &queue_debugger,
-            );
-            stats_collector.register_countable(
-                "queue",
-                Countable::Owned(Box::new(counter)),
-                vec![
-                    StatsOption::Tag("module", "1-tagged-flow-to-app-protocol-logs".to_string()),
-                    StatsOption::Tag("index", i.to_string()),
-                ],
-            );
-
-            let (session_aggr, counter) = SessionAggregator::new(
-                log_receiver,
-                proto_log_sender.clone(),
-                i as u32,
-                config_handler.log_parser(),
-                synchronizer.ntp_diff(),
-            );
-            stats_collector.register_countable(
-                "l7_session_aggr",
-                Countable::Ref(Arc::downgrade(&counter) as Weak<dyn RefCountable>),
-                vec![StatsOption::Tag("index", i.to_string())],
-            );
-            session_aggrs.push(session_aggr);
-
-            // Enterprise Edition Feature: packet-sequence
-            // create and start packet sequence
-            let (packet_sequence_sender, packet_sequence_receiver, counter) =
-                queue::bounded_with_debug(
-                    yaml_config.packet_sequence_queue_size,
-                    "1-packet-sequence-block-to-parser",
-                    &queue_debugger,
-                );
-            stats_collector.register_countable(
-                "queue",
-                Countable::Owned(Box::new(counter)),
-                vec![
-                    StatsOption::Tag("module", "1-packet-sequence-block-to-parser".to_string()),
-                    StatsOption::Tag("index", i.to_string()),
-                ],
-            );
-
-            let packet_sequence_parser = PacketSequenceParser::new(
-                packet_sequence_receiver,
-                packet_sequence_uniform_output.clone(),
-                i as u32,
-            );
-            packet_sequence_parsers.push(packet_sequence_parser);
-            let (pcap_assembler, mini_packet_sender) = build_pcap_assembler(
-                // CE-AGENT always set pcap-assembler disabled
+            let dispatcher_component = build_dispatchers(
+                i,
+                links,
+                stats_collector.clone(),
+                config_handler,
+                queue_debugger.clone(),
                 version_info.name != env!("AGENT_NAME"),
-                &yaml_config.pcap,
-                &stats_collector,
+                synchronizer,
+                npb_bps_limit.clone(),
+                npb_arp_table.clone(),
+                rx_leaky_bucket.clone(),
+                policy_getter,
+                exception_handler.clone(),
+                local_dispatcher_count,
+                bpf_options.clone(),
+                packet_sequence_uniform_output.clone(),
+                proto_log_sender.clone(),
                 pcap_batch_sender.clone(),
-                &queue_debugger,
-                synchronizer.ntp_diff(),
-                i,
-            );
-            pcap_assemblers.push(pcap_assembler);
-
-            let handler_builder = Arc::new(Mutex::new(vec![
-                PacketHandlerBuilder::Pcap(mini_packet_sender),
-                PacketHandlerBuilder::Npb(NpbBuilder::new(
-                    i,
-                    &config_handler.candidate_config.npb,
-                    &queue_debugger,
-                    npb_bps_limit.clone(),
-                    npb_arp_table.clone(),
-                    stats_collector.clone(),
-                )),
-            ]));
-            handler_builders.push(handler_builder.clone());
-
-            let tap_interfaces = get_listener_links(
-                &config_handler.candidate_config.dispatcher,
-                #[cfg(target_os = "linux")]
-                &netns,
-            );
-
-            let pcap_interfaces = if candidate_config.tap_mode == TapMode::Local {
-                tap_interfaces.clone()
-            } else if candidate_config.tap_mode == TapMode::Mirror && yaml_config.dpdk_enabled {
-                vec![]
-            } else {
-                #[cfg(target_os = "linux")]
-                match netns::link_by_name_in_netns(&src_interface, &netns) {
-                    Ok(link) => vec![link],
-                    Err(e) => {
-                        warn!("link_by_name: {}, error: {}", src_interface, e);
-                        vec![]
-                    }
-                }
-                #[cfg(any(target_os = "windows", target_os = "android"))]
-                match public::utils::net::link_by_name(&src_interface) {
-                    Ok(link) => vec![link],
-                    Err(e) => {
-                        warn!("link_by_name: {}, error: {}", src_interface, e);
-                        vec![]
-                    }
-                }
-            };
-
-            let dispatcher_builder = DispatcherBuilder::new()
-                .id(i)
-                .pause(agent_mode == RunningMode::Managed)
-                .handler_builders(handler_builder)
-                .ctrl_mac(ctrl_mac)
-                .leaky_bucket(rx_leaky_bucket.clone())
-                .options(Arc::new(Mutex::new(dispatcher::Options {
-                    #[cfg(any(target_os = "linux", target_os = "android"))]
-                    af_packet_version: config_handler.candidate_config.dispatcher.af_packet_version,
-                    packet_blocks: config_handler.candidate_config.dispatcher.af_packet_blocks,
-                    tap_mode: candidate_config.tap_mode,
-                    tap_mac_script: yaml_config.tap_mac_script.clone(),
-                    is_ipv6: ctrl_ip.is_ipv6(),
-                    npb_port: yaml_config.npb_port,
-                    vxlan_flags: yaml_config.vxlan_flags,
-                    controller_port: static_config.controller_port,
-                    controller_tls_port: static_config.controller_tls_port,
-                    libpcap_enabled: yaml_config.libpcap_enabled,
-                    snap_len: config_handler
-                        .candidate_config
-                        .dispatcher
-                        .capture_packet_size as usize,
-                    dpdk_enabled: config_handler.candidate_config.dispatcher.dpdk_enabled,
-                    dispatcher_queue: config_handler.candidate_config.dispatcher.dispatcher_queue,
-                    ..Default::default()
-                })))
-                .bpf_options(bpf_options.clone())
-                .default_tap_type(
-                    (yaml_config.default_tap_type as u16)
-                        .try_into()
-                        .unwrap_or(TapType::Cloud),
-                )
-                .mirror_traffic_pcp(yaml_config.mirror_traffic_pcp)
-                .tap_typer(tap_typer.clone())
-                .analyzer_dedup_disabled(yaml_config.analyzer_dedup_disabled)
-                .flow_output_queue(flow_sender.clone())
-                .l7_stats_output_queue(l7_stats_sender.clone())
-                .log_output_queue(log_sender.clone())
-                .packet_sequence_output_queue(packet_sequence_sender) // Enterprise Edition Feature: packet-sequence
-                .stats_collector(stats_collector.clone())
-                .flow_map_config(config_handler.flow())
-                .log_parse_config(config_handler.log_parser())
-                .collector_config(config_handler.collector())
-                .policy_getter(policy_getter)
-                .exception_handler(exception_handler.clone())
-                .ntp_diff(synchronizer.ntp_diff())
-                .src_interface(src_interface.clone())
-                .trident_type(candidate_config.dispatcher.trident_type)
-                .queue_debugger(queue_debugger.clone())
-                .analyzer_queue_size(yaml_config.analyzer_queue_size as usize)
-                .pcap_interfaces(pcap_interfaces)
-                .local_dispatcher_count(local_dispatcher_count)
-                .analyzer_raw_packet_block_size(
-                    yaml_config.analyzer_raw_packet_block_size as usize,
-                );
-            #[cfg(target_os = "linux")]
-            let dispatcher_builder = dispatcher_builder
-                .netns(netns)
-                .libvirt_xml_extractor(libvirt_xml_extractor.clone())
-                .platform_poller(kubernetes_poller.clone());
-            let dispatcher = match dispatcher_builder.build() {
-                Ok(d) => d,
-                Err(e) => {
-                    warn!(
-                        "dispatcher creation failed: {}, deepflow-agent restart...",
-                        e
-                    );
-                    thread::sleep(Duration::from_secs(1));
-                    return Err(e.into());
-                }
-            };
-            let mut dispatcher_listener = dispatcher.listener();
-            dispatcher_listener.on_config_change(&candidate_config.dispatcher);
-            dispatcher_listener.on_tap_interface_change(
-                &tap_interfaces,
-                candidate_config.dispatcher.if_mac_source,
-                candidate_config.dispatcher.trident_type,
-                &vec![],
-            );
-            dispatcher_listener.on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
-            synchronizer.add_flow_acl_listener(Box::new(dispatcher_listener.clone()));
-
-            dispatchers.push(dispatcher);
-            dispatcher_listeners.push(dispatcher_listener);
-
-            // create and start collector
-            let collector = Self::new_collector(
-                i,
-                stats_collector.clone(),
-                flow_receiver,
+                tap_typer.clone(),
+                vm_mac_addrs.clone(),
+                gateway_vmac_addrs.clone(),
                 toa_sender.clone(),
-                Some(l4_flow_aggr_sender.clone()),
+                l4_flow_aggr_sender.clone(),
                 metrics_sender.clone(),
-                MetricsType::SECOND | MetricsType::MINUTE,
-                config_handler,
-                &queue_debugger,
-                &synchronizer,
-                agent_mode,
-            );
-            collectors.push(collector);
-            let l7_collector = Self::new_l7_collector(
-                i,
-                stats_collector.clone(),
-                l7_stats_receiver,
-                metrics_sender.clone(),
-                MetricsType::SECOND | MetricsType::MINUTE,
-                config_handler,
-                &queue_debugger,
-                &synchronizer,
-                agent_mode,
-            );
-            l7_collectors.push(l7_collector);
+                #[cfg(target_os = "linux")]
+                netns,
+                #[cfg(target_os = "linux")]
+                kubernetes_poller.clone(),
+                #[cfg(target_os = "linux")]
+                libvirt_xml_extractor.clone(),
+            )?;
+            dispatcher_components.push(dispatcher_component);
         }
+        tap_interfaces.sort();
         let proc_event_queue_name = "1-proc-event-to-sender";
         #[allow(unused)]
         let (proc_event_sender, proc_event_receiver, counter) = queue::bounded_with_debug(
@@ -2241,9 +2218,9 @@ impl AgentComponents {
             true,
         );
 
-        let ebpf_dispatcher_id = dispatchers.len();
+        let ebpf_dispatcher_id = dispatcher_components.len();
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        let mut ebpf_collector = None;
+        let mut ebpf_dispatcher_component = None;
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if !config_handler.ebpf().load().ebpf.disabled
             && candidate_config.tap_mode != TapMode::Analyzer
@@ -2301,7 +2278,7 @@ impl AgentComponents {
                     StatsOption::Tag("index", ebpf_dispatcher_id.to_string()),
                 ],
             );
-            let (session_aggr, counter) = SessionAggregator::new(
+            let (session_aggregator, counter) = SessionAggregator::new(
                 log_receiver,
                 proto_log_sender.clone(),
                 ebpf_dispatcher_id as u32,
@@ -2313,8 +2290,6 @@ impl AgentComponents {
                 Countable::Ref(Arc::downgrade(&counter) as Weak<dyn RefCountable>),
                 vec![StatsOption::Tag("index", ebpf_dispatcher_id.to_string())],
             );
-            session_aggrs.push(session_aggr);
-            collectors.push(collector);
             let l7_collector = Self::new_l7_collector(
                 ebpf_dispatcher_id,
                 stats_collector.clone(),
@@ -2326,7 +2301,6 @@ impl AgentComponents {
                 &synchronizer,
                 agent_mode,
             );
-            l7_collectors.push(l7_collector);
             match EbpfCollector::new(
                 ebpf_dispatcher_id,
                 synchronizer.ntp_diff(),
@@ -2343,14 +2317,20 @@ impl AgentComponents {
                 &queue_debugger,
                 stats_collector.clone(),
             ) {
-                Ok(collector) => {
-                    synchronizer.add_flow_acl_listener(Box::new(collector.get_sync_dispatcher()));
+                Ok(ebpf_collector) => {
+                    synchronizer
+                        .add_flow_acl_listener(Box::new(ebpf_collector.get_sync_dispatcher()));
                     stats_collector.register_countable(
                         "ebpf-collector",
-                        Countable::Owned(Box::new(collector.get_sync_counter())),
+                        Countable::Owned(Box::new(ebpf_collector.get_sync_counter())),
                         vec![],
                     );
-                    ebpf_collector = Some(collector);
+                    ebpf_dispatcher_component = Some(EbpfDispatcherComponent {
+                        ebpf_collector,
+                        session_aggregator,
+                        collector,
+                        l7_collector,
+                    });
                 }
                 Err(e) => {
                     log::error!("ebpf collector error: {:?}", e);
@@ -2407,7 +2387,6 @@ impl AgentComponents {
             &synchronizer,
             agent_mode,
         );
-        l7_collectors.push(l7_collector);
 
         let prometheus_queue_name = "1-prometheus-to-sender";
         let (prometheus_sender, prometheus_receiver, counter) = queue::bounded_with_debug(
@@ -2531,10 +2510,6 @@ impl AgentComponents {
             rx_leaky_bucket,
             tap_typer,
             cur_tap_types: vec![],
-            dispatchers,
-            dispatcher_listeners,
-            collectors,
-            l7_collectors,
             l4_flow_uniform_sender,
             metrics_uniform_sender,
             l7_flow_uniform_sender,
@@ -2547,12 +2522,14 @@ impl AgentComponents {
             #[cfg(target_os = "linux")]
             prometheus_targets_watcher,
             debugger,
-            session_aggrs,
             #[cfg(any(target_os = "linux", target_os = "android"))]
-            ebpf_collector,
+            ebpf_dispatcher_component,
             stats_collector,
             running: AtomicBool::new(false),
-            external_metrics_server,
+            metrics_server_component: MetricsServerComponent {
+                external_metrics_server,
+                l7_collector,
+            },
             exception_handler,
             max_memory,
             otel_uniform_sender,
@@ -2561,19 +2538,34 @@ impl AgentComponents {
             profile_uniform_sender,
             proc_event_uniform_sender,
             tap_mode: candidate_config.tap_mode,
+            packet_sequence_uniform_output, // Enterprise Edition Feature: packet-sequence
             packet_sequence_uniform_sender, // Enterprise Edition Feature: packet-sequence
-            packet_sequence_parsers,        // Enterprise Edition Feature: packet-sequence
             npb_bps_limit,
-            handler_builders,
             compressed_otel_uniform_sender,
-            pcap_assemblers,
             pcap_batch_uniform_sender,
+            proto_log_sender,
+            pcap_batch_sender,
+            toa_info_sender: toa_sender,
+            l4_flow_aggr_sender,
+            metrics_sender,
             agent_mode,
             policy_setter,
+            policy_getter,
             npb_bandwidth_watcher,
             npb_arp_table,
             runtime,
+            dispatcher_components,
+            is_ce_version: version_info.name != env!("AGENT_NAME"),
+            tap_interfaces,
+            last_dispatcher_component_id: otel_dispatcher_id,
+            bpf_options,
         })
+    }
+
+    pub fn clear_dispatcher_components(&mut self) {
+        self.dispatcher_components.iter_mut().for_each(|d| d.stop());
+        self.dispatcher_components.clear();
+        self.tap_interfaces.clear();
     }
 
     fn start(&mut self) {
@@ -2601,9 +2593,6 @@ impl AgentComponents {
 
         // Enterprise Edition Feature: packet-sequence
         self.packet_sequence_uniform_sender.start();
-        for packet_sequence_parser in self.packet_sequence_parsers.iter() {
-            packet_sequence_parser.start();
-        }
 
         // When tap_mode is Analyzer mode and agent is not running in container and agent
         // in the environment where cgroup is not supported, we need to check free memory
@@ -2613,8 +2602,8 @@ impl AgentComponents {
         {
             match free_memory_check(self.max_memory, &self.exception_handler) {
                 Ok(()) => {
-                    for dispatcher in self.dispatchers.iter() {
-                        dispatcher.start();
+                    for d in self.dispatcher_components.iter_mut() {
+                        d.start();
                     }
                 }
                 Err(e) => {
@@ -2622,26 +2611,14 @@ impl AgentComponents {
                 }
             }
         } else {
-            for dispatcher in self.dispatchers.iter() {
-                dispatcher.start();
+            for d in self.dispatcher_components.iter_mut() {
+                d.start();
             }
         }
 
-        for sess_aggr in self.session_aggrs.iter() {
-            sess_aggr.start();
-        }
-
-        for collector in self.collectors.iter_mut() {
-            collector.start();
-        }
-
-        for collector in self.l7_collectors.iter_mut() {
-            collector.start();
-        }
-
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        if let Some(ebpf_collector) = self.ebpf_collector.as_mut() {
-            ebpf_collector.start();
+        if let Some(ebpf_dispatcher_component) = self.ebpf_dispatcher_component.as_mut() {
+            ebpf_dispatcher_component.start();
         }
         if matches!(self.agent_mode, RunningMode::Managed) {
             self.otel_uniform_sender.start();
@@ -2651,19 +2628,12 @@ impl AgentComponents {
             self.profile_uniform_sender.start();
             self.proc_event_uniform_sender.start();
             if self.config.metric_server.enabled {
-                self.external_metrics_server.start();
+                self.metrics_server_component.start();
             }
             self.pcap_batch_uniform_sender.start();
         }
-        self.handler_builders.iter().for_each(|x| {
-            x.lock().unwrap().iter_mut().for_each(|y| {
-                y.start();
-            })
-        });
+
         self.npb_bandwidth_watcher.start();
-        for p in self.pcap_assemblers.iter() {
-            p.start();
-        }
         self.npb_arp_table.start();
         info!("Started agent components.");
     }
@@ -2675,7 +2645,8 @@ impl AgentComponents {
 
         let mut join_handles = vec![];
 
-        for d in self.dispatchers.iter_mut() {
+        self.policy_setter.reset_queue_size(0);
+        for d in self.dispatcher_components.iter_mut() {
             d.stop();
         }
 
@@ -2685,20 +2656,6 @@ impl AgentComponents {
         {
             self.kubernetes_poller.stop();
             self.prometheus_targets_watcher.stop();
-        }
-
-        for q in self.collectors.iter_mut() {
-            join_handles.append(&mut q.notify_stop());
-        }
-
-        for q in self.l7_collectors.iter_mut() {
-            join_handles.append(&mut q.notify_stop());
-        }
-
-        for p in self.session_aggrs.iter() {
-            if let Some(h) = p.notify_stop() {
-                join_handles.push(h);
-            }
         }
 
         if let Some(h) = self.l4_flow_uniform_sender.notify_stop() {
@@ -2712,12 +2669,13 @@ impl AgentComponents {
         }
 
         self.debugger.stop();
+
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        if let Some(h) = self.ebpf_collector.as_mut().and_then(|t| t.notify_stop()) {
-            join_handles.push(h);
+        if let Some(d) = self.ebpf_dispatcher_component.as_mut() {
+            d.stop();
         }
 
-        self.external_metrics_server.stop();
+        self.metrics_server_component.stop();
         if let Some(h) = self.otel_uniform_sender.notify_stop() {
             join_handles.push(h);
         }
@@ -2743,21 +2701,11 @@ impl AgentComponents {
         if let Some(h) = self.packet_sequence_uniform_sender.notify_stop() {
             join_handles.push(h);
         }
-        self.handler_builders.iter().for_each(|x| {
-            x.lock().unwrap().iter_mut().for_each(|y| {
-                if let Some(h) = y.notify_stop() {
-                    join_handles.push(h);
-                }
-            })
-        });
+
         if let Some(h) = self.npb_bandwidth_watcher.notify_stop() {
             join_handles.push(h);
         }
-        for p in self.pcap_assemblers.iter() {
-            if let Some(h) = p.notify_stop() {
-                join_handles.push(h);
-            }
-        }
+
         if let Some(h) = self.npb_arp_table.notify_stop() {
             join_handles.push(h);
         }
@@ -2881,4 +2829,268 @@ fn build_pcap_assembler(
         ],
     );
     (pcap_assembler, mini_packet_sender)
+}
+
+fn build_dispatchers(
+    id: usize,
+    links: Vec<Link>,
+    stats_collector: Arc<stats::Collector>,
+    config_handler: &ConfigHandler,
+    queue_debugger: Arc<QueueDebugger>,
+    is_ce_version: bool,
+    synchronizer: &Arc<Synchronizer>,
+    npb_bps_limit: Arc<LeakyBucket>,
+    npb_arp_table: Arc<NpbArpTable>,
+    rx_leaky_bucket: Arc<LeakyBucket>,
+    policy_getter: PolicyGetter,
+    exception_handler: ExceptionHandler,
+    local_dispatcher_count: usize,
+    bpf_options: Arc<Mutex<BpfOptions>>,
+    packet_sequence_uniform_output: DebugSender<BoxedPacketSequenceBlock>,
+    proto_log_sender: DebugSender<BoxAppProtoLogsData>,
+    pcap_batch_sender: DebugSender<BoxedPcapBatch>,
+    tap_typer: Arc<TapTyper>,
+    vm_mac_addrs: Vec<MacAddr>,
+    gateway_vmac_addrs: Vec<MacAddr>,
+    toa_info_sender: DebugSender<Box<(SocketAddr, SocketAddr)>>,
+    l4_flow_aggr_sender: DebugSender<BoxedTaggedFlow>,
+    metrics_sender: DebugSender<BoxedDocument>,
+    #[cfg(target_os = "linux")] netns: netns::NsFile,
+    #[cfg(target_os = "linux")] kubernetes_poller: Arc<GenericPoller>,
+    #[cfg(target_os = "linux")] libvirt_xml_extractor: Arc<LibvirtXmlExtractor>,
+) -> Result<DispatcherComponent> {
+    let candidate_config = &config_handler.candidate_config;
+    let yaml_config = &candidate_config.yaml_config;
+    let dispatcher_config = &candidate_config.dispatcher;
+    let static_config = &config_handler.static_config;
+    let agent_mode = static_config.agent_mode;
+    let ctrl_ip = config_handler.ctrl_ip;
+    let ctrl_mac = config_handler.ctrl_mac;
+    let src_link = links.get(0).map(|l| l.to_owned()).unwrap_or_default();
+
+    let (flow_sender, flow_receiver, counter) = queue::bounded_with_debug(
+        yaml_config.flow_queue_size,
+        "1-tagged-flow-to-quadruple-generator",
+        &queue_debugger,
+    );
+    stats_collector.register_countable(
+        "queue",
+        Countable::Owned(Box::new(counter)),
+        vec![
+            StatsOption::Tag("module", "1-tagged-flow-to-quadruple-generator".to_string()),
+            StatsOption::Tag("index", id.to_string()),
+        ],
+    );
+
+    let (l7_stats_sender, l7_stats_receiver, counter) = queue::bounded_with_debug(
+        yaml_config.flow_queue_size,
+        "1-l7-stats-to-quadruple-generator",
+        &queue_debugger,
+    );
+    stats_collector.register_countable(
+        "queue",
+        Countable::Owned(Box::new(counter)),
+        vec![
+            StatsOption::Tag("module", "1-l7-stats-to-quadruple-generator".to_string()),
+            StatsOption::Tag("index", id.to_string()),
+        ],
+    );
+
+    // create and start app proto logs
+    let (log_sender, log_receiver, counter) = queue::bounded_with_debug(
+        yaml_config.flow_queue_size,
+        "1-tagged-flow-to-app-protocol-logs",
+        &queue_debugger,
+    );
+    stats_collector.register_countable(
+        "queue",
+        Countable::Owned(Box::new(counter)),
+        vec![
+            StatsOption::Tag("module", "1-tagged-flow-to-app-protocol-logs".to_string()),
+            StatsOption::Tag("index", id.to_string()),
+        ],
+    );
+
+    let (session_aggr, counter) = SessionAggregator::new(
+        log_receiver,
+        proto_log_sender.clone(),
+        id as u32,
+        config_handler.log_parser(),
+        synchronizer.ntp_diff(),
+    );
+    stats_collector.register_countable(
+        "l7_session_aggr",
+        Countable::Ref(Arc::downgrade(&counter) as Weak<dyn RefCountable>),
+        vec![StatsOption::Tag("index", id.to_string())],
+    );
+
+    // Enterprise Edition Feature: packet-sequence
+    // create and start packet sequence
+    let (packet_sequence_sender, packet_sequence_receiver, counter) = queue::bounded_with_debug(
+        yaml_config.packet_sequence_queue_size,
+        "1-packet-sequence-block-to-parser",
+        &queue_debugger,
+    );
+    stats_collector.register_countable(
+        "queue",
+        Countable::Owned(Box::new(counter)),
+        vec![
+            StatsOption::Tag("module", "1-packet-sequence-block-to-parser".to_string()),
+            StatsOption::Tag("index", id.to_string()),
+        ],
+    );
+
+    let packet_sequence_parser = PacketSequenceParser::new(
+        packet_sequence_receiver,
+        packet_sequence_uniform_output,
+        id as u32,
+    );
+    let (pcap_assembler, mini_packet_sender) = build_pcap_assembler(
+        is_ce_version,
+        &yaml_config.pcap,
+        &stats_collector,
+        pcap_batch_sender.clone(),
+        &queue_debugger,
+        synchronizer.ntp_diff(),
+        id,
+    );
+
+    let handler_builders = Arc::new(Mutex::new(vec![
+        PacketHandlerBuilder::Pcap(mini_packet_sender),
+        PacketHandlerBuilder::Npb(NpbBuilder::new(
+            id,
+            &candidate_config.npb,
+            &queue_debugger,
+            npb_bps_limit.clone(),
+            npb_arp_table.clone(),
+            stats_collector.clone(),
+        )),
+    ]));
+
+    let pcap_interfaces =
+        if candidate_config.tap_mode == TapMode::Mirror && yaml_config.dpdk_enabled {
+            vec![]
+        } else {
+            links.clone()
+        };
+
+    let dispatcher_builder = DispatcherBuilder::new()
+        .id(id)
+        .pause(agent_mode == RunningMode::Managed)
+        .handler_builders(handler_builders.clone())
+        .ctrl_mac(ctrl_mac)
+        .leaky_bucket(rx_leaky_bucket.clone())
+        .options(Arc::new(Mutex::new(dispatcher::Options {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            af_packet_version: dispatcher_config.af_packet_version,
+            packet_blocks: dispatcher_config.af_packet_blocks,
+            tap_mode: candidate_config.tap_mode,
+            tap_mac_script: yaml_config.tap_mac_script.clone(),
+            is_ipv6: ctrl_ip.is_ipv6(),
+            npb_port: yaml_config.npb_port,
+            vxlan_flags: yaml_config.vxlan_flags,
+            controller_port: static_config.controller_port,
+            controller_tls_port: static_config.controller_tls_port,
+            libpcap_enabled: yaml_config.libpcap_enabled,
+            snap_len: dispatcher_config.capture_packet_size as usize,
+            dpdk_enabled: dispatcher_config.dpdk_enabled,
+            dispatcher_queue: dispatcher_config.dispatcher_queue,
+            ..Default::default()
+        })))
+        .bpf_options(bpf_options)
+        .default_tap_type(
+            (yaml_config.default_tap_type as u16)
+                .try_into()
+                .unwrap_or(TapType::Cloud),
+        )
+        .mirror_traffic_pcp(yaml_config.mirror_traffic_pcp)
+        .tap_typer(tap_typer.clone())
+        .analyzer_dedup_disabled(yaml_config.analyzer_dedup_disabled)
+        .flow_output_queue(flow_sender.clone())
+        .l7_stats_output_queue(l7_stats_sender.clone())
+        .log_output_queue(log_sender.clone())
+        .packet_sequence_output_queue(packet_sequence_sender) // Enterprise Edition Feature: packet-sequence
+        .stats_collector(stats_collector.clone())
+        .flow_map_config(config_handler.flow())
+        .log_parse_config(config_handler.log_parser())
+        .collector_config(config_handler.collector())
+        .policy_getter(policy_getter)
+        .exception_handler(exception_handler.clone())
+        .ntp_diff(synchronizer.ntp_diff())
+        .src_interface(if candidate_config.tap_mode != TapMode::Local {
+            src_link.name.clone()
+        } else {
+            "".into()
+        })
+        .trident_type(dispatcher_config.trident_type)
+        .queue_debugger(queue_debugger.clone())
+        .analyzer_queue_size(yaml_config.analyzer_queue_size as usize)
+        .pcap_interfaces(pcap_interfaces.clone())
+        .local_dispatcher_count(local_dispatcher_count)
+        .analyzer_raw_packet_block_size(yaml_config.analyzer_raw_packet_block_size as usize);
+    #[cfg(target_os = "linux")]
+    let dispatcher_builder = dispatcher_builder
+        .netns(netns)
+        .libvirt_xml_extractor(libvirt_xml_extractor.clone())
+        .platform_poller(kubernetes_poller.clone());
+    let dispatcher = match dispatcher_builder.build() {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(
+                "dispatcher creation failed: {}, deepflow-agent restart...",
+                e
+            );
+            thread::sleep(Duration::from_secs(1));
+            return Err(e.into());
+        }
+    };
+    let mut dispatcher_listener = dispatcher.listener();
+    dispatcher_listener.on_config_change(dispatcher_config);
+    dispatcher_listener.on_tap_interface_change(
+        &links,
+        dispatcher_config.if_mac_source,
+        dispatcher_config.trident_type,
+        &vec![],
+    );
+    dispatcher_listener.on_vm_change(&vm_mac_addrs, &gateway_vmac_addrs);
+    synchronizer.add_flow_acl_listener(Box::new(dispatcher_listener.clone()));
+
+    // create and start collector
+    let collector = AgentComponents::new_collector(
+        id,
+        stats_collector.clone(),
+        flow_receiver,
+        toa_info_sender.clone(),
+        Some(l4_flow_aggr_sender.clone()),
+        metrics_sender.clone(),
+        MetricsType::SECOND | MetricsType::MINUTE,
+        config_handler,
+        &queue_debugger,
+        &synchronizer,
+        agent_mode,
+    );
+
+    let l7_collector = AgentComponents::new_l7_collector(
+        id,
+        stats_collector.clone(),
+        l7_stats_receiver,
+        metrics_sender.clone(),
+        MetricsType::SECOND | MetricsType::MINUTE,
+        config_handler,
+        &queue_debugger,
+        &synchronizer,
+        agent_mode,
+    );
+    Ok(DispatcherComponent {
+        id,
+        dispatcher,
+        dispatcher_listener,
+        session_aggregator: session_aggr,
+        collector,
+        l7_collector,
+        packet_sequence_parser,
+        pcap_assembler,
+        handler_builders,
+        src_link,
+    })
 }

--- a/server/controller/model/agent_group_config_example.yaml
+++ b/server/controller/model/agent_group_config_example.yaml
@@ -666,8 +666,7 @@ vtap_group_id: g-xxxxxx
   ## Dispatcher ##
   ################
   ## TAP NICs when tap_mode != 0
-  ## Note: The list of capture NICs when tap_mode is not equal to 0, in which
-  ##   case tap_interface_regex is invalid.
+  ## Note: Deprecated and instead use tap_interface_regex
   #src-interfaces:
   #- dummy0
   #- dummy1


### PR DESCRIPTION
### This PR is for:

- Agent

### Support merging tap-interface-regex and src-interfaces
- Discard src interfaces, TapMode::Analyzer, andTapMode::Mirror. use tap_interface_regex to obtain the network interfaces to capture
- Split AgentComponents into DispatcherComponent, EbpfDispatcherComponent, MetricServerComponent
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main

