### PR TITLE
[Agent] Fixed the problem of blocking guard component

### DIFF
--- a/agent/src/utils/guard.rs
+++ b/agent/src/utils/guard.rs
@@ -305,6 +305,7 @@ impl Guard {
                 if !system_guard.refresh_process_specifics(pid, ProcessRefreshKind::new().with_cpu()) {
                     warn!("refresh process with cpu failed");
                 }
+                drop(system_guard);
                 system_load.check(config.system_load_circuit_breaker_threshold, config.system_load_circuit_breaker_recover, config.system_load_circuit_breaker_metric);
                 match get_file_and_size_sum(&log_dir) {
                     Ok(file_and_size_sum) => {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixed the problem of blocking guard component
#### Steps to reproduce the bug
- change the setting: capture_packet_size, then agent will block and cannot gracefully stop.
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
