### PR TITLE
[eBPF] Add a warning log when UPROBE does not have necessary symbols

### DIFF
--- a/agent/src/ebpf/user/log.c
+++ b/agent/src/ebpf/user/log.c
@@ -100,9 +100,9 @@ void _ebpf_error(int how_to_die, char *function_name, char *file_path,
 
 	if (function_name) {
 		if (how_to_die & ERROR_WARNING) {
-			len += snprintf(msg + len, max - len, "[eBPF] WARNING: func %s()", function_name);
+			len += snprintf(msg + len, max - len, "[eBPF] WARN func %s()", function_name);
 		} else {
-			len += snprintf(msg + len, max - len, "[eBPF] ERROR: func %s()", function_name);
+			len += snprintf(msg + len, max - len, "[eBPF] ERROR func %s()", function_name);
 		}
 		if (line_number > 0)
 			len +=


### PR DESCRIPTION
[eBPF] Add a warning log when UPROBE does not have necessary symbols

### This PR is for:

- Agent

#### Affected branches
- main
- v6.4
- v6.3
- v6.2
