### PR TITLE
[eBPF] Reducing CPU consumption for process events exec/exit

### DIFF
--- a/agent/src/ebpf/README.md
+++ b/agent/src/ebpf/README.md
@@ -456,7 +456,7 @@ graph LR
 - 8 rust extra events callback
   - We provide a function that the user can register a callback interface for a specific event. e.g. Use rust function process these events.
 - 9.1 add_event_to_proc_header
-  - Add `struct process_event` to list-head(proc_events_head), need to set a expire time in `struct process_event`, see the description of [TLS/SSL Tracing](https://github.com/deepflowio/deepflow/tree/main/agent/src/ebpf#tlsssl-tracing) for the reason.
+  - Add `struct probe_process_event` to list-head(proc_events_head), need to set a expire time in `struct probe_process_event`, see the description of [TLS/SSL Tracing](https://github.com/deepflowio/deepflow/tree/main/agent/src/ebpf#tlsssl-tracing) for the reason.
 - 14.2.1 clear_probes_by_pid
   - Clear all probe, when process id == pid (event fetched).
 - 14.2.2 proc_parse_and_register

--- a/agent/src/ebpf/kernel/uprobe_base.bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base.bpf.c
@@ -641,29 +641,20 @@ int bpf_func_sched_process_exit(struct sched_comm_exit_ctx *ctx)
 	return 0;
 }
 
-// /sys/kernel/debug/tracing/events/sched/sched_process_fork/format
-SEC("tracepoint/sched/sched_process_fork")
-int bpf_func_sched_process_fork(struct sched_comm_fork_ctx *ctx)
+static inline int kernel_clone_exit(struct syscall_comm_exit_ctx *ctx)
 {
-	/*
-	 * When you find that the golang process starts, sometimes you
-	 * don't get the process start information, all you get is
-	 * threads. Take the following example:
-	 *
-	 * # pstree -p 4157
-	 * deepflow-server(4157)─┬─{deepflow-server}(4214)
-	 *                       ├─{deepflow-server}(4216)
-	 *                       ├─{deepflow-server}(4217)
-	 *                       ├─{deepflow-server}(4218)
-	 *                       ├─{deepflow-server}(4219)
-	 *                       ├─{deepflow-server}(4229)
-	 *
-	 * fetch data:
-	 * .... 296916.616252: 0: parent_pid 4216 child_pid 4218
-	 * .... 296916.616366: 0: parent_pid 4218 child_pid 4219
-	 *
-	 * To get process startup information we add probe 'sched_process_exec'.
-	 */
+	__u64 id = bpf_get_current_pid_tgid();
+	long ret = ctx->ret;
+
+	// error or parent process
+	if (ret != 0)
+		return 0;
+
+	int pid = (int)id;
+	int tgid = (int)(id >> 32);
+	// filter threads
+	if (pid != tgid)
+		return 0;
 
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -671,12 +662,22 @@ int bpf_func_sched_process_fork(struct sched_comm_fork_ctx *ctx)
 
 	struct process_event_t data;
 	data.meta.event_type = EVENT_TYPE_PROC_EXEC;
-	data.pid = ctx->child_pid;
+	data.pid = pid;
 	bpf_get_current_comm(data.name, sizeof(data.name));
 	bpf_perf_event_output(ctx, &NAME(socket_data),
 			      BPF_F_CURRENT_CPU, &data, sizeof(data));
 
 	return 0;
+}
+
+// /sys/kernel/debug/tracing/events/syscalls/sys_exit_fork/format
+TPPROG(sys_exit_fork) (struct syscall_comm_exit_ctx * ctx) {
+	return kernel_clone_exit(ctx);
+}
+
+// /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/format
+TPPROG(sys_exit_clone) (struct syscall_comm_exit_ctx * ctx) {
+	return kernel_clone_exit(ctx);
 }
 
 // /sys/kernel/debug/tracing/events/sched/sched_process_exec/format

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -67,7 +67,11 @@ enum {
 
 //thread index for bihash
 enum {
+	// cp-reader-0
 	THREAD_PROFILER_READER_IDX = 0,
+	// proc-events
+	THREAD_PROC_EVENTS_IDX,
+	// sk-reader-0 ...
 	THREAD_PROC_ACT_IDX_BASE
 };
 

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -44,7 +44,7 @@
 
 static struct list_head events_list;	// Use for extra register events
 static pthread_t proc_events_pthread;	// Process exec/exit thread
-
+extern __thread uword thread_index;     // for bihash
 /*
  * tracer_hooks_detach() and tracer_hooks_attach() will become terrible
  * when the number of probes is very large. Because we have to spend a
@@ -174,7 +174,8 @@ static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_accept");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_accept4");
 	// process execute
-	tps_set_symbol(tps, "tracepoint/sched/sched_process_fork");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_fork");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_clone");
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exec");
 
 	// 周期性触发用于缓存的数据的超时检查
@@ -1183,6 +1184,7 @@ static void check_datadump_timeout(void)
 static void process_events_handle_main(__unused void *arg)
 {
 	prctl(PR_SET_NAME, "proc-events");
+	thread_index = THREAD_PROC_EVENTS_IDX;
 	struct bpf_tracer *t = arg;
 	for (;;) {
 		/*


### PR DESCRIPTION
Replace `sched_process_fork` with `sys_exit_fork` and `sys_exit_clone` tracepoints because sched_process_fork cannot distinguish between processes and threads, leading to excessive threads being pushed to the upper layer unnecessarily. `sys_exit_fork` and `sys_exit_clone` only push process information.

Use spin locks to protect the process event list instead of thread mutex locks to avoid frequent context switches.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
