### PR TITLE
[Agent] Fixes the wrong dns perf_stats

### DIFF
--- a/agent/src/flow_generator/protocol_logs/dns.rs
+++ b/agent/src/flow_generator/protocol_logs/dns.rs
@@ -231,7 +231,7 @@ impl L7ProtocolParserInterface for DnsLog {
             info.set_is_on_blacklist(config);
         }
         if !info.is_on_blacklist && !self.last_is_on_blacklist {
-            if info.query_type == DNS_RESPONSE {
+            if info.msg_type == LogMessageType::Response {
                 self.perf_stats.as_mut().map(|p| p.inc_resp());
                 if info.status == L7ResponseStatus::ClientError {
                     self.perf_stats.as_mut().map(|p| p.inc_req_err());


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the wrong dns perf_stats
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.


