### PR TITLE
[Agent] Recorrect window's start_time in collector

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -385,10 +385,9 @@ impl Stash {
             return;
         }
 
-        // timeInSecond needs to be corrected here.
-        // because doc time is used to push the time window, no correction is made to the timestamp in doc.
-        // for tick in queue (that is, accFlow = = nil), the time is modified to time_in_second-delay_seconds.
-        // for minute collector, minus 60s
+        // time_in_second needs to be corrected here. because doc time is used to push the time window,
+        // no correction is made to the timestamp in doc. for tick in queue (that is, accFlow == nil),
+        // the time is modified to time_in_second - delay_seconds. for minute collector, minus 60s
         if acc_flow.is_none() && time_in_second >= self.context.delay_seconds {
             match self.context.metric_type {
                 MetricsType::SECOND => time_in_second -= self.context.delay_seconds,
@@ -610,10 +609,23 @@ impl Stash {
             return;
         }
 
-        // timeInSecond needs to be corrected here.
-        // because doc time is used to push the time window, no correction is made to the timestamp in doc.
-        // for tick in queue (that is, accFlow = = nil), the time is modified to time_in_second-delay_seconds.
-        // for minute collector, minus 60s
+        // if the flow is closed, fill and send the stats data as soon as possible, and do not push the time window
+        if let Some(m) = meter.as_ref() {
+            if m.flow.close_type != CloseType::Unknown
+                && m.flow.close_type != CloseType::ForcedReport
+            {
+                if !m.is_active_host0 && !m.is_active_host1 && !config.inactive_ip_enabled {
+                    self.counter.drop_inactive.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+                self.fill_l7_stats(m, &m.flow.directions, &config);
+                return;
+            }
+        }
+
+        // time_in_second needs to be corrected here, because doc time is used to push the time window,
+        // no correction is made to the timestamp in doc, for tick in queue (that is, meter == nil),
+        // the time is modified to time_in_second - delay_seconds, for minute collector, minus 60s
         if meter.is_none() && time_in_second >= self.context.delay_seconds {
             match self.context.metric_type {
                 MetricsType::SECOND => time_in_second -= self.context.delay_seconds,


### PR DESCRIPTION
### This PR is for:

- Agent

### Recorrect window's start_time in collector
#### Steps to reproduce the bug
- Because the closed_doc was sent ahead of time, the window of the collector was pushed, so that some data that had not been sent was drop_before_window.
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
