### PR TITLE
[eBPF] Remove logic to not trace data sent from the client as the origin

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -2305,7 +2305,6 @@ infer_protocol_1(struct ctx_info_s *ctx,
 			     infer_http_message(infer_buf, count,
 						conn_info)) != MSG_UNKNOWN) {
 				inferred_message.protocol = PROTO_HTTP1;
-				conn_info->infer_reliable = 1;
 				return inferred_message;
 			}
 			break;
@@ -2454,7 +2453,6 @@ infer_protocol_1(struct ctx_info_s *ctx,
 	if ((inferred_message.type =
 #endif
 	     infer_http_message(infer_buf, count, conn_info)) != MSG_UNKNOWN) {
-		conn_info->infer_reliable = 1;
 		inferred_message.protocol = PROTO_HTTP1;
 #ifdef LINUX_VER_5_2_PLUS
 	} else if (skip_proto != PROTO_REDIS && (inferred_message.type =

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -130,7 +130,7 @@ struct conn_info_s {
 	__u16 skc_family;	/* PF_INET, PF_INET6... */
 	__u16 sk_type;		/* socket type (SOCK_STREAM, etc) */
 	__u8 skc_ipv6only:1;
-	__u8 infer_reliable:1;	// Is protocol inference reliable?
+	__u8 reserved:1;
 	/*
 	 * Whether the socket l7 protocol type needs
 	 * to be confirmed again.

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -146,11 +146,7 @@ struct trace_key_t {
 } __attribute__((packed));
 
 struct trace_info_t {
-	/*
-	 * Whether traceID is zero ?
-	 * For the client to actively send request, set traceID to zero.
-	 */
-	bool is_trace_id_zero;
+	__u8  reserve;
 	__u32 update_time; // 从系统开机开始到创建/更新时的间隔时间单位是秒
 	__u32 peer_fd;	   // 用于socket之间的关联
 	__u64 thread_trace_id; // 线程追踪ID


### PR DESCRIPTION
The reason for removal:

- We already have tracing tree pruning functionality, which can prune invalid traces based on the time range of the root node (span).

- The following scenario requires the removal of the non-tracing logic:

```
                 Requset threadID   Response threadID   Requset traceID   Response traceID
------------------------------------------------------------------------------------------
server process   TID-A              TID-B               traceID-A         0 [3]
client process   TID-B              TID-B               0 [1]             0 [2]
```
As we can see, because the client process serves as the starting point for sending data, its request traceID is 0 (as indicated by [1]), and due to previous non-tracing logic, the value at [2] is also 0. Consequently, the data from the server and the client cannot be associated. By removing the non-tracing logic, [2] and [3] will generate a non-zero valid traceID, enabling the association of the two sets of data.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.4

Fixes #6361




