### PR TITLE
[Agent] Fixes the problem of check_memory overflow in wasm plugin

### DIFF
--- a/agent/src/plugin/wasm/abi_import.rs
+++ b/agent/src/plugin/wasm/abi_import.rs
@@ -40,7 +40,7 @@ use wasmtime_wasi::snapshots::preview_1::add_wasi_snapshot_preview1_to_linker;
 
     note that the caller storeData.parse_ctx is Always None
 */
-pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32, level: i32) {
+pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32, level: u32) {
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mut buf = vec![0u8; len as usize];
 
@@ -72,7 +72,7 @@ pub(super) fn wasm_log(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32, 
 }
 
 // check_memory must invoke first in almost import function
-fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: i32, len: i32, func_name: &str) -> bool {
+fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: u32, len: u32, func_name: &str) -> bool {
     let mem = caller.get_export("memory").unwrap().into_memory().unwrap();
     let mem_size = mem.data_size(caller.as_context());
     if (b + len) as usize > mem_size {
@@ -96,7 +96,7 @@ fn check_memory(caller: &mut Caller<'_, StoreDataType>, b: i32, len: i32, func_n
     //export vm_read_ctx_base
     func vmReadCtxBase(b *byte, length int) int
 */
-pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     /*
         wasm vm read the parse ctx, host need sesrialize the parse param to bytes and write to the vm.
         b is the wasm ptr indicate the addr bias from instance memory.
@@ -133,7 +133,7 @@ pub(super) fn vm_read_ctx_base(mut caller: Caller<'_, StoreDataType>, b: i32, le
     //export vm_read_payload
     func vmReadPayload(b *byte, length int) int
 */
-pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_PAYLOAD) {
         return 0;
     }
@@ -179,8 +179,8 @@ pub(super) fn vm_read_payload(mut caller: Caller<'_, StoreDataType>, b: i32, len
 */
 pub(super) fn vm_read_http_req_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_HTTP_REQ) {
         return 0;
@@ -224,8 +224,8 @@ pub(super) fn vm_read_http_req_info(
 */
 pub(super) fn vm_read_http_resp_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_VM_READ_HTTP_RESP) {
         return 0;
@@ -271,8 +271,8 @@ pub(super) fn vm_read_http_resp_info(
 */
 pub(super) fn host_read_l7_protocol_info(
     mut caller: Caller<'_, StoreDataType>,
-    b: i32,
-    len: i32,
+    b: u32,
+    len: u32,
 ) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_HOST_READ_L7_PROTOCOL_INFO) {
         return 0;
@@ -354,7 +354,7 @@ pub(super) fn host_read_l7_protocol_info(
     //export host_read_str_result
     func hostReadStrResult(b *byte, length int) bool
 */
-pub(super) fn host_read_str_result(mut caller: Caller<'_, StoreDataType>, b: i32, len: i32) -> i32 {
+pub(super) fn host_read_str_result(mut caller: Caller<'_, StoreDataType>, b: u32, len: u32) -> i32 {
     if !check_memory(&mut caller, b, len, IMPORT_FUNC_HOST_READ_STR_RESULT) {
         return 0;
     }

--- a/agent/src/plugin/wasm/host.rs
+++ b/agent/src/plugin/wasm/host.rs
@@ -54,9 +54,9 @@ pub(super) const IMPORT_FUNC_VM_READ_HTTP_RESP: &str = "vm_read_http_resp_info";
 pub(super) const IMPORT_FUNC_HOST_READ_L7_PROTOCOL_INFO: &str = "host_read_l7_protocol_info";
 pub(super) const IMPORT_FUNC_HOST_READ_STR_RESULT: &str = "host_read_str_result";
 
-pub(super) const LOG_LEVEL_INFO: i32 = 0;
-pub(super) const LOG_LEVEL_WARN: i32 = 1;
-pub(super) const LOG_LEVEL_ERR: i32 = 2;
+pub(super) const LOG_LEVEL_INFO: u32 = 0;
+pub(super) const LOG_LEVEL_WARN: u32 = 1;
+pub(super) const LOG_LEVEL_ERR: u32 = 2;
 
 pub const WASM_EXPORT_FUNC_NAME: [&'static str; 4] = [
     EXPORT_FUNC_CHECK_PAYLOAD,


### PR DESCRIPTION
### This PR is for:

- Agent

###  Fixes the problem of check_memory overflow in wasm plugin
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
 