### PR TITLE
[Agent] Fixes protolog_buffer too large

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -2008,9 +2008,6 @@ impl FlowMap {
         meta_packet: &MetaPacket,
         l7_info: L7ProtocolInfo,
     ) {
-        if self.protolog_buffer.len() >= QUEUE_BATCH_SIZE {
-            self.flush_app_protolog();
-        }
         let domain = l7_info.get_request_domain();
         if !domain.is_empty() {
             node.tagged_flow.flow.request_domain = domain;
@@ -2026,6 +2023,9 @@ impl FlowMap {
             {
                 self.protolog_buffer
                     .push(Box::new(AppProto::MetaAppProto(app_proto)));
+                if self.protolog_buffer.len() >= QUEUE_BATCH_SIZE {
+                    self.flush_app_protolog();
+                }
             }
         }
     }


### PR DESCRIPTION
### This PR is for:

- Agent

### protolog_buffer too large
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
