### PR TITLE
[eBPF] Adjust cycle to push data every 10ms & adjust datadump time

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -19,6 +19,7 @@
  * SPDX-License-Identifier: GPL-2.0
  */
 
+#include <linux/bpf_perf_event.h>
 #include "config.h"
 #include "include/socket_trace.h"
 #include "include/task_struct_utils.h"
@@ -2070,63 +2071,6 @@ exit:
 	return 0;
 }
 
-// /sys/kernel/debug/tracing/events/syscalls/sys_enter_getppid
-// Here, the tracepoint is used to periodically send the data residing in the cache but not
-// yet transmitted to the user-level receiving program for processing.
-TPPROG(sys_enter_getppid) (struct syscall_comm_enter_ctx * ctx) {
-	// Only pre-specified Pid is allowed to trigger.
-	if (!check_pid_validity())
-		return 0;
-
-	int k0 = 0;
-	struct __socket_data_buffer *v_buff =
-	    bpf_map_lookup_elem(&NAME(data_buf), &k0);
-	if (v_buff) {
-		if (v_buff->events_num > 0) {
-			struct __socket_data *v =
-			    (struct __socket_data *)&v_buff->data[0];
-			if ((bpf_ktime_get_ns() - v->timestamp * NS_PER_US) >
-			    NS_PER_SEC) {
-				__u32 buf_size =
-				    (v_buff->len +
-				     offsetof(typeof
-					      (struct __socket_data_buffer),
-					      data))
-				    & (sizeof(*v_buff) - 1);
-				/* 
-				 * Note that when 'buf_size == 0', it indicates that the data being
-				 * sent is at its maximum value (sizeof(*v_buff)), and it should
-				 * be sent accordingly.
-				 */
-				if (buf_size < sizeof(*v_buff) && buf_size > 0) {
-					/* 
-					 * Use 'buf_size + 1' instead of 'buf_size' to circumvent
-					 * (Linux 4.14.x) length checks.
-					 */
-					bpf_perf_event_output(ctx,
-							      &NAME
-							      (socket_data),
-							      BPF_F_CURRENT_CPU,
-							      v_buff,
-							      buf_size + 1);
-				} else {
-					bpf_perf_event_output(ctx,
-							      &NAME
-							      (socket_data),
-							      BPF_F_CURRENT_CPU,
-							      v_buff,
-							      sizeof(*v_buff));
-				}
-
-				v_buff->events_num = 0;
-				v_buff->len = 0;
-			}
-		}
-	}
-
-	return 0;
-}
-
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_socket/format
 TPPROG(sys_exit_socket) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
@@ -2633,6 +2577,63 @@ PROGTP(io_event) (void *ctx) {
 		trace_io_event_common(ctx, data_args, T_EGRESS, id);
 		active_write_args_map__delete(&id);
 		return 0;
+	}
+
+	return 0;
+}
+
+/*
+ * Here, the perf event is used to periodically send the data residing in
+ * the cache but not yet transmitted to the user-level receiving program
+ * for processing.
+ */
+SEC("perf_event")
+int bpf_push_socket_data(struct bpf_perf_event_data *ctx)
+{
+	int k0 = 0;
+	struct __socket_data_buffer *v_buff =
+	    bpf_map_lookup_elem(&NAME(data_buf), &k0);
+	if (v_buff) {
+		if (v_buff->events_num > 0) {
+			struct __socket_data *v =
+			    (struct __socket_data *)&v_buff->data[0];
+			if ((bpf_ktime_get_ns() - v->timestamp * NS_PER_US) >
+			    NS_PER_SEC) {
+				__u32 buf_size =
+				    (v_buff->len +
+				     offsetof(typeof
+					      (struct __socket_data_buffer),
+					      data))
+				    & (sizeof(*v_buff) - 1);
+				/* 
+				 * Note that when 'buf_size == 0', it indicates that the data being
+				 * sent is at its maximum value (sizeof(*v_buff)), and it should
+				 * be sent accordingly.
+				 */
+				if (buf_size < sizeof(*v_buff) && buf_size > 0) {
+					/* 
+					 * Use 'buf_size + 1' instead of 'buf_size' to circumvent
+					 * (Linux 4.14.x) length checks.
+					 */
+					bpf_perf_event_output(ctx,
+							      &NAME
+							      (socket_data),
+							      BPF_F_CURRENT_CPU,
+							      v_buff,
+							      buf_size + 1);
+				} else {
+					bpf_perf_event_output(ctx,
+							      &NAME
+							      (socket_data),
+							      BPF_F_CURRENT_CPU,
+							      v_buff,
+							      sizeof(*v_buff));
+				}
+
+				v_buff->events_num = 0;
+				v_buff->len = 0;
+			}
+		}
 	}
 
 	return 0;

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -743,6 +743,34 @@ bool is_process(int pid)
 	return __is_process(pid, false);
 }
 
+char *get_timestamp_from_us(u64 microseconds)
+{
+#define TIME_STR_SIZE 32
+
+	time_t seconds = microseconds / US_IN_SEC;
+	long remainder_microseconds = microseconds % US_IN_SEC;
+
+	struct tm *local_time = localtime(&seconds);
+
+	int year = local_time->tm_year + 1900;
+	int month = local_time->tm_mon + 1;
+	int day = local_time->tm_mday;
+	int hour = local_time->tm_hour;
+	int minute = local_time->tm_min;
+	int second = local_time->tm_sec;
+
+	char *str;
+	str = malloc(TIME_STR_SIZE);
+	if (str == NULL) {
+		ebpf_warning("malloc() failed.\n");
+		return NULL;
+	}
+
+	snprintf(str, TIME_STR_SIZE, "%d-%02d-%02d %02d:%02d:%02d.%ld", year,
+		 month, day, hour, minute, second, remainder_microseconds);
+	return str;
+}
+
 static char *__gen_datetime_str(const char *fmt, u64 ns)
 {
 	const int strlen = DATADUMP_FILE_PATH_SIZE;

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -32,6 +32,8 @@
 #define PORT_NUM_MAX	65536
 #define NS_IN_SEC       1000000000ULL
 #define NS_IN_MSEC      1000000ULL
+#define US_IN_SEC	1000000ULL
+#define MS_IN_SEC       1000ULL
 #define TIME_TYPE_NAN   1
 #define TIME_TYPE_SEC   0
 
@@ -293,6 +295,7 @@ int generate_random_integer(int max_value);
  * a non-zero value represents the address of the kernel symbol.
  */
 u64 kallsyms_lookup_name(const char *name);
+char *get_timestamp_from_us(u64 microseconds);
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -177,6 +177,14 @@ enum {
 #define MAX_PUSH_MSG_TIME_INTERVAL 1000000000ULL	/* 1 seconds */
 
 /*
+ * The kernel uses bundled burst to send data to the user.
+ * The implementation method is that all CPUs trigger timeout checks and send
+ * the data resident in the eBPF buffer. This value is the periodic time, unit
+ * is milliseconds.
+ */
+#define KICK_KERN_PERIOD 10
+
+/*
  * timer config
  */
 
@@ -188,12 +196,9 @@ enum {
 #define EVENT_TIMER_TICK_US    10000
 
 /*
- * The kernel uses bundled burst to send data to the user.
- * The implementation method is that all CPUs trigger timeout checks and send
- * the data resident in the eBPF buffer. This value is the periodic time, unit
- * is milliseconds.
+ * Trigger kernel adaptation.
  */
-#define KICK_KERN_PERIOD 10	// 10 ticks(100 milliseconds)
+#define TRIG_KERN_ADAPT_PERIOD 10 // 10 ticks(100 millisecond)
 
 /*
  * System boot time update cycle time, unit is milliseconds.

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -177,9 +177,6 @@ static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_fork");
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exec");
 
-	// 周期性触发用于缓存的数据的超时检查
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");
-
 	// clear trace connection
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_close");
 	// fetch close info
@@ -1095,6 +1092,7 @@ static int check_kern_adapt_and_state_update(void)
 		CLIB_MEMORY_BARRIER();
 		add_probes_act(ACT_DETACH);
 		set_period_event_invalid("check-kern-adapt");
+		set_period_event_invalid("trigger_kern_adapt");
 		t->adapt_success = true;
 	}
 
@@ -2015,7 +2013,8 @@ int running_socket_tracer(tracer_callback_t handle,
 	struct bpf_tracer *tracer =
 	    setup_bpf_tracer(SK_TRACER_NAME, bpf_load_buffer_name,
 			     bpf_bin_buffer, buffer_sz, tps,
-			     thread_nr, NULL, NULL, (void *)handle, 0);
+			     thread_nr, NULL, NULL, (void *)handle,
+			     MS_IN_SEC / KICK_KERN_PERIOD);
 	if (tracer == NULL)
 		return -EINVAL;
 
@@ -2117,6 +2116,12 @@ int running_socket_tracer(tracer_callback_t handle,
 
 	// Configure l7 protocol ports
 	config_proto_ports_bitmap(tracer);
+
+	/*
+	 * Enable periodic perf events and periodically poll to push
+	 * socket data residing in the kernel to a user-space program.
+	 */
+	tracer->enable_sample = true;
 
 	if (tracer_hooks_attach(tracer))
 		return -EINVAL;
@@ -2701,7 +2706,7 @@ static void print_socket_data(struct socket_bpf_data *sd)
 	if (!allow_datadump(sd))
 		return;
 
-	char *timestamp = gen_timestamp_str(0);
+	char *timestamp = get_timestamp_from_us(sd->timestamp);
 	if (timestamp == NULL)
 		return;
 


### PR DESCRIPTION
- Adjust the datadump time to occur between kernel data captures.
- Here, the perf event is used to periodically send the data residing in the cache but not yet transmitted to the user-level receiving program for processing.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.5