### PR TITLE
[eBPF] Fix http2 server could not capture data

### DIFF
--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -91,7 +91,7 @@ enum process_data_extra_source {
 #endif
 
 #ifndef EBPF_CACHE_SIZE
-#define EBPF_CACHE_SIZE 8
+#define EBPF_CACHE_SIZE 16
 #endif
 
 #endif /* DF_BPF_COMMON_H */


### PR DESCRIPTION
Because the data was split into multiple system calls to read (first read 9 bytes of protocol information), the http2 protocol inference could not be completed. The fix here is to merge the two data.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
- v6.3
- v6.2
-