### PR TITLE
[Agent] Fixes get_hostname, get hostname from ROOT_UTS_PATH

### DIFF
--- a/agent/src/utils/command/mod.rs
+++ b/agent/src/utils/command/mod.rs
@@ -39,9 +39,3 @@ fn exec_command(program: &str, args: &[&str]) -> Result<String> {
             .map_err(|e| Error::new(ErrorKind::Other, e.to_string()))?)
     }
 }
-
-pub fn get_hostname() -> Result<String> {
-    hostname::get()?
-        .into_string()
-        .map_err(|_| Error::new(ErrorKind::Other, "get hostname failed"))
-}

--- a/agent/src/utils/command/windows.rs
+++ b/agent/src/utils/command/windows.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+
 use public::utils::net::{
     get_adapters_addresses, is_global, is_link_local_multicast, is_link_local_unicast, Error,
     LinkFlags, Result,
@@ -55,4 +57,10 @@ pub fn get_ip_address() -> Result<String, Error> {
         }
     }
     Ok(link_info)
+}
+
+pub fn get_hostname() -> IoResult<String> {
+    hostname::get()?
+        .into_string()
+        .map_err(|_| IoError::new(ErrorKind::Other, "get hostname failed"))
 }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes get_hostname, get hostname from ROOT_UTS_PATH
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
