### PR TITLE
[Agent] Fixes block uniform_sender

### DIFF
--- a/agent/src/sender/uniform_sender.rs
+++ b/agent/src/sender/uniform_sender.rs
@@ -427,7 +427,7 @@ impl<T: Sendable> UniformSender<T> {
         let tcp_stream = self.tcp_stream.as_mut().unwrap();
 
         let mut write_offset = 0usize;
-        loop {
+        while self.running.load(Ordering::Relaxed) {
             let result = tcp_stream.write(&buffer[write_offset..]);
             match result {
                 Ok(size) => {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes block uniform_sender
#### Steps to reproduce the bug
- Probably because server stopped and agent reached escape time, agent blocked in uniform_sender and could not exit.
#### Changes to fix the bug
- Add the retry_count for tcp_stream writes of uniform_sender. If the retry_count exceeds a certain number, the data will be dropped
#### Affected branches
- main
- v6.4
- v6.3
- v6.2
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
