### PR TITLE
[eBPF] Support kernel interface names with the ".isra" suffix

### DIFF
--- a/agent/src/ebpf/user/profile/profile_common.c
+++ b/agent/src/ebpf/user/profile/profile_common.c
@@ -1092,7 +1092,7 @@ bool check_profiler_regex(struct profiler_context *ctx, const char *name)
 		if (g_ctx_array[i] == NULL)
 			continue;
 
-		if (ctx != NULL) {
+		if (ctx != NULL && ctx->name != NULL) {
 			if (strcmp(g_ctx_array[i]->name, ctx->name))
 				continue;
 		}


### PR DESCRIPTION
Handle cases where the kernel interface name includes the ".isra" suffix for compatibility.


### This PR is for:

- Agent


#### Affected branches
- main
- v6.5