### PR TITLE
[ingester] split off-cpu profile by splitting granularity

### DIFF
--- a/server/ingester/profile/config/config.go
+++ b/server/ingester/profile/config/config.go
@@ -28,12 +28,13 @@ import (
 var log = logging.MustGetLogger("profile.config")
 
 type Config struct {
-	Base                 *config.Config
-	CKWriterConfig       config.CKWriterConfig `yaml:"profile-ck-writer"`
-	ProfileTTL           int                   `yaml:"profile-ttl-hour"`
-	DecoderQueueCount    int                   `yaml:"profile-decoder-queue-count"`
-	DecoderQueueSize     int                   `yaml:"profile-decoder-queue-size"`
-	CompressionAlgorithm *string               `yaml:"profile-compression-algorithm"`
+	Base                       *config.Config
+	CKWriterConfig             config.CKWriterConfig `yaml:"profile-ck-writer"`
+	ProfileTTL                 int                   `yaml:"profile-ttl-hour"`
+	DecoderQueueCount          int                   `yaml:"profile-decoder-queue-count"`
+	DecoderQueueSize           int                   `yaml:"profile-decoder-queue-size"`
+	CompressionAlgorithm       *string               `yaml:"profile-compression-algorithm"`
+	OffCpuSplittingGranularity int                   `yaml:"profile-off-cpu-splitting-granularity"`
 }
 
 type ProfileConfig struct {
@@ -41,9 +42,10 @@ type ProfileConfig struct {
 }
 
 const (
-	DefaultProfileTTL        = 72 // hour
-	DefaultDecoderQueueCount = 2
-	DefaultDecoderQueueSize  = 1 << 14
+	DefaultProfileTTL                 = 72 // hour
+	DefaultDecoderQueueCount          = 2
+	DefaultDecoderQueueSize           = 1 << 14
+	DefaultOffCpuSplittingGranularity = 1
 )
 
 func (c *Config) Validate() error {
@@ -72,11 +74,12 @@ func (c *Config) Validate() error {
 func Load(base *config.Config, path string) *Config {
 	config := &ProfileConfig{
 		Profile: Config{
-			Base:              base,
-			CKWriterConfig:    config.CKWriterConfig{QueueCount: 1, QueueSize: 100000, BatchSize: 51200, FlushTimeout: 5},
-			ProfileTTL:        DefaultProfileTTL,
-			DecoderQueueCount: DefaultDecoderQueueCount,
-			DecoderQueueSize:  DefaultDecoderQueueSize,
+			Base:                       base,
+			CKWriterConfig:             config.CKWriterConfig{QueueCount: 1, QueueSize: 100000, BatchSize: 51200, FlushTimeout: 5},
+			ProfileTTL:                 DefaultProfileTTL,
+			DecoderQueueCount:          DefaultDecoderQueueCount,
+			DecoderQueueSize:           DefaultDecoderQueueSize,
+			OffCpuSplittingGranularity: DefaultOffCpuSplittingGranularity,
 		},
 	}
 	if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/server/ingester/profile/dbwriter/profile.go
+++ b/server/ingester/profile/dbwriter/profile.go
@@ -131,14 +131,14 @@ func ProfileColumns() []*ckdb.Column {
 		ckdb.NewColumn("ip6", ckdb.IPv6).SetComment("IPV6地址"),
 		ckdb.NewColumn("is_ipv4", ckdb.UInt8).SetComment("是否为IPv4地址").SetIndex(ckdb.IndexMinmax),
 
-		ckdb.NewColumn("app_service", ckdb.String).SetComment("应用名称, 用户配置上报"),
+		ckdb.NewColumn("app_service", ckdb.LowCardinalityString).SetComment("应用名称, 用户配置上报"),
 		ckdb.NewColumn("profile_location_str", ckdb.String).SetComment("单次 profile 堆栈"),
 		ckdb.NewColumn("profile_value", ckdb.Int64).SetComment("profile self value"),
-		ckdb.NewColumn("profile_value_unit", ckdb.String).SetComment("profile value 的单位"),
-		ckdb.NewColumn("profile_event_type", ckdb.String).SetComment("剖析类型"),
+		ckdb.NewColumn("profile_value_unit", ckdb.LowCardinalityString).SetComment("profile value 的单位"),
+		ckdb.NewColumn("profile_event_type", ckdb.LowCardinalityString).SetComment("剖析类型"),
 		ckdb.NewColumn("profile_create_timestamp", ckdb.DateTime64us).SetIndex(ckdb.IndexSet).SetComment("client 端聚合时间"),
 		ckdb.NewColumn("profile_in_timestamp", ckdb.DateTime64us).SetComment("DeepFlow 的写入时间，同批上报的批次数据具备相同的值"),
-		ckdb.NewColumn("profile_language_type", ckdb.String).SetComment("语言类型"),
+		ckdb.NewColumn("profile_language_type", ckdb.LowCardinalityString).SetComment("语言类型"),
 		ckdb.NewColumn("profile_id", ckdb.String).SetComment("含义等同 l7_flow_log 的 span_id"),
 		ckdb.NewColumn("trace_id", ckdb.String).SetComment("含义等同 l7_flow_log 的 trace_id"),
 		ckdb.NewColumn("span_name", ckdb.String).SetComment("含义等同 l7_flow_log 的 endpoint"),
@@ -269,6 +269,16 @@ func ReleaseInProcess(p *InProcessProfile) {
 	p.TagNames = tagNames
 	p.TagValues = tagValues
 	poolInProcess.Put(p)
+}
+
+func (p *InProcessProfile) Clone() *InProcessProfile {
+	c := AcquireInProcess()
+	*c = *p
+	c.TagNames = make([]string, len(p.TagNames))
+	copy(p.TagNames, p.TagNames)
+	c.TagValues = make([]string, len(p.TagValues))
+	copy(p.TagValues, p.TagValues)
+	return c
 }
 
 func (p *InProcessProfile) FillProfile(input *storage.PutInput,

--- a/server/ingester/profile/dbwriter/profile_writer.go
+++ b/server/ingester/profile/dbwriter/profile_writer.go
@@ -73,13 +73,13 @@ func (p *ProfileWriter) GetCounter() interface{} {
 	return counter
 }
 
-func (p *ProfileWriter) Write(m interface{}) {
-	inProcess := m.(*InProcessProfile)
+func (p *ProfileWriter) Write(m []interface{}) {
+	inProcess := m[0].(*InProcessProfile)
 	inProcess.GenerateFlowTags(p.flowTagWriter.Cache)
 	p.flowTagWriter.WriteFieldsAndFieldValuesInCache()
 
-	atomic.AddInt64(&p.counter.ProfilesCount, 1)
-	p.ckWriter.Put(m)
+	atomic.AddInt64(&p.counter.ProfilesCount, int64(len(m)))
+	p.ckWriter.Put(m...)
 }
 
 func NewProfileWriter(msgType datatype.MessageType, decoderIndex int, config *config.Config) (*ProfileWriter, error) {

--- a/server/ingester/profile/profile/profile.go
+++ b/server/ingester/profile/profile/profile.go
@@ -82,6 +82,7 @@ func NewProfiler(msgType datatype.MessageType, config *config.Config, platformDa
 			i,
 			msgType,
 			*config.CompressionAlgorithm,
+			config.OffCpuSplittingGranularity,
 			platformDatas[i],
 			queue.QueueReader(decodeQueues.FixedMultiQueue[i]),
 			profileWriter,

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -524,6 +524,9 @@ ingester:
   ## profile compression algorithm, default is zstd, empty string for not compress
   #profile-compression-algorithm: "zstd"
 
+  ## off-cpu pofile splitting granularity, 0 mean disable splitting (unit: second)
+  #profile-off-cpu-splitting-granularity: 1
+
   ## 默认读超时，修改数据保留时长时使用
   #ck-read-timeout: 300
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


