### PR TITLE
[ingester] add tap_side values for prometheus export

### DIFF
--- a/server/libs/zerodoc/tag.go
+++ b/server/libs/zerodoc/tag.go
@@ -854,6 +854,18 @@ func (t *Tag) MarshalTo(b []byte) int {
 			offset += copy(b[offset:], ",tap_side=c-gw")
 		case ServerGateway:
 			offset += copy(b[offset:], ",tap_side=s-gw")
+		case ClientProcess:
+			offset += copy(b[offset:], ",tap_side=c-p")
+		case ServerProcess:
+			offset += copy(b[offset:], ",tap_side=s-p")
+		case ClientApp:
+			offset += copy(b[offset:], ",tap_side=c-app")
+		case ServerApp:
+			offset += copy(b[offset:], ",tap_side=s-app")
+		case App:
+			offset += copy(b[offset:], ",tap_side=app")
+		case Local:
+			offset += copy(b[offset:], ",tap_side=local")
 		}
 	}
 	if t.Code&TAPType != 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


