### PR TITLE
[ingester] support cleaning CK TTL expired data

### DIFF
--- a/server/ingester/ckmonitor/monitor.go
+++ b/server/ingester/ckmonitor/monitor.go
@@ -278,6 +278,11 @@ func (m *Monitor) start() {
 					}
 				}
 			}
+
+			// the frequency of TTL check is 1/16 of disk check
+			if counter%(m.checkInterval<<4) == 0 && !m.cfg.CKDiskMonitor.TTLCheckDisabled {
+				checkAndDropExpiredPartition(connect)
+			}
 		}
 	}
 }

--- a/server/ingester/ckmonitor/monitor_ttl.go
+++ b/server/ingester/ckmonitor/monitor_ttl.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2023 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ckmonitor
+
+import (
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+func getFullTable(database, table string) string {
+	return fmt.Sprintf("%s.`%s`", database, table)
+}
+
+func getDfStorageTTLsMap(connect *sql.DB) (map[string]int, error) {
+	ttlMap := make(map[string]int)
+
+	sql := "SELECT database,table,engine_full FROM system.tables WHERE storage_policy='df_storage'"
+	log.Info(sql)
+	rows, err := connect.Query(sql)
+	if err != nil {
+		return nil, err
+	}
+	re := regexp.MustCompile(`TTL time \+ toIntervalHour\((\d+)\)`)
+	for rows.Next() {
+		var database, table, engine_full string
+		err := rows.Scan(&database, &table, &engine_full)
+		if err != nil {
+			return nil, err
+		}
+		// find first match
+		matches := re.FindAllStringSubmatch(engine_full, 1)
+		for _, match := range matches {
+			hourInterval, err := strconv.Atoi(match[1])
+			if err != nil || hourInterval == 0 {
+				log.Warningf("engine full (%s) not match ttl hour", engine_full)
+				break
+			}
+			ttlMap[getFullTable(database, table)] = hourInterval
+			break
+		}
+	}
+	return ttlMap, nil
+}
+
+func getPartitionsMap(connect *sql.DB) (map[string][]string, error) {
+	sql := "SELECT partition,database,table FROM system.parts WHERE active=1 GROUP BY partition,database,table ORDER BY partition"
+	rows, err := connect.Query(sql)
+	log.Info(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	partitionsMap := make(map[string][]string)
+	for rows.Next() {
+		var partition, database, table string
+
+		err := rows.Scan(&partition, &database, &table)
+		if err != nil {
+			return nil, err
+		}
+		fullTable := getFullTable(database, table)
+		partitions := partitionsMap[fullTable]
+		if len(partitions) == 0 {
+			partitionsMap[fullTable] = []string{partition}
+		} else {
+			partitions = append(partitions, partition)
+			partitionsMap[fullTable] = partitions
+		}
+	}
+	return partitionsMap, nil
+}
+
+func isPartitionExpired(partition string, ttlHour int) bool {
+	layout := "2006-01-02 15:04:05"
+	partitionTime, err := time.Parse(layout, partition)
+	if err != nil {
+		log.Warningf("parse time failed: %s", err)
+		return false
+	}
+	// expired more then 1 day, then clear
+	return time.Since(partitionTime) > time.Duration(ttlHour)*time.Hour+time.Hour*24
+}
+
+func dropPartiton(connect *sql.DB, partition, fullTable string) error {
+	sql := fmt.Sprintf("ALTER TABLE %s DROP PARTITION '%s'", fullTable, partition)
+	log.Info("drop partition for TTL expired: ", sql)
+	_, err := connect.Exec(sql)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkAndDropExpiredPartition(connect *sql.DB) error {
+	ttlsMap, err := getDfStorageTTLsMap(connect)
+	if err != nil {
+		log.Warningf("get ttlsMap failed: %s", err)
+		return err
+	}
+	partitionsMap, err := getPartitionsMap(connect)
+	if err != nil {
+		log.Warningf("get partitionsMap failed: %s", err)
+		return err
+	}
+
+	for fullTable, partitions := range partitionsMap {
+		ttlHour, ok := ttlsMap[fullTable]
+		if !ok {
+			continue
+		}
+		for _, partition := range partitions {
+			if isPartitionExpired(partition, ttlHour) {
+				log.Infof("partition (%s) of %s TTL is %d hour is expired", partition, fullTable, ttlHour)
+				if err := dropPartiton(connect, partition, fullTable); err != nil {
+					log.Warningf("%s drop partition %s failed: %s", fullTable, partition, err)
+					continue
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/server/ingester/config/config.go
+++ b/server/ingester/config/config.go
@@ -70,9 +70,10 @@ type DiskCleanup struct {
 }
 
 type CKDiskMonitor struct {
-	CheckInterval int             `yaml:"check-interval"` // s
-	DiskCleanups  []DiskCleanup   `yaml:"disk-cleanups"`
-	PriorityDrops []DatabaseTable `yaml:"priority-drops"`
+	CheckInterval    int             `yaml:"check-interval"` // s
+	TTLCheckDisabled bool            `yaml:"ttl-check-disabled"`
+	DiskCleanups     []DiskCleanup   `yaml:"disk-cleanups"`
+	PriorityDrops    []DatabaseTable `yaml:"priority-drops"`
 }
 
 type Disk struct {
@@ -382,6 +383,7 @@ func Load(path string) *Config {
 			TCPReaderBuffer: 1 << 20,
 			CKDiskMonitor: CKDiskMonitor{
 				DefaultCheckInterval,
+				false,
 				[]DiskCleanup{
 					{
 						DefaultSystemDiskPrefix,

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -492,7 +492,8 @@ ingester:
   #prometheus-sample-ignore-universal-tag: false
 
   #ck-disk-monitor:
-  #  check-interval: 180 # 检查时间间隔(单位: 秒)
+  #  check-interval: 180 # check time interval (unit: seconds)
+  #  ttl-check-disabled: false # whether to not check TTL expired data
   ## 磁盘空间不足时，同时满足磁盘占用率>used-percent和磁盘空闲<free-space, 或磁盘占用大于used-space, 开始清理数据
   ## When the disk space is insufficient, the disk occupancy > 'used-percent' and the disk idle < 'free-space' are met at the same time, or the disk occupancy > 'used-space', then the data is cleaned up
   #  disk-cleanups:


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


