### PR TITLE
[querier] escape single quote and fix promql testcases

### DIFF
--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -319,12 +319,12 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 		if len(value) > 1 {
 			tmpFilters := make([]string, 0, len(value))
 			for _, v := range value {
-				tmpFilters = append(tmpFilters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, v))
+				tmpFilters = append(tmpFilters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, escapeSingleQuote(v)))
 			}
 			filters = append(filters, fmt.Sprintf("(%s)", strings.Join(tmpFilters, " OR ")))
 		} else {
 			// () with only ONE condition in it will cause error
-			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, value[0]))
+			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, escapeSingleQuote(value[0])))
 		}
 
 		if db == "" || db == chCommon.DB_NAME_PROMETHEUS || db == chCommon.DB_NAME_EXT_METRICS {
@@ -988,11 +988,11 @@ func (p *prometheusReader) parseQueryRequestToSQL(ctx context.Context, queryReq 
 		if len(value) > 1 {
 			tmpFilters := make([]string, 0, len(value))
 			for _, v := range value {
-				tmpFilters = append(tmpFilters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, v))
+				tmpFilters = append(tmpFilters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, escapeSingleQuote(v)))
 			}
 			filters = append(filters, fmt.Sprintf("(%s)", strings.Join(tmpFilters, " OR ")))
 		} else {
-			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, value[0]))
+			filters = append(filters, fmt.Sprintf("%s %s '%s'", tagMatcher, operation, escapeSingleQuote(value[0])))
 		}
 
 		if isDeepFlowTag && cap(groupBy) == 0 {
@@ -1188,6 +1188,7 @@ func formatEnumTag(tagName string) (string, bool) {
 	_, exists := tagdescription.TAG_ENUMS[enumFile]
 	if !exists {
 		enumFile = fmt.Sprintf("%s.%s", enumFile, config.Cfg.Language)
+		_, exists = tagdescription.TAG_ENUMS[enumFile]
 	}
 	if exists {
 		return fmt.Sprintf("Enum(%s)", tagName), exists
@@ -1233,4 +1234,8 @@ func removeDeepFlowPrefix(tag string) string {
 
 func removeTagPrefix(tag string) string {
 	return strings.Replace(tag, "tag_", "", 1)
+}
+
+func escapeSingleQuote(v string) string {
+	return strings.Replace(v, "'", "''", -1)
 }

--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -75,6 +75,11 @@ func TestMain(m *testing.M) {
 			AutoTaggingPrefix:       "df_",
 			ExternalTagCacheSize:    1024,
 			ExternalTagLoadInterval: 300,
+			Cache: cfg.PrometheusCache{
+				RemoteReadCache:    false,
+				ResponseCache:      false,
+				CacheCleanInterval: 100,
+			},
 		},
 	}
 	// run for test
@@ -165,10 +170,14 @@ func TestParseMetric(t *testing.T) {
 
 func TestPromReaderTransToSQL(t *testing.T) {
 	executor := NewPrometheusExecutor(5 * time.Minute)
+	executor.extraLabelCache = map[string]*lru.Cache[string, string]{
+		"1": lru.NewCache[string, string](100),
+	}
 	executor.extraLabelCache["1"].Add("k8s_label_k8s_app", "k8s.label/k8s_app")
 	prometheusReader := &prometheusReader{
 		getExternalTagFromCache: executor.convertExternalTagToQuerierAllowTag,
 		addExternalTagToCache:   executor.addExtraLabelsToCache,
+		orgID:                   "1",
 	}
 	endMs := time.Now().UnixMicro()
 	startMs := endMs - 5*60*1e3 // minus 5mins
@@ -342,6 +351,15 @@ func TestPromReaderTransToSQL(t *testing.T) {
 			db:       "flow_metrics",
 			hasError: false,
 		},
+
+		// filter escape
+		{
+
+			hints:    promqlHints{matcher: "node_cpu_seconds_total{instance=\"'demo\"}"},
+			input:    "node_cpu_seconds_total{instance=\"'demo\"}",
+			output:   fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,value,`tag` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = '''demo'  ORDER BY timestamp desc LIMIT %s", startS, endS, limit),
+			hasError: false,
+		},
 	}
 
 	Convey("TestPromReaderTransToSQL_Query_Parse_1", t, func() {
@@ -352,8 +370,11 @@ func TestPromReaderTransToSQL(t *testing.T) {
 
 			queries := make([]*prompb.Query, 0, 1)
 			matchers := make([]*prompb.LabelMatcher, 0, len(labelMatchers[0]))
-
+			metric_name_from_testcase := ""
 			for _, l := range labelMatchers[0] {
+				if l.Name == "__name__" {
+					metric_name_from_testcase = l.Value
+				}
 				matchers = append(matchers, &prompb.LabelMatcher{
 					Type:  prompb.LabelMatcher_Type(l.Type),
 					Name:  l.Name,
@@ -383,7 +404,7 @@ func TestPromReaderTransToSQL(t *testing.T) {
 				So(sql, ShouldEqual, p.output)
 				So(db, ShouldEqual, p.db)
 				So(ds, ShouldEqual, p.ds)
-				So(metricName, ShouldEqual, p.hints.matcher)
+				So(metricName, ShouldEqual, metric_name_from_testcase)
 			} else {
 				So(err, ShouldNotBeNil)
 			}
@@ -397,7 +418,9 @@ func TestParsePromQLTag(t *testing.T) {
 		extraLabelCache: map[string]*lru.Cache[string, string]{"1": lru.NewCache[string, string](1)},
 	}
 	executor.extraLabelCache["1"].Add("app_kubernetes_io_managed_by", "app.kubernetes.io/managed-by")
-	p := &prometheusReader{}
+	p := &prometheusReader{
+		orgID: "1",
+	}
 	p.getExternalTagFromCache = executor.convertExternalTagToQuerierAllowTag
 	tagdescription.TAG_ENUMS["l7_protocol"] = []*tagdescription.TagEnum{{Value: 20, DisplayName: "HTTP"}}
 	tagdescription.TAG_ENUMS["auto_service_type.ch"] = []*tagdescription.TagEnum{{Value: 1, DisplayName: "云服务器"}}
@@ -490,6 +513,9 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 	endMs := end * 1000
 	min_5 := 5 * time.Minute
 	var interval int64 = 14 * 1000
+	queryInterval := ((startMs % interval) + min_interval.Milliseconds()) / 1e3
+	rateInterval := (startMs % interval) / 1e3
+	irateInterval := (startMs%min_interval.Milliseconds() + min_interval.Milliseconds()) / 1e3
 
 	// instant query
 	instantQueryTestcases := []queryRequestParse{
@@ -497,7 +523,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 			input: &QueryHint{
 				start: startMs,
 				end:   endMs,
-				step:  0,
+				step:  interval,
 				query: "eval sum(rate(node_cpu_seconds_total[5m])) by (cpu)",
 				funcs: []functionCall{
 					{Range: min_5, Name: "rate"},
@@ -509,7 +535,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: "",
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(toUnixTimestamp(time),1) as _last_timestamp,Percentile(toUnixTimestamp(time),0) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
 			err:    nil,
 		},
 
@@ -624,7 +650,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Sum(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,FastTrans(tag) as __labels_index__,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
 			err:    nil,
 		},
 
@@ -663,6 +689,24 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Last(Derivative(value,tag)) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
 			err:    nil,
 		},
+
+		{
+			input: &QueryHint{
+				start: startMs,
+				end:   endMs,
+				step:  0,
+				query: "eval irate(node_cpu_seconds_total[5m])",
+				funcs: []functionCall{{Name: "irate", Range: min_5}},
+				matchers: []*labels.Matcher{
+					{Name: "__name__", Type: labels.MatchEqual, Value: "node_cpu_seconds_total"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "localhost"},
+					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
+					{Name: "instance", Type: labels.MatchEqual, Value: "'demo"},
+				},
+			},
+			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Last(Derivative(value,tag)) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' AND `tag.instance` = '''demo' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			err:    nil,
+		},
 	}
 
 	// range query
@@ -683,7 +727,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: "",
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(toUnixTimestamp(time),1) as _last_timestamp,Percentile(toUnixTimestamp(time),0) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
 			err:    nil,
 		},
 
@@ -702,7 +746,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,FastTrans(tag) as __labels_index__,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,FastTrans(tag) as __labels_index__,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 
@@ -721,7 +765,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,`tag`,Max(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,`tag`,Max(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 
@@ -759,7 +803,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,`tag`,1 as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,`tag`,1 as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 
@@ -778,7 +822,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,`tag`,Last(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,`tag`,Sum(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 
@@ -798,7 +842,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,`tag`,Last(value) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Sum(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 
@@ -817,7 +861,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(value, 0.5) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", (startMs%interval)/1e3, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1, '', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(value, 0.5) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", queryInterval, start, end),
 			err:    nil,
 		},
 		{
@@ -833,7 +877,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,`tag`,Last(Derivative(value,tag)) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", start, end),
+			output: fmt.Sprintf("SELECT time(time, 10, 1,'', %d) AS timestamp,`tag`,Last(Derivative(value,tag)) as value FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY `tag`,timestamp ORDER BY timestamp desc LIMIT 1000000", irateInterval, start, end),
 			err:    nil,
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes query with single quote and enum query error
#### Steps to reproduce the bug
- query with enum
#### Changes to fix the bug
- fix enum file search
- fix single quote escape
#### Affected branches
- v6.5