### PR TITLE
[eBPF] Modify the calculation of the offset value for 'ipv6only'

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1329,8 +1329,7 @@ static int update_offset_map_from_btf_vmlinux(struct bpf_tracer *t)
 	    kernel_struct_field_offset(obj, "sock_common", "skc_num");
 	int struct_sock_skc_state_offset =
 	    kernel_struct_field_offset(obj, "sock_common", "skc_state");
-	int struct_sock_common_ipv6only_offset =
-	    kernel_struct_field_offset(obj, "sock_common", "skc_flags");
+	int struct_sock_common_ipv6only_offset = struct_sock_skc_state_offset + 1;
 
 	if (copied_seq_offs < 0 || write_seq_offs < 0 || files_offs < 0 ||
 	    sk_flags_offs < 0 || struct_files_struct_fdt_offset < 0 ||


### PR DESCRIPTION
[eBPF] Modify the calculation of the offset value for 'ipv6only'

### This PR is for:

- Agent



#### Affected branches
- main
- v6.4
- v6.3
- v6.2