### PR TITLE
[Agent] Remove redundant l7 stat

### DIFF
--- a/agent/src/flow_generator/error.rs
+++ b/agent/src/flow_generator/error.rs
@@ -28,9 +28,7 @@ pub enum Error {
     InvalidPacketTimestamp,
     #[error("tcp retransmission packet")]
     RetransPacket,
-    // call LayerFlowPerf::parse return Error(Layer7 mismatch_response_count)
-    #[error("layer7 request not found")]
-    L7ReqNotFound(u64),
+
     #[error("zero payload len")]
     ZeroPayloadLen,
     #[error("invalid ip protocol")]

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -1676,11 +1676,6 @@ impl FlowMap {
                         _ => {}
                     }
                 }
-                Err(Error::L7ReqNotFound(c)) => {
-                    self.flow_perf_counter
-                        .mismatched_response
-                        .fetch_add(c, Ordering::Relaxed);
-                }
                 Err(Error::L7ProtocolUnknown) => {
                     self.flow_perf_counter
                         .unknown_l7_protocol

--- a/agent/src/flow_generator/perf/stats.rs
+++ b/agent/src/flow_generator/perf/stats.rs
@@ -43,7 +43,6 @@ pub struct FlowPerfCounter {
     pub invalid_packet_count: AtomicU64,
 
     // L7 stats
-    pub mismatched_response: AtomicU64,
     pub unknown_l7_protocol: AtomicU64,
 }
 
@@ -51,7 +50,6 @@ impl RefCountable for FlowPerfCounter {
     fn get_counters(&self) -> Vec<Counter> {
         let ignored = self.ignored_packet_count.swap(0, Ordering::Relaxed);
         let invalid = self.invalid_packet_count.swap(0, Ordering::Relaxed);
-        let mismatched = self.mismatched_response.swap(0, Ordering::Relaxed);
         let unknown_l7_protocol = self.unknown_l7_protocol.swap(0, Ordering::Relaxed);
 
         vec![
@@ -64,11 +62,6 @@ impl RefCountable for FlowPerfCounter {
                 "invalid_packet_count",
                 CounterType::Counted,
                 CounterValue::Unsigned(invalid),
-            ),
-            (
-                "l7_mismatch_response",
-                CounterType::Counted,
-                CounterValue::Unsigned(mismatched),
             ),
             (
                 "unknown_l7_protocol",

--- a/server/agent_config/example.yaml
+++ b/server/agent_config/example.yaml
@@ -1052,7 +1052,7 @@ vtap_group_id: g-xxxxxx
     #"HTTP2": "1-65535" # for both HTTP2 and gRPC
     #"SofaRPC": "1-65535"
     #"FastCGI": "1-65535"
-    #"Brpc": "1-65535"
+    #"bRPC": "1-65535"
     #"Dubbo": "1-65535"
     #"MySQL": "1-65535"
     #"PostgreSQL": "1-65535"


### PR DESCRIPTION
### This PR is for:

- Agent

### Remove redundant l7 stat
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.


