### PR TITLE
[eBPF] Adjust the timestamp of socket data to real-time actual time

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -244,13 +244,21 @@ static inline uint32_t align32pow2(uint32_t x)
 	return x + 1;
 }
 
+uint64_t gettime(clockid_t clk_id, int flag);
+static inline int64_t get_sysboot_time_ns(void)
+{
+	int64_t real_time, monotonic_time;
+	real_time = gettime(CLOCK_REALTIME, TIME_TYPE_NAN);
+	monotonic_time = gettime(CLOCK_MONOTONIC, TIME_TYPE_NAN);
+	return (real_time - monotonic_time);
+}
+
 bool is_core_kernel(void);
 int get_cpus_count(bool **mask);
 void clear_residual_probes();
 int max_locked_memory_set_unlimited(void);
 int sysfs_write(const char *file_name, char *v);
 int sysfs_read_num(const char *file_name);
-uint64_t gettime(clockid_t clk_id, int flag);
 uint32_t get_sys_uptime(void);
 u64 get_sys_btime_msecs(void);
 u64 get_process_starttime(pid_t pid);

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -320,9 +320,14 @@ prefetch_and_process_data(struct bpf_tracer *t, int nb_rx, void **datas_burst)
 		if (block_head->fn != NULL) {
 			block_head->fn(sd);
 		} else {
+			int64_t boot_time = get_sysboot_time_ns();
 			if (t->datadump)
-				t->datadump((void *)sd);
-
+				t->datadump((void *)sd, boot_time);
+			/*
+			 * Modify socket data time to real time, 
+			 * time precision is in microseconds.
+			 */
+			sd->timestamp = (sd->timestamp + boot_time) / NS_IN_USEC;
 			callback(sd);
 		}
 

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -365,7 +365,7 @@ struct bpf_tracer {
 	int dispatch_workers_nr;                // Number of dispatch threads
 	struct queue queues[MAX_CPU_NR];        // Dispatch queues, each dispatch thread has its corresponding queue.
 	void *process_fn;                       // Callback interface passed from the application for data processing
-	void (*datadump) (void *data);          // eBPF data dump handle
+	void (*datadump) (void *data, int64_t boot_time); // eBPF data dump handle
 
 	/*
 	 * perf ring-buffer from kernel to user.


### PR DESCRIPTION
Here are the adjustments made:

- Adjusted the timestamp of socket data to real-time actual time.
- Added relative time (MONOTONIC type time) to the data dump, along with a sequence number for identifying any data disorder issues in the dump.


### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
