### PR TITLE
[eBPF] Modify the symbol name used in the create_ksyms_cache() interface

### DIFF
--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -1279,22 +1279,22 @@ int creat_ksyms_cache(void)
 			     strerror(errno));
 		return -1;
 	}
-	u64 test_addr = kallsyms_lookup_name("finish_task_switch");
+	u64 test_addr = kallsyms_lookup_name("__sys_sendmsg");
 	if (test_addr == 0) {
-		ebpf_warning("Symbol 'finish_task_switch', not find.\n");
+		ebpf_warning("Symbol '__sys_sendmsg', not find.\n");
 		return -1;
 	}
 
 	struct bcc_symbol sym = {};
 	bcc_symcache_resolve_no_demangle(k_resolver, test_addr, &sym);
-	if (strcmp(sym.name, "finish_task_switch")) {
+	if (strcmp(sym.name, "__sys_sendmsg")) {
 		ebpf_warning
-		    ("address 0x%lx target symbol 'finish_task_switch', "
+		    ("address 0x%lx target symbol '__sys_sendmsg', "
 		     "but find symbol is %s.\n", test_addr, sym.name);
 		return -1;
 	}
 
-	ebpf_info("address 0x%lx find symbol 'finish_task_switch', "
+	ebpf_info("address 0x%lx find symbol '__sys_sendmsg', "
 		  "ksyms-cache, created successfully.\n", test_addr);
 	return 0;
 }


### PR DESCRIPTION


### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
