### PR TITLE
[Server] Fixes the failure in configuring l7-log-session-slot-capacity

### DIFF
--- a/server/agent_config/config.go
+++ b/server/agent_config/config.go
@@ -147,7 +147,7 @@ type StaticConfig struct {
 	IngressFlavour                     *string                     `yaml:"ingress-flavour,omitempty"`
 	GrpcBufferSize                     *int                        `yaml:"grpc-buffer-size,omitempty"`            // 单位：M
 	L7LogSessionAggrTimeout            *string                     `yaml:"l7-log-session-aggr-timeout,omitempty"` // 单位: s
-	L7LogSessionQueueSize              *int                        `yaml:"l7-log-session-queue-size,omitempty"`
+	L7LogSessionSlotCapacity           *int                        `yaml:"l7-log-session-slot-capacity,omitempty"`
 	TapMacScript                       *string                     `yaml:"tap-mac-script,omitempty"`
 	BpfDisabled                        *bool                       `yaml:"bpf-disabled,omitempty"`
 	L7ProtocolInferenceMaxFailCount    *uint64                     `yaml:"l7-protocol-inference-max-fail-count,omitempty"`


### PR DESCRIPTION
### This PR is for:

- Server

### Fixes the failure in configuring l7-log-session-slot-capacity
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
