### PR TITLE
[ingester] add log key word for ckwrite failed

### DIFF
--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -330,7 +330,7 @@ func (w *CKWriter) writeItems(queueID, connID int, items []CKItem) error {
 	if IsNil(ck) {
 		if err := w.ResetConnection(connID); err != nil {
 			time.Sleep(time.Second * 10)
-			return fmt.Errorf("can not connect to clickhouse: %s", err)
+			return fmt.Errorf("write block failed, can not connect to clickhouse: %s", err)
 		}
 		ck = w.conns[connID]
 	}
@@ -340,13 +340,13 @@ func (w *CKWriter) writeItems(queueID, connID int, items []CKItem) error {
 	if IsNil(batch) {
 		w.batchs[batchID], err = ck.PrepareBatch(context.Background(), w.prepare)
 		if err != nil {
-			return err
+			return fmt.Errorf("prepare batch item write block failed: %s", err)
 		}
 		batch = w.batchs[batchID]
 	} else {
 		batch, err = ck.PrepareReuseBatch(context.Background(), w.prepare, batch)
 		if err != nil {
-			return err
+			return fmt.Errorf("prepare reuse batch item write block failed: %s", err)
 		}
 		w.batchs[batchID] = batch
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


