### PR TITLE
[Agent] Fixes quadruple_generator and collector drop_before_window

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -1178,13 +1178,12 @@ impl Collector {
         receiver: Receiver<Box<FlowMeterWithFlow>>,
         sender: DebugSender<BoxedDocument>,
         metric_type: MetricsType,
-        delay_seconds: u32,
+        delay_seconds: u64,
         stats: &Arc<stats::Collector>,
         config: CollectorAccess,
         ntp_diff: Arc<AtomicI64>,
         agent_mode: RunningMode,
     ) -> Self {
-        let delay_seconds = delay_seconds as u64;
         let (kind, name) = match metric_type {
             MetricsType::MINUTE => {
                 if delay_seconds < MINUTE || delay_seconds >= MINUTE * 2 {
@@ -1320,13 +1319,12 @@ impl L7Collector {
         l7_receiver: Receiver<Box<AppMeterWithFlow>>,
         sender: DebugSender<BoxedDocument>,
         metric_type: MetricsType,
-        delay_seconds: u32,
+        delay_seconds: u64,
         stats: &Arc<stats::Collector>,
         config: CollectorAccess,
         ntp_diff: Arc<AtomicI64>,
         agent_mode: RunningMode,
     ) -> Self {
-        let delay_seconds = delay_seconds as u64;
         let (kind, name) = match metric_type {
             MetricsType::MINUTE => {
                 if delay_seconds < MINUTE || delay_seconds >= MINUTE * 2 {

--- a/agent/src/flow_generator/mod.rs
+++ b/agent/src/flow_generator/mod.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 
 const FLOW_METRICS_PEER_SRC: usize = 0;
 const FLOW_METRICS_PEER_DST: usize = 1;
-const TIME_UNIT: Duration = Duration::from_secs(1);
+pub const TIME_UNIT: Duration = Duration::from_secs(1);
 const QUEUE_BATCH_SIZE: usize = 1024;
 const STATISTICAL_INTERVAL: Duration = Duration::from_secs(1);
 const DEFAULT_L7_LOG_PACKET_SIZE: u32 = 256;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes quadruple_generator and collector drop_before_window
The flow_map may send data to qg ahead of time due to the output_buffer exceeding its limit. This can result in the time_window of qg being advanced prematurely, with the maximum advancement time being the flush_interval.
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- flowgen_tolerable_delay is increased by flow.flush_interval to prevent flow_map from pushing the window ahead, which could result in drop_before_window.
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
