### PR TITLE
[Agent] Fixes wrong cached l7 log

### DIFF
--- a/agent/src/flow_generator/protocol_logs/parser.rs
+++ b/agent/src/flow_generator/protocol_logs/parser.rs
@@ -653,6 +653,7 @@ impl SessionQueue {
                 _ => {
                     if v.base_info.start_time > item.base_info.start_time {
                         self.send(item);
+                        slot.put(key, v);
                     } else {
                         // swap out old item and send
                         self.counter.cached_request_resource.fetch_sub(


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong cached l7 log
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
- v6.4
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
