### PR TITLE
[querier] add signal_source for adapter

### DIFF
--- a/server/querier/app/tracing-adapter/model/tracing.go
+++ b/server/querier/app/tracing-adapter/model/tracing.go
@@ -16,6 +16,9 @@
 
 package model
 
+// deepflow-app use `signal_source` to divide flows, all comes from apm use `4`
+const L7_FLOW_SIGNAL_SOURCE_OTEL = 4
+
 type ExSpan struct {
 	Name            string `json:"name"`
 	ID              uint64 `json:"_id"`           // unique id
@@ -35,6 +38,7 @@ type ExSpan struct {
 	AppService      string `json:"app_service"`   // service name
 	AppInstance     string `json:"app_instance"`  // service instance name
 	ServiceUname    string `json:"service_uname"` // equals app_service
+	SignalSource    int    `json:"signal_source"` // fixed value, use 4
 
 	Attribute map[string]string `json:"attribute"`
 }

--- a/server/querier/app/tracing-adapter/service/skywalking.go
+++ b/server/querier/app/tracing-adapter/service/skywalking.go
@@ -168,6 +168,7 @@ func (s *SkyWalkingAdapter) skywalkingTracesToExTraces(traces *query.Trace) *mod
 			AppInstance:     skywalkingSpan.ServiceInstanceName,
 			ServiceUname:    skywalkingSpan.ServiceCode,
 			RequestResource: *skywalkingSpan.EndpointName, // maybe overwrite by tags
+			SignalSource:    model.L7_FLOW_SIGNAL_SOURCE_OTEL,
 			Attribute:       s.swTagsToAttributes(skywalkingSpan.Tags),
 		}
 		s.swTagsToSpanRequestInfo(*skywalkingSpan.Layer, skywalkingSpan.Tags, &span)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes when use apm data for distributed-tracing
#### Steps to reproduce the bug
- quey external outside apm data, it use `signal_source` to find app-span (use `tap_side` before)
#### Changes to fix the bug
- add `signal_source` in return, confirm all apm data cover `signal_source` value
#### Affected branches
- main
- v6.4