### PR TITLE
[eBPF] Fixed golang process startup information not captured

### DIFF
--- a/agent/src/ebpf/kernel/uprobe_base.bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base.bpf.c
@@ -147,7 +147,7 @@ struct __http2_stack {
 				union {
 					struct __http2_buffer http2_buffer;
 					struct __http2_dataframe
-					    http2_dataframe;
+					 http2_dataframe;
 				};
 			} __attribute__ ((packed));
 		};
@@ -378,8 +378,7 @@ static __inline int get_fd_from_tls_conn_interface(void *conn,
 	return -1;
 }
 
-static __inline int get_fd_from_h2c_rwConn_interface(void *conn,
-						     struct ebpf_proc_info
+static __inline int get_fd_from_h2c_rwConn_interface(void *conn, struct ebpf_proc_info
 						     *info)
 {
 	/*
@@ -646,6 +645,26 @@ int bpf_func_sched_process_exit(struct sched_comm_exit_ctx *ctx)
 SEC("tracepoint/sched/sched_process_fork")
 int bpf_func_sched_process_fork(struct sched_comm_fork_ctx *ctx)
 {
+	/*
+	 * When you find that the golang process starts, sometimes you
+	 * don't get the process start information, all you get is
+	 * threads. Take the following example:
+	 *
+	 * # pstree -p 4157
+	 * deepflow-server(4157)─┬─{deepflow-server}(4214)
+	 *                       ├─{deepflow-server}(4216)
+	 *                       ├─{deepflow-server}(4217)
+	 *                       ├─{deepflow-server}(4218)
+	 *                       ├─{deepflow-server}(4219)
+	 *                       ├─{deepflow-server}(4229)
+	 *
+	 * fetch data:
+	 * .... 296916.616252: 0: parent_pid 4216 child_pid 4218
+	 * .... 296916.616366: 0: parent_pid 4218 child_pid 4219
+	 *
+	 * To get process startup information we add probe 'sched_process_exec'.
+	 */
+
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
 		return 0;
@@ -656,6 +675,30 @@ int bpf_func_sched_process_fork(struct sched_comm_fork_ctx *ctx)
 	bpf_get_current_comm(data.name, sizeof(data.name));
 	bpf_perf_event_output(ctx, &NAME(socket_data),
 			      BPF_F_CURRENT_CPU, &data, sizeof(data));
+
+	return 0;
+}
+
+// /sys/kernel/debug/tracing/events/sched/sched_process_exec/format
+SEC("tracepoint/sched/sched_process_exec")
+int bpf_func_sched_process_exec(struct sched_comm_exec_ctx *ctx)
+{
+	struct member_fields_offset *offset = retrieve_ready_kern_offset();
+	if (offset == NULL)
+		return 0;
+
+	struct process_event_t data;
+	__u64 id = bpf_get_current_pid_tgid();
+	pid_t pid = id >> 32;
+	pid_t tid = (__u32) id;
+
+	if (pid == tid) {
+		data.meta.event_type = EVENT_TYPE_PROC_EXEC;
+		data.pid = pid;
+		bpf_get_current_comm(data.name, sizeof(data.name));
+		bpf_perf_event_output(ctx, &NAME(socket_data),
+				      BPF_F_CURRENT_CPU, &data, sizeof(data));
+	}
 
 	return 0;
 }

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -50,20 +50,22 @@
 #include "socket.h"
 #include "elf.h"
 
+/* *INDENT-OFF* */
 // For process execute/exit events.
 struct process_event {
-	struct list_head list;          // list add to proc_events_head
-	struct bpf_tracer *tracer;      // link to struct bpf_tracer
-	uint8_t type;                   // EVENT_TYPE_PROC_EXEC or EVENT_TYPE_PROC_EXIT
-	char *path;                     // Full path "/proc/<pid>/root/..."
-	int pid;                        // Process ID
-	uint32_t expire_time;           // Expiration Date, the number of seconds since the system started.
+	struct list_head list;	// list add to proc_events_head
+	struct bpf_tracer *tracer;	// link to struct bpf_tracer
+	uint8_t type;		// EVENT_TYPE_PROC_EXEC or EVENT_TYPE_PROC_EXIT
+	char *path;		// Full path "/proc/<pid>/root/..."
+	int pid;		// Process ID
+	uint32_t expire_time;	// Expiration Date, the number of seconds since the system started.
 };
+/* *INDENT-ON* */
 
 extern uint32_t k_version;
 static char build_info_magic[] = "\xff Go buildinf:";
 static struct list_head proc_info_head;	// For pid-offsets correspondence lists.
-static struct list_head proc_events_head;     // For process execute/exit events list.
+static struct list_head proc_events_head;	// For process execute/exit events list.
 static pthread_mutex_t mutex_proc_events_lock;
 
 /* *INDENT-OFF* */
@@ -478,8 +480,7 @@ static struct proc_info *alloc_proc_info_by_pid(void)
 	struct proc_info *info;
 	info = calloc(1, sizeof(struct proc_info));
 	if (info == NULL) {
-		ebpf_warning
-		    ("calloc() size:sizeof(struct proc_info) error.\n");
+		ebpf_warning("calloc() size:sizeof(struct proc_info) error.\n");
 		return NULL;
 	}
 
@@ -504,7 +505,7 @@ static int resolve_bin_file(const char *path, int pid,
 			continue;
 		}
 
-		if (!binary_path){
+		if (!binary_path) {
 			binary_path = strdup(probe_sym->binary_path);
 			if (binary_path == NULL) {
 				goto failed;
@@ -520,7 +521,7 @@ static int resolve_bin_file(const char *path, int pid,
 			for (j = 0; j < probe_sym->rets_count; j++) {
 				addr = probe_sym->rets[j];
 				sub_probe_sym =
-					malloc(sizeof(struct symbol_uprobe));
+				    malloc(sizeof(struct symbol_uprobe));
 				if (sub_probe_sym == NULL) {
 					ebpf_warning("malloc() error.\n");
 					ret = ETR_NOMEM;
@@ -541,13 +542,13 @@ static int resolve_bin_file(const char *path, int pid,
 		} else
 			add_uprobe_symbol(pid, probe_sym, conf);
 
-		ebpf_info(
-			"Uprobe [%s] pid:%d go%d.%d.%d entry:0x%lx size:%ld symname:%s probe_func:%s rets_count:%d\n",
-			probe_sym->binary_path, probe_sym->pid,
-			probe_sym->ver.major, probe_sym->ver.minor,
-			probe_sym->ver.revision, probe_sym->entry,
-			probe_sym->size, probe_sym->name, probe_sym->probe_func,
-			probe_sym->rets_count);
+		ebpf_info
+		    ("Uprobe [%s] pid:%d go%d.%d.%d entry:0x%lx size:%ld symname:%s probe_func:%s rets_count:%d\n",
+		     probe_sym->binary_path, probe_sym->pid,
+		     probe_sym->ver.major, probe_sym->ver.minor,
+		     probe_sym->ver.revision, probe_sym->entry, probe_sym->size,
+		     probe_sym->name, probe_sym->probe_func,
+		     probe_sym->rets_count);
 
 		if (probe_sym->isret)
 			free_uprobe_symbol(probe_sym, NULL);
@@ -557,17 +558,17 @@ static int resolve_bin_file(const char *path, int pid,
 
 	if (syms_count == 0) {
 		ret = ETR_NOSYMBOL;
-		ebpf_warning(
-			"Go process pid %d [path: %s] (version: go%d.%d). Not find any symbols!"
-			" You can try setting the configuration option 'golang-symbol' to see "
-			"if it resolves the issue, if the issue persists, please attempt to "
-			"resolve it using the Golang executable with symbol table included.\n",
-			pid, path, go_ver->major, go_ver->minor);
+		ebpf_warning
+		    ("Go process pid %d [path: %s] (version: go%d.%d). Not find any symbols!"
+		     " You can try setting the configuration option 'golang-symbol' to see "
+		     "if it resolves the issue, if the issue persists, please attempt to "
+		     "resolve it using the Golang executable with symbol table included.\n",
+		     pid, path, go_ver->major, go_ver->minor);
 		goto failed;
 	}
 
 	struct proc_info *p_info = NULL;
-	if (binary_path){
+	if (binary_path) {
 		bool is_new_info = false;
 		p_info = find_proc_info_by_pid(pid);
 		if (p_info == NULL) {
@@ -593,10 +594,11 @@ static int resolve_bin_file(const char *path, int pid,
 		// resolve all offsets.
 		for (int k = 0; k < NELEMS(offsets); k++) {
 			off = &offsets[k];
-			int offset =
-			    struct_member_offset_analyze(binary_path,
-							 off->structure,
-							 off->field_name);
+			int offset = struct_member_offset_analyze(binary_path,
+								  off->
+								  structure,
+								  off->
+								  field_name);
 			if (offset == ETR_INVAL)
 				offset = off->default_offset;
 
@@ -608,31 +610,33 @@ static int resolve_bin_file(const char *path, int pid,
 			tcp_conn_sym = "go.itab.*net.TCPConn,net.Conn";
 			tls_conn_sym = "go.itab.*crypto/tls.Conn,net.Conn";
 			syscall_conn_sym =
-				"go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn";
+			    "go.itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn";
 		} else {
 			tcp_conn_sym = "go:itab.*net.TCPConn,net.Conn";
 			tls_conn_sym = "go:itab.*crypto/tls.Conn,net.Conn";
 			syscall_conn_sym =
-				"go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn";
+			    "go:itab.*google.golang.org/grpc/internal/credentials.syscallConn,net.Conn";
 		}
 
 		p_info->info.net_TCPConn_itab =
-			get_symbol_addr_from_binary(binary_path, tcp_conn_sym);
+		    get_symbol_addr_from_binary(binary_path, tcp_conn_sym);
 		if (p_info->info.net_TCPConn_itab == 0)
-			ebpf_warning("'%s' does not exist. Since eBPF uprobe relies on it to retrieve "
-				     "connection information, if it is empty, eBPF will not retrieve any"
-				     " data. This situation may be due to the lack of symbol table in "
-				     "the golang executable (confirm by executing 'nm %s'). If it shows "
-				     "'no symbols', you can try setting the configuration option "
-				     "'golang-symbol' to see if it resolves the issue, if the issue "
-				     "persists, please attempt to resolve it using the Golang executable "
-				     "with symbol table included.\n", tcp_conn_sym, binary_path);
+			ebpf_warning
+			    ("'%s' does not exist. Since eBPF uprobe relies on it to retrieve "
+			     "connection information, if it is empty, eBPF will not retrieve any"
+			     " data. This situation may be due to the lack of symbol table in "
+			     "the golang executable (confirm by executing 'nm %s'). If it shows "
+			     "'no symbols', you can try setting the configuration option "
+			     "'golang-symbol' to see if it resolves the issue, if the issue "
+			     "persists, please attempt to resolve it using the Golang executable "
+			     "with symbol table included.\n", tcp_conn_sym,
+			     binary_path);
 
 		p_info->info.crypto_tls_Conn_itab =
-			get_symbol_addr_from_binary(binary_path, tls_conn_sym);
+		    get_symbol_addr_from_binary(binary_path, tls_conn_sym);
 
-		p_info->info.credentials_syscallConn_itab = get_symbol_addr_from_binary(
-			binary_path, syscall_conn_sym);
+		p_info->info.credentials_syscallConn_itab =
+		    get_symbol_addr_from_binary(binary_path, syscall_conn_sym);
 
 		p_info->has_updated = false;
 
@@ -714,7 +718,7 @@ bool is_go_process(int pid)
 static inline bool golang_kern_check(void)
 {
 	return ((k_version == KERNEL_VERSION(3, 10, 0))
-	    || (k_version >= KERNEL_VERSION(4, 14, 0)));
+		|| (k_version >= KERNEL_VERSION(4, 14, 0)));
 }
 
 static inline bool golang_process_check(int pid)
@@ -748,7 +752,8 @@ int collect_go_uprobe_syms_from_procfs(struct tracer_probes_conf *conf)
 		return ETR_OK;
 
 	if (!golang_kern_check()) {
-		ebpf_warning("Uprobe golang requires Linux version 4.14+ or linux 3.10.0\n");
+		ebpf_warning
+		    ("Uprobe golang requires Linux version 4.14+ or linux 3.10.0\n");
 		return ETR_OK;
 	}
 
@@ -805,8 +810,10 @@ static bool __attribute__ ((unused)) probe_exist_in_procfs(struct probe *p)
 	return pid_exist_in_procfs(sym_uprobe->pid, sym_uprobe->starttime);
 }
 
-static bool __attribute__ ((unused)) pid_exist_in_probes(struct bpf_tracer *tracer, int pid,
-				unsigned long long starttime)
+static bool
+    __attribute__ ((unused)) pid_exist_in_probes(struct bpf_tracer *tracer,
+						 int pid,
+						 unsigned long long starttime)
 {
 	struct probe *p;
 	struct symbol_uprobe *sym;
@@ -896,7 +903,7 @@ static void clear_probes_by_pid(struct bpf_tracer *tracer, int pid,
 				ebpf_info("Clear process PID %d\n", pid);
 				info_print = true;
 			}
-				
+
 			free_probe_from_tracer(probe);
 		}
 	}
@@ -919,7 +926,8 @@ void update_proc_info_to_map(struct bpf_tracer *tracer)
 			continue;
 		len =
 		    snprintf(buff, sizeof(buff), "go%d.%d offsets:",
-			     info->version >> 16, ((info->version >> 8) & 0xff));
+			     info->version >> 16,
+			     ((info->version >> 8) & 0xff));
 		for (i = 0; i < OFFSET_IDX_MAX; i++) {
 			len +=
 			    snprintf(buff + len, sizeof(buff) - len, "%d:%d ",
@@ -958,8 +966,27 @@ static void process_execute_handle(int pid, struct bpf_tracer *tracer)
 	pthread_mutex_unlock(&tracer->mutex_probes_lock);
 }
 
+// The caller needs 'mutex_proc_events_lock' for protection
+static inline void find_and_clear_event_from_list(int pid)
+{
+	struct process_event *pe;
+	struct list_head *p, *n;
+	list_for_each_safe(p, n, &proc_events_head) {
+		pe = container_of(p, struct process_event, list);
+		if (pe->pid == pid) {
+			list_head_del(&pe->list);
+			free(pe->path);
+			free(pe);
+		}
+	}
+}
+
 static void process_exit_handle(int pid, struct bpf_tracer *tracer)
 {
+	pthread_mutex_lock(&mutex_proc_events_lock);
+	find_and_clear_event_from_list(pid);
+	pthread_mutex_unlock(&mutex_proc_events_lock);
+
 	// Protect the probes operation in multiple threads, similar to process_execute_handle()
 	pthread_mutex_lock(&tracer->mutex_probes_lock);
 	struct tracer_probes_conf *conf = tracer->tps;
@@ -967,8 +994,13 @@ static void process_exit_handle(int pid, struct bpf_tracer *tracer)
 	pthread_mutex_unlock(&tracer->mutex_probes_lock);
 }
 
-static void add_event_to_proc_header(struct bpf_tracer *tracer, int pid, uint8_t type)
+static void add_event_to_proc_header(struct bpf_tracer *tracer, int pid,
+				     uint8_t type)
 {
+	// Uprobe's hook points are only for user processes
+	if (!is_user_process(pid))
+		return;
+
 	char *path = get_elf_path_by_pid(pid);
 	if (path == NULL) {
 		return;
@@ -990,11 +1022,12 @@ static void add_event_to_proc_header(struct bpf_tracer *tracer, int pid, uint8_t
 	pe->path = path;
 	pe->pid = pid;
 	pe->type = type;
-	pe->expire_time = get_sys_uptime() + PROC_EVENT_DELAY_HANDLE_DEF; 
+	pe->expire_time = get_sys_uptime() + PROC_EVENT_DELAY_HANDLE_DEF;
 
 	pthread_mutex_lock(&mutex_proc_events_lock);
+	find_and_clear_event_from_list(pid);
 	list_add_tail(&pe->list, &proc_events_head);
-	pthread_mutex_unlock(&mutex_proc_events_lock);	
+	pthread_mutex_unlock(&mutex_proc_events_lock);
 }
 
 /**
@@ -1054,31 +1087,30 @@ void go_process_events_handle(void)
 		} else {
 			pe = NULL;
 		}
-		pthread_mutex_unlock(&mutex_proc_events_lock);
 
-		if (pe == NULL)
+		if (pe == NULL) {
+			pthread_mutex_unlock(&mutex_proc_events_lock);
 			break;
+		}
 
 		if (get_sys_uptime() >= pe->expire_time) {
-			pthread_mutex_lock(&mutex_proc_events_lock);
+			char *path = strdup(pe->path);
+			int pid = pe->pid;
+			struct bpf_tracer *tracer = pe->tracer;
+			uint8_t type = pe->type;
 			list_head_del(&pe->list);
-			pthread_mutex_unlock(&mutex_proc_events_lock);
-
-			if (pe->type == EVENT_TYPE_PROC_EXEC) {
-				/*
-				 * Threads and processes share the code section,
-				 * here only processes are concerned.
-				 */
-				if (is_user_process(pe->pid)
-				    && access(pe->path, F_OK) == 0) {
-					process_execute_handle(pe->pid,
-							       pe->tracer);
-				}
-			}
-
 			free(pe->path);
 			free(pe);
+			pthread_mutex_unlock(&mutex_proc_events_lock);
+			if (type == EVENT_TYPE_PROC_EXEC) {
+				if (access(path, F_OK) == 0) {
+					process_execute_handle(pid, tracer);
+				}
+			}
+			free(path);
+
 		} else {
+			pthread_mutex_unlock(&mutex_proc_events_lock);
 			break;
 		}
 	} while (true);

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -175,6 +175,7 @@ static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_accept4");
 	// process execute
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_fork");
+	tps_set_symbol(tps, "tracepoint/sched/sched_process_exec");
 
 	// 周期性触发用于缓存的数据的超时检查
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");


### PR DESCRIPTION
When you find that the golang process starts, sometimes you don't get the process start information, all you get is threads. Take the following example:

`pstree -p 4157`
deepflow-server(4157)─┬─{deepflow-server}(4214)
                      ├─{deepflow-server}(4216)
                      ├─{deepflow-server}(4217)
                      ├─{deepflow-server}(4218)
                      ├─{deepflow-server}(4219)
                      ├─{deepflow-server}(4229)

fetch data:
   .... 296916.616252: 0: parent_pid 4216 child_pid 4218
   .... 296916.616366: 0: parent_pid 4218 child_pid 4219

To get process startup information we add probe 'sched_process_exec'.


### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
- v6.3
- v6.2
