### PR TITLE
[eBPF] Unify the names of eBPF progs & Add 'MSG_COMMON'

### DIFF
--- a/agent/src/ebpf/kernel/go_http2.bpf.c
+++ b/agent/src/ebpf/kernel/go_http2.bpf.c
@@ -542,8 +542,7 @@ static __inline bool skip_http2_uprobe(struct ebpf_proc_info *info)
 }
 
 // func (cc *http2ClientConn) writeHeader(name, value string)
-SEC("uprobe/go_http2ClientConn_writeHeader")
-int uprobe_go_http2ClientConn_writeHeader(struct pt_regs *ctx)
+UPROG(go_http2ClientConn_writeHeader) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -602,8 +601,7 @@ int uprobe_go_http2ClientConn_writeHeader(struct pt_regs *ctx)
 }
 
 // func (cc *http2ClientConn) writeHeaders(streamID uint32, endStream bool, maxFrameSize int, hdrs []byte) error
-SEC("uprobe/go_http2ClientConn_writeHeaders")
-int uprobe_go_http2ClientConn_writeHeaders(struct pt_regs *ctx)
+UPROG(go_http2ClientConn_writeHeaders) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -648,8 +646,7 @@ int uprobe_go_http2ClientConn_writeHeaders(struct pt_regs *ctx)
 }
 
 // func (sc *http2serverConn) processHeaders(f *http2MetaHeadersFrame) error
-SEC("uprobe/go_http2serverConn_processHeaders")
-int uprobe_go_http2serverConn_processHeaders(struct pt_regs *ctx)
+UPROG(go_http2serverConn_processHeaders) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -688,8 +685,7 @@ int uprobe_go_http2serverConn_processHeaders(struct pt_regs *ctx)
 }
 
 // func (sc *http2serverConn) writeHeaders(st *http2stream, headerData *http2writeResHeaders) error
-SEC("uprobe/go_http2serverConn_writeHeaders")
-int uprobe_go_http2serverConn_writeHeaders(struct pt_regs *ctx)
+UPROG(go_http2serverConn_writeHeaders) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -778,8 +774,7 @@ int uprobe_go_http2serverConn_writeHeaders(struct pt_regs *ctx)
 }
 
 // func (rl *http2clientConnReadLoop) handleResponse(cs *http2clientStream, f *http2MetaHeadersFrame) (*Response, error)
-SEC("uprobe/go_http2clientConnReadLoop_handleResponse")
-int uprobe_go_http2clientConnReadLoop_handleResponse(struct pt_regs *ctx)
+UPROG(go_http2clientConnReadLoop_handleResponse) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -818,8 +813,7 @@ int uprobe_go_http2clientConnReadLoop_handleResponse(struct pt_regs *ctx)
 }
 
 // func (l *loopyWriter) writeHeader(streamID uint32, endStream bool, hf []hpack.HeaderField, onWrite func()) error
-SEC("uprobe/go_loopyWriter_writeHeader")
-int uprobe_go_loopyWriter_writeHeader(struct pt_regs *ctx)
+UPROG(go_loopyWriter_writeHeader) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -863,8 +857,7 @@ int uprobe_go_loopyWriter_writeHeader(struct pt_regs *ctx)
 }
 
 // func (t *http2Server) operateHeaders(frame *http2.MetaHeadersFrame, handle func(*Stream), traceCtx func(context.Context, string) context.Context) (fatal bool)
-SEC("uprobe/go_http2Server_operateHeaders")
-int uprobe_go_http2Server_operateHeaders(struct pt_regs *ctx)
+UPROG(go_http2Server_operateHeaders) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -904,8 +897,7 @@ int uprobe_go_http2Server_operateHeaders(struct pt_regs *ctx)
 }
 
 // func (t *http2Client) operateHeaders(frame *http2.MetaHeadersFrame)
-SEC("uprobe/go_http2Client_operateHeaders")
-int uprobe_go_http2Client_operateHeaders(struct pt_regs *ctx)
+UPROG(go_http2Client_operateHeaders) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -1099,9 +1091,7 @@ static __inline int fill_http2_dataframe_data(struct __http2_stack *stack,
 
 // grpc dataframe
 // func (fr *Framer) checkFrameOrder(f Frame) error
-SEC("uprobe/golang_org_x_net_http2_Framer_checkFrameOrder")
-static int
-uprobe_golang_org_x_net_http2_Framer_checkFrameOrder(struct pt_regs *ctx)
+UPROG(golang_org_x_net_http2_Framer_checkFrameOrder) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)
@@ -1159,9 +1149,7 @@ uprobe_golang_org_x_net_http2_Framer_checkFrameOrder(struct pt_regs *ctx)
 }
 
 // func (f *Framer) WriteDataPadded(streamID uint32, endStream bool, data, pad []byte) error
-SEC("uprobe/golang_org_x_net_http2_Framer_WriteDataPadded")
-static int
-uprobe_golang_org_x_net_http2_Framer_WriteDataPadded(struct pt_regs *ctx)
+UPROG(golang_org_x_net_http2_Framer_WriteDataPadded) (struct pt_regs *ctx)
 {
 	struct member_fields_offset *offset = retrieve_ready_kern_offset();
 	if (offset == NULL)

--- a/agent/src/ebpf/kernel/go_tls.bpf.c
+++ b/agent/src/ebpf/kernel/go_tls.bpf.c
@@ -60,15 +60,14 @@ do { \
 #endif
 
 /*
- *  uprobe_go_tls_write_enter  (In tls_conn_map record A(tcp_seq) before syscall)
+ *      go_tls_write_enter  (In tls_conn_map record A(tcp_seq) before syscall)
  *               |
  *               | - syscall write()
  *               |
- *  uprobe_go_tls_write_exit(return)  lookup A(tcp_seq) from tls_conn_map
+ *      go_tls_write_exit(return)  lookup A(tcp_seq) from tls_conn_map
  *     send to user finally tcp sequence is "A(tcp_seq) + bytes_count"
-#ifdef TLS_DEBUG */
-SEC("uprobe/go_tls_write_enter")
-int uprobe_go_tls_write_enter(struct pt_regs *ctx)
+ */
+UPROG(go_tls_write_enter) (struct pt_regs *ctx)
 {
 	DEFINE_DBG_DATA(dbg_data);
 	submit_debug(1, 0, 0);
@@ -112,8 +111,7 @@ int uprobe_go_tls_write_enter(struct pt_regs *ctx)
 	return 0;
 }
 
-SEC("uprobe/go_tls_write_exit")
-int uprobe_go_tls_write_exit(struct pt_regs *ctx)
+UPROG(go_tls_write_exit) (struct pt_regs *ctx)
 {
 	DEFINE_DBG_DATA(dbg_data);
 	submit_debug(2, 0, 0);
@@ -183,15 +181,14 @@ int uprobe_go_tls_write_exit(struct pt_regs *ctx)
 }
 
 /*
- *  uprobe_go_tls_read_enter  (In tls_conn_map record A(tcp_seq) before syscall)
+ *      go_tls_read_enter  (In tls_conn_map record A(tcp_seq) before syscall)
  *               |
  *               | - syscall read()
  *               |
- *  uprobe_go_tls_read_exit(return)  lookup A(tcp_seq) from tls_conn_map
+ *      go_tls_read_exit(return)  lookup A(tcp_seq) from tls_conn_map
  *     send to user finally tcp sequence is "A(tcp_seq) + bytes_count"
  */
-SEC("uprobe/go_tls_read_enter")
-int uprobe_go_tls_read_enter(struct pt_regs *ctx)
+UPROG(go_tls_read_enter) (struct pt_regs *ctx)
 {
 	DEFINE_DBG_DATA(dbg_data);
 	submit_debug(3, 0, 0);
@@ -236,8 +233,7 @@ int uprobe_go_tls_read_enter(struct pt_regs *ctx)
 	return 0;
 }
 
-SEC("uprobe/go_tls_read_exit")
-int uprobe_go_tls_read_exit(struct pt_regs *ctx)
+UPROG(go_tls_read_exit) (struct pt_regs *ctx)
 {
 	DEFINE_DBG_DATA(dbg_data);
 	submit_debug(4, 0, 0);

--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -256,12 +256,38 @@ _Pragma("GCC error \"PT_GO_REGS_PARM\"");
 
 #define NAME(N)  __##N
 
-#define PROGTP(F) SEC("prog/tp/"__stringify(F)) int bpf_prog_tp__##F
-#define PROGKP(F) SEC("prog/kp/"__stringify(F)) int bpf_prog_kp__##F
-#define KRETPROG(F) SEC("kretprobe/"__stringify(F)) int kretprobe__##F
-#define KPROG(F) SEC("kprobe/"__stringify(F)) int kprobe__##F
-#define TPPROG(F) SEC("tracepoint/syscalls/"__stringify(F)) int bpf_func_##F
-#define TP_SCHED_PROG(F) SEC("tracepoint/sched/"__stringify(F)) int bpf_func_##F
+/*
+ * DeepFlow eBPF program naming convention:
+ *
+ *   'df_<type_identifier>_<probe_name>'
+ *
+ * type_identifier:
+ *   "T"   - tracepoint/syscalls/sys_* / tracepoint/sched/sched_*
+ *   "K"   - kprobe
+ *   "KR"  - kretprobe
+ *   "U"   - uprobe
+ *   "UR"  - uretprobe
+ *   "TP"  - Tailcall eBPF prog of tracepoint type
+ *   "KP"  - Tailcall eBPF prog of kprobe type
+ *
+ * probe_name:
+ *   The name of the tracepoint or the kernel interface.
+ * 
+ * For example:
+ * tracepoint: prog->name:df_T_enter_recvfrom
+ * kprobe: prog->name:df_K_sys_sendmsg
+ * kretprobe: prog->name:df_KR_sys_sendmsg
+ */
+
+#define TP_SYSCALL_PROG(F) SEC("tracepoint/syscalls/sys_"__stringify(F)) int df_T_##F
+#define TP_SCHED_PROG(F) SEC("tracepoint/sched/sched_"__stringify(F)) int df_T_##F
+#define PROGTP(F) SEC("prog/tp/"__stringify(F)) int df_TP_##F
+#define PROGKP(F) SEC("prog/kp/"__stringify(F)) int df_KP_##F
+#define KPROG(F) SEC("kprobe/"__stringify(F)) int df_K_##F
+#define KRETPROG(F) SEC("kretprobe/"__stringify(F)) int df_KR_##F
+#define UPROG(F) SEC("uprobe/"__stringify(F)) int df_U_##F
+#define URETPROG(F) SEC("uretprobe/"__stringify(F)) int df_UR_##F
+#define PERF_EVENT_PROG(F) SEC("perf_event") int df_##F
 
 #ifndef CUR_CPU_IDENTIFIER
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)

--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -42,6 +42,8 @@ enum message_type {
 	MSG_REASM_START,
 	// Segment of data reassembled
 	MSG_REASM_SEG,
+	// Common messages
+	MSG_COMMON,
 
 	// 无法推断协议类型，先在map中存储等下一次的数据
 	// 获取后两者合并，再进行判断。主要场景用于MySQL，Kafka

--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -107,7 +107,7 @@ __protocol_port_check(enum traffic_protocol proto,
 		 * If the "is_set_ports_bitmap()" function is used in both stages,
 		 * there may be the following error when loading an eBPF program in
 		 * the 4.14 kernel:
-		 * `failed. name: bpf_func_sys_exit_sendmmsg, Argument list too long errno: 7`
+		 * `failed. name: df_T_exit_sendmmsg, Argument list too long errno: 7`
 		 * To avoid this situation, it is necessary to differentiate the calls.
 		 */
 		if (prog_num == L7_PROTO_INFER_PROG_1) {

--- a/agent/src/ebpf/kernel/openssl.bpf.c
+++ b/agent/src/ebpf/kernel/openssl.bpf.c
@@ -62,8 +62,7 @@ static int get_fd_from_openssl_ssl(void *ssl)
 }
 
 // int SSL_write(SSL *ssl, const void *buf, int num);
-SEC("uprobe/openssl_write_enter")
-int uprobe_openssl_write_enter(struct pt_regs *ctx)
+UPROG(openssl_write_enter) (struct pt_regs *ctx)
 {
 	void *ssl = (void *)PT_REGS_PARM1(ctx);
 	int fd = get_fd_from_openssl_ssl(ssl);
@@ -79,8 +78,7 @@ int uprobe_openssl_write_enter(struct pt_regs *ctx)
 }
 
 // int SSL_write(SSL *ssl, const void *buf, int num);
-SEC("uretprobe/openssl_write_exit")
-int uprobe_openssl_write_exit(struct pt_regs *ctx)
+UPROG(openssl_write_exit) (struct pt_regs *ctx)
 {
 	__u64 id = bpf_get_current_pid_tgid();
 	struct ssl_ctx_struct *ssl_ctx = ssl_ctx_map__lookup(&id);
@@ -118,8 +116,7 @@ int uprobe_openssl_write_exit(struct pt_regs *ctx)
 }
 
 // int SSL_read(SSL *ssl, void *buf, int num);
-SEC("uprobe/openssl_read_enter")
-int uprobe_openssl_read_enter(struct pt_regs *ctx)
+UPROG(openssl_read_enter) (struct pt_regs *ctx)
 {
 	void *ssl = (void *)PT_REGS_PARM1(ctx);
 	int fd = get_fd_from_openssl_ssl(ssl);
@@ -135,8 +132,7 @@ int uprobe_openssl_read_enter(struct pt_regs *ctx)
 }
 
 // int SSL_read(SSL *ssl, void *buf, int num);
-SEC("uretprobe/openssl_read_exit")
-int uprobe_openssl_read_exit(struct pt_regs *ctx)
+UPROG(openssl_read_exit) (struct pt_regs *ctx)
 {
 	__u64 id = bpf_get_current_pid_tgid();
 	struct ssl_ctx_struct *ssl_ctx = ssl_ctx_map__lookup(&id);

--- a/agent/src/ebpf/kernel/perf_profiler.bpf.c
+++ b/agent/src/ebpf/kernel/perf_profiler.bpf.c
@@ -68,8 +68,7 @@ MAP_STACK_TRACE(stack_map_b, STACK_MAP_ENTRIES)
  * switching between buffer a and buffer b.
  */
 MAP_ARRAY(profiler_state_map, __u32, __u64, PROFILER_CNT)
- SEC("perf_event")
-int bpf_perf_event(struct bpf_perf_event_data *ctx)
+PERF_EVENT_PROG(oncpu_profile) (struct bpf_perf_event_data *ctx)
 {
 	__u32 count_idx;
 

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1560,7 +1560,7 @@ static __inline void process_syscall_data_vecs(struct pt_regs *ctx, __u64 id,
 /***********************************************************
  * BPF syscall probe/tracepoint function entry-points
  ***********************************************************/
-TPPROG(sys_enter_write) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_write) (struct syscall_comm_enter_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int fd = (int)ctx->fd;
 	char *buf = (char *)ctx->buf;
@@ -1577,7 +1577,7 @@ TPPROG(sys_enter_write) (struct syscall_comm_enter_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_write/format
-TPPROG(sys_exit_write) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_write) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 	// Unstash arguments, and process syscall.
@@ -1594,7 +1594,7 @@ TPPROG(sys_exit_write) (struct syscall_comm_exit_ctx * ctx) {
 }
 
 // ssize_t read(int fd, void *buf, size_t count);
-TPPROG(sys_enter_read) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_read) (struct syscall_comm_enter_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int fd = (int)ctx->fd;
 	char *buf = (char *)ctx->buf;
@@ -1611,7 +1611,7 @@ TPPROG(sys_enter_read) (struct syscall_comm_enter_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_read/format
-TPPROG(sys_exit_read) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_read) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 	// Unstash arguments, and process syscall.
@@ -1629,7 +1629,7 @@ TPPROG(sys_exit_read) (struct syscall_comm_exit_ctx * ctx) {
 
 // ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
 //              const struct sockaddr *dest_addr, socklen_t addrlen);
-TPPROG(sys_enter_sendto) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_sendto) (struct syscall_comm_enter_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int sockfd = (int)ctx->fd;
 
@@ -1649,7 +1649,7 @@ TPPROG(sys_enter_sendto) (struct syscall_comm_enter_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_sendto/format
-TPPROG(sys_exit_sendto) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_sendto) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 
@@ -1672,7 +1672,7 @@ TPPROG(sys_exit_sendto) (struct syscall_comm_exit_ctx * ctx) {
 
 // ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
 //                struct sockaddr *src_addr, socklen_t *addrlen);
-TPPROG(sys_enter_recvfrom) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_recvfrom) (struct syscall_comm_enter_ctx * ctx) {
 	// If flags contains MSG_PEEK, it is returned directly.
 	// ref : https://linux.die.net/man/2/recvfrom
 	if (ctx->flags & MSG_PEEK)
@@ -1693,7 +1693,7 @@ TPPROG(sys_enter_recvfrom) (struct syscall_comm_enter_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_recvfrom/format
-TPPROG(sys_exit_recvfrom) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_recvfrom) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 
@@ -1736,7 +1736,7 @@ KPROG(__sys_sendmsg) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_sendmsg/format
-TPPROG(sys_exit_sendmsg) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_sendmsg) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 	// Unstash arguments, and process syscall.
@@ -1779,7 +1779,7 @@ KPROG(__sys_sendmmsg) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_sendmmsg/format
-TPPROG(sys_exit_sendmmsg) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_sendmmsg) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 
 	int num_msgs = ctx->ret;
@@ -1830,7 +1830,7 @@ KPROG(__sys_recvmsg) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_recvmsg/format
-TPPROG(sys_exit_recvmsg) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_recvmsg) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 	// Unstash arguments, and process syscall.
@@ -1887,7 +1887,7 @@ KPROG(__sys_recvmmsg) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_recvmmsg/format
-TPPROG(sys_exit_recvmmsg) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_recvmmsg) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int num_msgs = ctx->ret;
 	// Unstash arguments, and process syscall.
@@ -1930,7 +1930,7 @@ KPROG(do_writev) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_writev/format
-TPPROG(sys_exit_writev) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_writev) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 
@@ -1971,7 +1971,7 @@ KPROG(do_readv) (struct pt_regs * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_readv/format
-TPPROG(sys_exit_readv) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_readv) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 	struct data_args_t *read_args = active_read_args_map__lookup(&id);
@@ -1986,7 +1986,7 @@ TPPROG(sys_exit_readv) (struct syscall_comm_exit_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_enter_close/format
-TPPROG(sys_enter_close) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_close) (struct syscall_comm_enter_ctx * ctx) {
 	int fd = ctx->fd;
 	//Ignore stdin, stdout and stderr
 	if (fd <= 2)
@@ -2023,7 +2023,7 @@ TPPROG(sys_enter_close) (struct syscall_comm_enter_ctx * ctx) {
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_close/format
-TPPROG(sys_exit_close) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_close) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	struct data_args_t *read_args = active_read_args_map__lookup(&pid_tgid);
 	if (read_args == NULL)
@@ -2072,7 +2072,7 @@ exit:
 }
 
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_socket/format
-TPPROG(sys_exit_socket) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_socket) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	__u64 fd = (__u64) ctx->ret;
 	char comm[TASK_COMM_LEN];
@@ -2104,7 +2104,7 @@ TPPROG(sys_exit_socket) (struct syscall_comm_exit_ctx * ctx) {
 	return 0;
 }
 
-TPPROG(sys_exit_accept) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_accept) (struct syscall_comm_exit_ctx * ctx) {
 	int sockfd = ctx->ret;
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = (__u32) (pid_tgid >> 32);
@@ -2114,7 +2114,7 @@ TPPROG(sys_exit_accept) (struct syscall_comm_exit_ctx * ctx) {
 	return 0;
 }
 
-TPPROG(sys_exit_accept4) (struct syscall_comm_exit_ctx * ctx) {
+TP_SYSCALL_PROG(exit_accept4) (struct syscall_comm_exit_ctx * ctx) {
 	int sockfd = ctx->ret;
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = (__u32) (pid_tgid >> 32);
@@ -2124,7 +2124,7 @@ TPPROG(sys_exit_accept4) (struct syscall_comm_exit_ctx * ctx) {
 	return 0;
 }
 
-TPPROG(sys_enter_connect) (struct syscall_comm_enter_ctx * ctx) {
+TP_SYSCALL_PROG(enter_connect) (struct syscall_comm_enter_ctx * ctx) {
 	int sockfd = ctx->fd;
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 tgid = (__u32) (pid_tgid >> 32);

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1322,7 +1322,7 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 	    time_stamp;
 	v->direction = conn_info->direction;
 	v->syscall_len = syscall_len;
-	v->msg_type = conn_info->message_type;
+	v->msg_type = MSG_COMMON;
 
 	// Reassembly modification type
 	if (sk_info.allow_reassembly) {
@@ -2056,6 +2056,7 @@ TP_SYSCALL_PROG(exit_close) (struct syscall_comm_exit_ctx * ctx) {
 	v->source = DATA_SOURCE_CLOSE;
 	v->syscall_len = 0;
 	v->data_seq = read_args->data_seq;
+	v->msg_type = MSG_COMMON;
 	bpf_get_current_comm(v->comm, sizeof(v->comm));
 	struct tail_calls_context *context =
 	    (struct tail_calls_context *)v->data;
@@ -2549,6 +2550,7 @@ static __inline void trace_io_event_common(void *ctx,
 	v->source = DATA_SOURCE_IO_EVENT;
 
 	v->thread_trace_id = trace_id;
+	v->msg_type = MSG_COMMON;
 	bpf_get_current_comm(v->comm, sizeof(v->comm));
 
 	struct tail_calls_context *context =

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -135,9 +135,10 @@ pub const DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE: u8 = 5;
 #[allow(dead_code)]
 pub const DATA_SOURCE_CLOSE: u8 = 6;
 
-// 消息类型
-// 目前除了 source=EBPF_TYPE_GO_HTTP2_UPROBE 以外,都不能保证这个方向的正确性.
-// go http2 uprobe 目前 只用了MSG_RESPONSE_END, 用于判断流结束.
+// Message types
+// Currently, except for source=EBPF_TYPE_GO_HTTP2_UPROBE, 
+// the correctness of this direction cannot be guaranteed.
+// The go http2 uprobe currently only uses MSG_RESPONSE_END to determine the end of the stream.
 #[allow(dead_code)]
 pub const MSG_REQUEST: u8 = 1;
 #[allow(dead_code)]
@@ -152,6 +153,11 @@ pub const MSG_REASM_START: u8 = 5;
 // The segment of data reassembly.
 #[allow(dead_code)]
 pub const MSG_REASM_SEG: u8 = 6;
+// When the message type obtained by eBPF cannot accurately
+// indicate a request or response, it should be uniformly
+// set to 'MSG_COMMON'.
+#[allow(dead_code)]
+pub const MSG_COMMON: u8 = 7;
 
 //Register event types
 #[allow(dead_code)]

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -38,13 +38,13 @@
 #define MAP_PROGS_JMP_KP_NAME		"__progs_jmp_kp_map"
 #define MAP_PROGS_JMP_TP_NAME		"__progs_jmp_tp_map"
 
-#define PROG_DATA_SUBMIT_NAME_FOR_KP	"bpf_prog_kp__data_submit"
-#define PROG_DATA_SUBMIT_NAME_FOR_TP	"bpf_prog_tp__data_submit"
-#define PROG_OUTPUT_DATA_NAME_FOR_KP	"bpf_prog_kp__output_data"
-#define PROG_OUTPUT_DATA_NAME_FOR_TP	"bpf_prog_tp__output_data"
-#define PROG_IO_EVENT_NAME_FOR_TP	"bpf_prog_tp__io_event"
-#define PROG_PROTO_INFER_FOR_KP		"bpf_prog_kp__proto_infer_2"
-#define PROG_PROTO_INFER_FOR_TP		"bpf_prog_tp__proto_infer_2"
+#define PROG_DATA_SUBMIT_NAME_FOR_KP	"df_KP_data_submit"
+#define PROG_DATA_SUBMIT_NAME_FOR_TP	"df_TP_data_submit"
+#define PROG_OUTPUT_DATA_NAME_FOR_KP	"df_KP_output_data"
+#define PROG_OUTPUT_DATA_NAME_FOR_TP	"df_TP_output_data"
+#define PROG_IO_EVENT_NAME_FOR_TP	"df_TP_io_event"
+#define PROG_PROTO_INFER_FOR_KP		"df_KP_proto_infer_2"
+#define PROG_PROTO_INFER_FOR_TP		"df_TP_proto_infer_2"
 
 // perf profiler
 #define MAP_PERF_PROFILER_BUF_A_NAME	"__profiler_output_a"

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -181,43 +181,43 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "runtime.execute",
-		.probe_func = "runtime_execute",
+		.probe_func = UPROBE_FUNC_NAME(runtime_execute),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "runtime.newproc1",
-		.probe_func = "enter_runtime_newproc1",
+		.probe_func = UPROBE_FUNC_NAME(enter_runtime_newproc1),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "runtime.newproc1",
-		.probe_func = "exit_runtime_newproc1",
+		.probe_func = UPROBE_FUNC_NAME(exit_runtime_newproc1),
 		.is_probe_ret = true,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "crypto/tls.(*Conn).Write",
-		.probe_func = "uprobe_go_tls_write_enter",
+		.probe_func = UPROBE_FUNC_NAME(go_tls_write_enter),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "crypto/tls.(*Conn).Write",
-		.probe_func = "uprobe_go_tls_write_exit",
+		.probe_func = UPROBE_FUNC_NAME(go_tls_write_exit),
 		.is_probe_ret = true,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "crypto/tls.(*Conn).Read",
-		.probe_func = "uprobe_go_tls_read_enter",
+		.probe_func = UPROBE_FUNC_NAME(go_tls_read_enter),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "crypto/tls.(*Conn).Read",
-		.probe_func = "uprobe_go_tls_read_exit",
+		.probe_func = UPROBE_FUNC_NAME(go_tls_read_exit),
 		.is_probe_ret = true,
 	},
 	// HTTP2，symbols select an interface based on the GO version.
@@ -226,13 +226,13 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "net/http.(*http2serverConn).writeHeaders",
-		.probe_func = "uprobe_go_http2serverConn_writeHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2serverConn_writeHeaders),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*serverConn).writeHeaders",
-		.probe_func = "uprobe_go_http2serverConn_writeHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2serverConn_writeHeaders),
 		.is_probe_ret = false,
 	},
 	// http2 server, fetch request headers
@@ -240,13 +240,13 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "net/http.(*http2serverConn).processHeaders",
-		.probe_func = "uprobe_go_http2serverConn_processHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2serverConn_processHeaders),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*serverConn).processHeaders",
-		.probe_func = "uprobe_go_http2serverConn_processHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2serverConn_processHeaders),
 		.is_probe_ret = false,
 	},
 	// http2 client, fetch response headers
@@ -254,13 +254,13 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "net/http.(*http2clientConnReadLoop).handleResponse",
-		.probe_func = "uprobe_go_http2clientConnReadLoop_handleResponse",
+		.probe_func = UPROBE_FUNC_NAME(go_http2clientConnReadLoop_handleResponse),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*clientConnReadLoop).handleResponse",
-		.probe_func = "uprobe_go_http2clientConnReadLoop_handleResponse",
+		.probe_func = UPROBE_FUNC_NAME(go_http2clientConnReadLoop_handleResponse),
 		.is_probe_ret = false,
 	},
 	// http2 client, fetch request headers
@@ -268,13 +268,13 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "net/http.(*http2ClientConn).writeHeader",
-		.probe_func = "uprobe_go_http2ClientConn_writeHeader",
+		.probe_func = UPROBE_FUNC_NAME(go_http2ClientConn_writeHeader),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*ClientConn).writeHeader",
-		.probe_func = "uprobe_go_http2ClientConn_writeHeader",
+		.probe_func = UPROBE_FUNC_NAME(go_http2ClientConn_writeHeader),
 		.is_probe_ret = false,
 	},
 	// http2 client, fetch request headers
@@ -282,13 +282,13 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "net/http.(*http2ClientConn).writeHeaders",
-		.probe_func = "uprobe_go_http2ClientConn_writeHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2ClientConn_writeHeaders),
 		.is_probe_ret = false,
 	},
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*ClientConn).writeHeaders",
-		.probe_func = "uprobe_go_http2ClientConn_writeHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2ClientConn_writeHeaders),
 		.is_probe_ret = false,
 	},
 	// gRPC
@@ -297,7 +297,7 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "google.golang.org/grpc/internal/transport.(*loopyWriter).writeHeader",
-		.probe_func = "uprobe_go_loopyWriter_writeHeader",
+		.probe_func = UPROBE_FUNC_NAME(go_loopyWriter_writeHeader),
 		.is_probe_ret = false,
 	},
 	// grpc client fetch response headers
@@ -305,7 +305,7 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "google.golang.org/grpc/internal/transport.(*http2Client).operateHeaders",
-		.probe_func = "uprobe_go_http2Client_operateHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2Client_operateHeaders),
 		.is_probe_ret = false,
 	},
 	// grpc server fetch request headers
@@ -313,21 +313,21 @@ static struct symbol syms[] = {
 	{
 		.type = GO_UPROBE,
 		.symbol = "google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders",
-		.probe_func = "uprobe_go_http2Server_operateHeaders",
+		.probe_func = UPROBE_FUNC_NAME(go_http2Server_operateHeaders),
 		.is_probe_ret = false,
 	},
 	// grpc datafram read
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*Framer).checkFrameOrder",
-		.probe_func = "uprobe_golang_org_x_net_http2_Framer_checkFrameOrder",
+		.probe_func = UPROBE_FUNC_NAME(golang_org_x_net_http2_Framer_checkFrameOrder),
 		.is_probe_ret = false,
 	},
 	// grpc datafram write
 	{
 		.type = GO_UPROBE,
 		.symbol = "golang.org/x/net/http2.(*Framer).WriteDataPadded",
-		.probe_func = "uprobe_golang_org_x_net_http2_Framer_WriteDataPadded",
+		.probe_func = UPROBE_FUNC_NAME(golang_org_x_net_http2_Framer_WriteDataPadded),
 		.is_probe_ret = false,
 	},
 };

--- a/agent/src/ebpf/user/probe.c
+++ b/agent/src/ebpf/user/probe.c
@@ -32,8 +32,10 @@ int bpf_get_program_fd(void *obj, const char *name, void **p)
 	struct ebpf_prog *prog;
 
 	/*
-	 * tracepoint: prog->name:bpf_func_sys_exit_recvfrom
-	 * kprobe: prog->name:kprobe____sys_sendmsg
+	 * tracepoint(syscall): prog->name:df_T_exit_recvfrom
+	 * tracepoint(sched): prog->name:df_T_process_exec
+	 * kprobe: prog->name:df_K_sys_sendmsg
+	 * kretprobe: prog->name:df_KR_sys_sendmsg
 	 */
 	char prog_name[PROBE_NAME_SZ];
 	int res;
@@ -42,7 +44,7 @@ int bpf_get_program_fd(void *obj, const char *name, void **p)
 	if (strstr(__name, "kprobe/")) {
 		__name += (sizeof("kprobe/") - 1);
 		res =
-		    snprintf((char *)prog_name, sizeof(prog_name), "kprobe__%s",
+		    snprintf((char *)prog_name, sizeof(prog_name), "df_K_%s",
 			     __name);
 		if (res < 0 || res >= sizeof(prog_name)) {
 			ebpf_warning("name (%s) snprintf() failed.\n", __name);
@@ -52,7 +54,7 @@ int bpf_get_program_fd(void *obj, const char *name, void **p)
 		__name += (sizeof("kretprobe/") - 1);
 		res =
 		    snprintf((char *)prog_name, sizeof(prog_name),
-			     "kretprobe__%s", __name);
+			     "df_KR_%s", __name);
 		if (res < 0 || res >= sizeof(prog_name)) {
 			ebpf_warning("name (%s) snprintf() failed.\n", __name);
 			return -1;
@@ -62,9 +64,16 @@ int bpf_get_program_fd(void *obj, const char *name, void **p)
 		while (*p != '\0')
 			if (*p++ == '/')
 				__name = p;
+
+		if (strncmp(__name, "sys_", 4) == 0) {
+			__name += 4;
+		} else if (strncmp(__name, "sched_", 6) == 0) {
+			__name += 6;
+		}
+
 		res =
 		    snprintf((char *)prog_name, sizeof(prog_name),
-			     "bpf_func_%s", __name);
+			     "df_T_%s", __name);
 		if (res < 0 || res >= sizeof(prog_name)) {
 			ebpf_warning("name (%s) snprintf() failed.\n", __name);
 			return -1;
@@ -201,7 +210,7 @@ struct ebpf_link *program__attach_tracepoint(void *prog)
 {
 	// e.g.:
 	// sec_name:  "tracepoint/syscalls/sys_enter_write"
-	// prog name: "bpf_func_sys_enter_write"
+	// prog name: "df_T_enter_write"
 
 	char *sec_name, *category, *name;
 	int len, pfd;

--- a/agent/src/ebpf/user/ssl_tracer.c
+++ b/agent/src/ebpf/user/ssl_tracer.c
@@ -46,25 +46,25 @@ static struct symbol openssl_syms[] = {
 	{
 		.type = OPENSSL_UPROBE,
 		.symbol = "SSL_write",
-		.probe_func = "uprobe_openssl_write_enter",
+		.probe_func = UPROBE_FUNC_NAME(openssl_write_enter),
 		.is_probe_ret = false,
 	},
 	{
 		.type = OPENSSL_UPROBE,
 		.symbol = "SSL_write",
-		.probe_func = "uprobe_openssl_write_exit",
+		.probe_func = UPROBE_FUNC_NAME(openssl_write_exit),
 		.is_probe_ret = true,
 	},
 	{
 		.type = OPENSSL_UPROBE,
 		.symbol = "SSL_read",
-		.probe_func = "uprobe_openssl_read_enter",
+		.probe_func = UPROBE_FUNC_NAME(openssl_read_enter),
 		.is_probe_ret = false,
 	},
 	{
 		.type = OPENSSL_UPROBE,
 		.symbol = "SSL_read",
-		.probe_func = "uprobe_openssl_read_exit",
+		.probe_func = UPROBE_FUNC_NAME(openssl_read_exit),
 		.is_probe_ret = true,
 	},
 };

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -45,7 +45,8 @@
 #include "symbol.h"
 #include <regex.h>
 
-// TODO: 对内存拷贝进行硬件优化。
+#define STRINGIFY(x) #x
+#define UPROBE_FUNC_NAME(N) STRINGIFY(df_U_##N)
 
 #define LOOP_DELAY_US  100000
 


### PR DESCRIPTION
Made the following adjustments：

1 DeepFlow eBPF program naming convention:

     `df_<type_identifier>_<probe_name>`
  - type_identifier:
    "T"   - tracepoint/syscalls/sys_* / tracepoint/sched/sched_*
    "K"   - kprobe
    "KR"  - kretprobe
    "U"   - uprobe
    "UR"  - uretprobe
    "TP"  - Tailcall eBPF prog of tracepoint type
    "KP"  - Tailcall eBPF prog of kprobe type

  - probe_name:
    The name of the tracepoint or the kernel interface.

  - For example:
    tracepoint: prog->name:df_T_enter_recvfrom
    kprobe: prog->name:df_K_sys_sendmsg
    kretprobe: prog->name:df_KR_sys_sendmsg
  
2 Add message type 'MSG_COMMON'
When the message type obtained by eBPF cannot accurately indicate a request or response, it should be uniformly set to 'MSG_COMMON'.


### This PR is for:
- Agent



#### Affected branches
- main
- v6.5