### PR TITLE
[Server] fix vtap group default team id

### DIFF
--- a/server/controller/db/mysql/migration/rawsql/init.sql
+++ b/server/controller/db/mysql/migration/rawsql/init.sql
@@ -2293,7 +2293,7 @@ INSERT INTO vl2(state, name, net_type, isp, lcuuid, domain) values(0, 'PublicNet
 set @lcuuid = (select uuid());
 set @short_uuid = (select substr(replace(uuid(),'-',''), 1, 10));
 set @short_uuid = concat('g-', @short_uuid);
-INSERT INTO vtap_group(lcuuid, id, name, short_uuid) values(@lcuuid, 1, "default", @short_uuid);
+INSERT INTO vtap_group(lcuuid, id, name, short_uuid, team_id) values(@lcuuid, 1, "default", @short_uuid, 1);
 
 CREATE TABLE IF NOT EXISTS data_source (
     id                          INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
