### PR TITLE
[ingester] add comment for version and get orgids

### DIFF
--- a/server/libs/datatype/droplet-message.go
+++ b/server/libs/datatype/droplet-message.go
@@ -207,7 +207,7 @@ type FlowHeader struct {
 	OrgID     uint16
 	Reserved1 uint16
 	AgentID   uint16
-	Reserved2 uint8 //
+	Reserved2 uint8
 }
 
 func (h *FlowHeader) Decode(buf []byte) {
@@ -220,6 +220,7 @@ func (h *FlowHeader) Decode(buf []byte) {
 		h.AgentID = binary.LittleEndian.Uint16(buf[AGENTID_OFFSET:])
 		// reserved2
 	} else {
+		// decoding the header of the old version (version <= v6.5.8)
 		h.TeamID = binary.LittleEndian.Uint32(buf[FLOW_TEAMID_OFFSET:])
 		h.OrgID = uint16(binary.LittleEndian.Uint32(buf[FLOW_ORGID_OFFSET:]))
 		h.AgentID = binary.LittleEndian.Uint16(buf[FLOW_VTAPID_OFFSET:])


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


