### PR TITLE
[Agent] Fixes wrong doc time and wrong doc_flag in collector

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -825,11 +825,15 @@ impl Stash {
                 Entry::Occupied(o) => {
                     let mut doc = o.remove();
                     doc.meter.sequential_merge(&meter);
+                    doc.timestamp = self.start_time.as_secs() as u32;
+                    doc.flags |= self.doc_flag;
                     self.push_closed_doc(BoxedDocument(Box::new(doc)));
                 }
                 Entry::Vacant(_) => {
                     let mut doc = Document::new(meter);
                     doc.tagger = tagger;
+                    doc.timestamp = self.start_time.as_secs() as u32;
+                    doc.flags |= self.doc_flag;
                     self.push_closed_doc(BoxedDocument(Box::new(doc)));
                 }
             }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong doc time and wrong doc_flag in collector
#### Steps to reproduce the bug
-
#### Changes to fix the bug
- Set the timestamp and doc_flag of closed_doc before pushing
#### Affected branches
- main
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
