### PR TITLE
[Agent] Fixes the problem of check_memory overflow in wasm plugin

### DIFF
--- a/agent/src/plugin/wasm/abi_import.rs
+++ b/agent/src/plugin/wasm/abi_import.rs
@@ -41,7 +41,7 @@ use wasmtime_wasi::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker;
 
     note that the caller storeData.parse_ctx is Always None
 */
-pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32, level: i32) {
+pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32, level: u32) {
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mut buf = vec![0u8; len as usize];
 
@@ -73,7 +73,7 @@ pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32, 
 }
 
 // check_memory must invoke first in almost import function
-fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: i32, len: i32, func_name: &str) -> bool {
+fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: u32, len: u32, func_name: &str) -> bool {
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mem_size = mem.data_size(caller.as_context());
     if (b + len) as usize > mem_size {
@@ -97,7 +97,7 @@ fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: i32, len: i32, func_n
     //export vm_read_ctx_base
     func vmReadCtxBase(b *byte, length int) int
 */
-pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     /*
         wasm vm read the parse ctx, host need sesrialize the parse param to bytes and write to the vm.
         b is the wasm ptr indicate the addr bias from instance memory.
@@ -134,7 +134,7 @@ pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: i32, le
     //export vm_read_payload
     func vmReadPayload(b *byte, length int) int
 */
-pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_PAYLOAD) {
         return 0;
     }
@@ -180,8 +180,8 @@ pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: i32, len
 */
 pub(super) fn vm_read_http_req_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_HTTP_REQ) {
         return 0;
@@ -225,8 +225,8 @@ pub(super) fn vm_read_http_req_info(
 */
 pub(super) fn vm_read_http_resp_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_HTTP_RESP) {
         return 0;
@@ -270,8 +270,8 @@ pub(super) fn vm_read_http_resp_info(
 */
 pub(super) fn vm_read_custom_message_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_CUSTOM_MESSAGE) {
         return 0;
@@ -317,8 +317,8 @@ pub(super) fn vm_read_custom_message_info(
 */
 pub(super) fn host_read_l7_protocol_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_HOST_READ_L7_PROTOCOL_INFO) {
         return 0;
@@ -400,7 +400,7 @@ pub(super) fn host_read_l7_protocol_info(
     //export host_read_str_result
     func hostReadStrResult(b *byte, length int) bool
 */
-pub(super) fn host_read_str_result(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn host_read_str_result(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_HOST_READ_STR_RESULT) {
         return 0;
     }

--- a/agent/src/plugin/wasm/host.rs
+++ b/agent/src/plugin/wasm/host.rs
@@ -58,9 +58,9 @@ pub(super) const IMPORT_FUNC_VM_READ_CUSTOM_MESSAGE: &str = "vm_read_custom_mess
 pub(super) const IMPORT_FUNC_HOST_READ_L7_PROTOCOL_INFO: &str = "host_read_l7_protocol_info";
 pub(super) const IMPORT_FUNC_HOST_READ_STR_RESULT: &str = "host_read_str_result";
 
-pub(super) const LOG_LEVEL_INFO: i32 = 0;
-pub(super) const LOG_LEVEL_WARN: i32 = 1;
-pub(super) const LOG_LEVEL_ERR: i32 = 2;
+pub(super) const LOG_LEVEL_INFO: u32 = 0;
+pub(super) const LOG_LEVEL_WARN: u32 = 1;
+pub(super) const LOG_LEVEL_ERR: u32 = 2;
 
 pub const WASM_EXPORT_FUNC_NAME: [&'static str; 5] = [
     EXPORT_FUNC_CHECK_PAYLOAD,


### PR DESCRIPTION
### This PR is for:

#6264 

- Agent

The pointer addresses passed in the wasm plugin should have a value range of uint64.

![img_v3_02ae_06e7c307-70c7-41a7-80db-dbbb5479112g](https://github.com/deepflowio/deepflow/assets/1598518/f5e91455-7aa3-4f62-b35e-7ff099c7e241)

After calling the import method of the wasm plugin, deepflow-agent will check the memory boundary and perform check_memory. The memory limit in wasm is `4G` (the limit for 32-bit programs). When we perform check_memory, we receive a pointer address, the original parameter type is `i32`, but it should actually be `u32`.

![img_v3_02ae_82c7e0b7-94df-4272-ae0d-77f38858aa9g](https://github.com/deepflowio/deepflow/assets/1598518/a9062560-c665-4f23-b5a5-62237e7dacdd)

###  Fixes the problem of check_memory overflow in wasm plugin
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
 