### PR TITLE
[Agent] Reduce memory usage of l7_quadruple_generator

### DIFF
--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -91,6 +91,7 @@ struct SubQuadGen {
     id: usize,
 
     l7_output: DebugSender<Box<AppMeterWithFlow>>,
+    closed_app_meters: Vec<Box<AppMeterWithFlow>>,
 
     counter: Arc<QgCounter>,
     metrics_type: MetricsType,
@@ -229,6 +230,23 @@ impl SubQuadGen {
             .store(cap as u64, Ordering::Relaxed);
     }
 
+    fn push_closed_app_meter(
+        closed_app_meters: &mut Vec<Box<AppMeterWithFlow>>,
+        l7_output: &mut DebugSender<Box<AppMeterWithFlow>>,
+        boxed_app_meter: Box<AppMeterWithFlow>,
+    ) {
+        closed_app_meters.push(boxed_app_meter);
+        if closed_app_meters.len() >= QUEUE_BATCH_SIZE {
+            if let Err(e) = l7_output.send_all(closed_app_meters) {
+                warn!(
+                    "l7_quadruple_generator push AppMeterWithFlows to queue failed, because {:?}",
+                    e
+                );
+                closed_app_meters.clear();
+            }
+        }
+    }
+
     pub fn inject_app_meter(
         &mut self,
         l7_stats: &L7Stats,
@@ -276,11 +294,12 @@ impl SubQuadGen {
 
             // If l7_stats.flow.is_some(), set the flow of all meter belonging to this flow
             if let Some(tagged_flow) = &l7_stats.flow {
+                let close_type = tagged_flow.flow.close_type;
                 let flow = MiniFlow::from(&tagged_flow.flow);
                 let (is_active_host0, is_active_host1) =
                     check_active(time_in_second.as_secs(), possible_host, &flow);
                 for meter in meters.drain(..) {
-                    let app_meter = Box::new(AppMeterWithFlow {
+                    let boxed_app_meter = Box::new(AppMeterWithFlow {
                         app_meter: meter.app_meter,
                         flow: flow.clone(),
                         l7_protocol: meter.l7_protocol,
@@ -291,7 +310,16 @@ impl SubQuadGen {
                         time_in_second: tagged_flow.flow.flow_stat_time,
                         biz_type: meter.biz_type,
                     });
-                    stash.meters.push(app_meter);
+
+                    if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
+                        Self::push_closed_app_meter(
+                            &mut self.closed_app_meters,
+                            &mut self.l7_output,
+                            boxed_app_meter,
+                        );
+                    } else {
+                        stash.meters.push(boxed_app_meter);
+                    }
                 }
             }
         } else {
@@ -301,6 +329,7 @@ impl SubQuadGen {
             }
             // If l7_stats.flow.is_some(), set the flow of all meter belonging to this flow
             if let Some(tagged_flow) = &l7_stats.flow {
+                let close_type = tagged_flow.flow.close_type;
                 let flow = MiniFlow::from(&tagged_flow.flow);
                 let (is_active_host0, is_active_host1) =
                     check_active(time_in_second.as_secs(), possible_host, &flow);
@@ -315,7 +344,15 @@ impl SubQuadGen {
                     time_in_second: tagged_flow.flow.flow_stat_time,
                     biz_type: l7_stats.biz_type,
                 });
-                stash.meters.push(boxed_app_meter);
+                if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
+                    Self::push_closed_app_meter(
+                        &mut self.closed_app_meters,
+                        &mut self.l7_output,
+                        boxed_app_meter,
+                    );
+                } else {
+                    stash.meters.push(boxed_app_meter);
+                }
             } else {
                 let meter = AppMeterWithL7Protocol {
                     app_meter: *app_meter,
@@ -501,6 +538,7 @@ impl L7QuadrupleGenerator {
                 batch_buffer: Vec::with_capacity(QUEUE_BATCH_SIZE),
                 counter: Arc::new(QgCounter::default()),
                 ntp_diff: ntp_diff.clone(),
+                closed_app_meters: Vec::with_capacity(QUEUE_BATCH_SIZE),
                 // traffic_setter: traffic_setter,
             };
 
@@ -530,6 +568,7 @@ impl L7QuadrupleGenerator {
                 batch_buffer: Vec::with_capacity(QUEUE_BATCH_SIZE),
                 counter: Arc::new(QgCounter::default()),
                 ntp_diff: ntp_diff.clone(),
+                closed_app_meters: Vec::with_capacity(QUEUE_BATCH_SIZE),
                 // traffic_setter: traffic_setter,
             };
 
@@ -673,6 +712,18 @@ impl L7QuadrupleGenerator {
                             let time_in_second = l7_stat.time_in_second;
                             self.handle(&config, Some(l7_stat), time_in_second);
                         }
+                        if let Some(q) = self.second_quad_gen.as_mut() {
+                            if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
+                                warn!("second_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                                q.closed_app_meters.clear();
+                            }
+                        }
+                        if let Some(q) = self.minute_quad_gen.as_mut() {
+                            if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
+                                warn!("minute_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                                q.closed_app_meters.clear();
+                            }
+                        }
                     } else {
                         l7_recv_batch.clear();
                     }
@@ -689,6 +740,18 @@ impl L7QuadrupleGenerator {
                         None,
                         get_timestamp(self.ntp_diff.load(Ordering::Relaxed)),
                     );
+                    if let Some(q) = self.second_quad_gen.as_mut() {
+                        if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
+                            warn!("second_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                            q.closed_app_meters.clear();
+                        }
+                    }
+                    if let Some(q) = self.minute_quad_gen.as_mut() {
+                        if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
+                            warn!("minute_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                            q.closed_app_meters.clear();
+                        }
+                    }
                 }
                 Err(Error::Terminated(_, _)) => {
                     if let Some(g) = self.second_quad_gen.as_mut() {

--- a/agent/src/collector/types.rs
+++ b/agent/src/collector/types.rs
@@ -21,7 +21,7 @@ use super::quadruple_generator::QgKey;
 use crate::{
     common::{
         enums::EthernetType,
-        flow::{Flow, FlowKey, FlowMetricsPeer, L7Protocol, SignalSource},
+        flow::{CloseType, Flow, FlowKey, FlowMetricsPeer, L7Protocol, SignalSource},
         tagged_flow::TaggedFlow,
         Timestamp,
     },
@@ -39,6 +39,7 @@ pub struct MiniFlow {
     pub signal_source: SignalSource,
     pub directions: [Direction; 2],
     pub is_active_service: bool,
+    pub close_type: CloseType,
 
     pub otel_service: Option<String>,
     pub otel_instance: Option<String>,
@@ -57,6 +58,7 @@ impl From<&Flow> for MiniFlow {
             signal_source: flow.signal_source,
             directions: flow.directions,
             is_active_service: flow.is_active_service,
+            close_type: flow.close_type,
 
             otel_service: flow.otel_service.clone(),
             otel_instance: flow.otel_instance.clone(),


### PR DESCRIPTION
### This PR is for:

- Agent

### Reduce memory usage of l7_quadruple_generator
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- If the flow is closed, send AppMeterWithFlow to the queue to reduce memory usage
#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
