### PR TITLE
[eBPF] Fix `PERCPU_ARRAY` map could not be updated

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1838,10 +1838,11 @@ static bool bpf_stats_map_update(struct bpf_tracer *tracer,
 static int update_offsets_table(struct bpf_tracer *t,
 				struct bpf_offset_param *offset)
 {
-	struct bpf_offset_param offs[MAX_CPU_NR];
+	int nr_cpus = get_num_possible_cpus();
+	struct bpf_offset_param offs[nr_cpus];
 	int i;
 	memset(&offs, 0, sizeof(offs));
-	for (i = 0; i < MAX_CPU_NR; i++) {
+	for (i = 0; i < nr_cpus; i++) {
 		offs[i] = *offset;
 	}
 


### PR DESCRIPTION
When updating EBPF map '__members_offset', the following warning appears:
```
[eBPF] WARNING: func bpf_table_set_value() [user/table.c:83] [bpf_table_set_value] bpf_map_update_elem, err tb_name:__members_offset, key : 0, err_message:Bad address
```
The possible total number of cpus exceeds 256, as shown in the following example:
```
cat /sys/devices/system/cpu/possible
0-319
```
This problem is solved by getting the maximum CPU value, rather than the fixed value CPUMAX(256).



### This PR is for:


- Agent



#### Affected branches
- main
- v6.4
- v6.3
- v6.2



