### PR TITLE
[Agent] Add Exception::IntegrationSocketError to the AUTO_CLEAR_BITS exception list

### DIFF
--- a/agent/src/exception.rs
+++ b/agent/src/exception.rs
@@ -34,6 +34,7 @@ impl ExceptionHandler {
         | Exception::LogFileExceeded as u64
         | Exception::ControllerSocketError as u64
         | Exception::AnalyzerSocketError as u64
+        | Exception::IntegrationSocketError as u64
         | Exception::NpbSocketError as u64;
 
     pub fn set(&self, e: Exception) {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the persistent IntegrationSocketError exception
#### Steps to reproduce the bug
- Once an IntegrationSocketError occurs, even if the situation returns to normal, it will continue to occur because it is not automatically cleared.
#### Changes to fix the bug
- Add Exception::IntegrationSocketError to the AUTO_CLEAR_BITS exception list
#### Affected branches
- main
- v6.5
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
