### PR TITLE
[Agent] Add support for the protocol types of l7-log-blacklist

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -494,6 +494,7 @@ pub struct L7ProtocolAdvancedFeatures {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct L7LogBlacklist {
     pub field_name: String,
     pub operator: String,

--- a/server/agent_config/example.yaml
+++ b/server/agent_config/example.yaml
@@ -1069,7 +1069,7 @@ vtap_group_id: g-xxxxxx
   ## Example:
   ##   l7-log-blacklist:
   ##     HTTP:
-  ##     - field_name: request_resource  # endpoint, request_type, request_domain, request_resource
+  ##     - field-name: request_resource  # endpoint, request_type, request_domain, request_resource
   ##       operator: equal  # equal, prefix
   ##       value: somevalue
   ## Note: A l7_flow_log blacklist can be configured for each protocol, preventing request logs matching
@@ -1079,6 +1079,25 @@ vtap_group_id: g-xxxxxx
   #l7-log-blacklist:
   #  HTTP: []
   #  HTTP2: []
+  #  Dubbo: []
+  #  Grpc: []
+  #  SofaRPC: []
+  #  FastCGI: []
+  #  Brpc: []
+  #  MySQL: []
+  #  PostgreSQL: []
+  #  Oracle: []
+  #  Redis: []
+  #  MongoDB: []
+  #  Kafka: []
+  #  MQTT: []
+  #  AMQP: []
+  #  OpenWire: []
+  #  NATS: []
+  #  Pulsar: []
+  #  ZMTP: []
+  #  DNS: []
+  #  TLS: []
   
   ## L7 Protocol Advanced Features
   #l7-protocol-advanced-features:


### PR DESCRIPTION
### This PR is for:

- Agent

### Add support for the protocol types of l7-log-blacklist
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
