### PR TITLE
[Agent] Reduce the storage of data where app_meter is empty

### DIFF
--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -299,6 +299,11 @@ impl SubQuadGen {
                 let (is_active_host0, is_active_host1) =
                     check_active(time_in_second.as_secs(), possible_host, &flow);
                 for meter in meters.drain(..) {
+                    // meter.app_meter.traffic.request and meter.app_meter.traffic.response are 0, there is no need to save
+                    if meter.app_meter.traffic.request == 0 && meter.app_meter.traffic.response == 0
+                    {
+                        continue;
+                    }
                     let boxed_app_meter = Box::new(AppMeterWithFlow {
                         app_meter: meter.app_meter,
                         flow: flow.clone(),


### PR DESCRIPTION
### This PR is for:

- Agent

### Reduce the storage of data where app_meter is empty
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
- v6.4
- v6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
