### PR TITLE
[Agent] Fixes protolog_buffer too large

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1992,6 +1992,9 @@ impl FlowMap {
                     );
                     self.protolog_buffer
                         .push(Box::new(AppProto::PseudoAppProto(app_proto)));
+                    if self.protolog_buffer.len() >= QUEUE_BATCH_SIZE {
+                        self.flush_app_protolog();
+                    }
                 }
             }
             _ => {}


### PR DESCRIPTION
### This PR is for:

- Agent

### protolog_buffer too large
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
