### PR TITLE
[Agent] Fixes warning log when running in a non k8s environment

### DIFF
--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -531,6 +531,9 @@ pub fn get_k8s_namespace() -> String {
 
 #[cfg(any(target_os = "linux"))]
 pub async fn get_current_k8s_image() -> Option<String> {
+    if !running_in_k8s() {
+        return None;
+    }
     let Ok(mut config) = Config::infer().await else {
         warn!("failed to infer kubernetes config");
         return None;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes warning log when running in a non k8s environment
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
