### PR TITLE
[ingester] fix db field captured_request_byte wrong

### DIFF
--- a/server/querier/db_descriptions/clickhouse/metrics/flow_log/l7_flow_log
+++ b/server/querier/db_descriptions/clickhouse/metrics/flow_log/l7_flow_log
@@ -5,7 +5,7 @@ session_length       ,                      , counter    , Throughput      , 111
 request_length       , request_length       , counter    , Throughput      , 111
 response_length      , response_length      , counter    , Throughput      , 111
 sql_affected_rows    , sql_affected_rows    , counter    , Throughput      , 111
-captured_request_byte  , captured_response_byte , counter , Throughput     , 111
+captured_request_byte  , captured_request_byte ,  counter , Throughput     , 111
 captured_response_byte , captured_response_byte , counter , Throughput     , 111
 direction_score      , direction_score      , bounded_gauge      , Throughput      , 111
 log_count            ,                      , counter    , Throughput      , 111        


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


