### PR TITLE
[Agent] Fixes wrong l7_stats without endpoint

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1568,7 +1568,9 @@ impl FlowMap {
         let last_biz_type = node.tagged_flow.flow.last_biz_type;
         // The original endpoint is inconsistent with new_endpoint
         if let Some(flow_perf_stats) = node.tagged_flow.flow.flow_perf_stats.as_mut() {
-            if (new_endpoint.is_some() && node.tagged_flow.flow.last_endpoint.ne(&new_endpoint))
+            if (node.tagged_flow.flow.last_endpoint.is_some()
+                && new_endpoint.is_some()
+                && node.tagged_flow.flow.last_endpoint.ne(&new_endpoint))
                 || last_biz_type.ne(&new_biz_type)
             {
                 let l7_timeout_count = self


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong l7_stats without endpoint
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- l7_stats will only be output when both last_endpoint and new_endpoint are `Some` and are not equal.
#### Affected branches
- main
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
