### PR TITLE
[Agent] Fixes the incorrect metrics in some protocols

### DIFF
--- a/agent/src/flow_generator/protocol_logs/mq/openwire.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/openwire.rs
@@ -1911,6 +1911,19 @@ impl L7ProtocolParserInterface for OpenWireLog {
                         self.perf_stats.as_mut().map(|p| p.inc_resp());
                     }
                 }
+                match info.status {
+                    L7ResponseStatus::ClientError => {
+                        self.perf_stats
+                            .as_mut()
+                            .map(|p: &mut L7PerfStats| p.inc_req_err());
+                    }
+                    L7ResponseStatus::ServerError => {
+                        self.perf_stats
+                            .as_mut()
+                            .map(|p: &mut L7PerfStats| p.inc_resp_err());
+                    }
+                    _ => {}
+                }
                 if info.msg_type != LogMessageType::Session {
                     info.cal_rrt(param).map(|rtt| {
                         info.rtt = rtt;

--- a/agent/src/flow_generator/protocol_logs/mq/zmtp.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/zmtp.rs
@@ -646,6 +646,19 @@ impl L7ProtocolParserInterface for ZmtpLog {
                         self.perf_stats.as_mut().map(|p| p.inc_resp());
                     }
                 }
+                match info.status {
+                    L7ResponseStatus::ClientError => {
+                        self.perf_stats
+                            .as_mut()
+                            .map(|p: &mut L7PerfStats| p.inc_req_err());
+                    }
+                    L7ResponseStatus::ServerError => {
+                        self.perf_stats
+                            .as_mut()
+                            .map(|p: &mut L7PerfStats| p.inc_resp_err());
+                    }
+                    _ => {}
+                }
                 info.cal_rrt(param).map(|rtt| {
                     info.rtt = rtt;
                     self.perf_stats.as_mut().map(|p| p.update_rrt(rtt));

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -399,6 +399,19 @@ impl L7ProtocolParserInterface for MysqlLog {
                     self.perf_stats.as_mut().map(|p| p.inc_resp());
                 }
             }
+            match info.status {
+                L7ResponseStatus::ClientError => {
+                    self.perf_stats
+                        .as_mut()
+                        .map(|p: &mut L7PerfStats| p.inc_req_err());
+                }
+                L7ResponseStatus::ServerError => {
+                    self.perf_stats
+                        .as_mut()
+                        .map(|p: &mut L7PerfStats| p.inc_resp_err());
+                }
+                _ => {}
+            }
             if info.msg_type != LogMessageType::Session {
                 info.cal_rrt(param).map(|rrt| {
                     info.rrt = rrt;
@@ -702,7 +715,6 @@ impl MysqlLog {
                     }
                     info.error_message = String::from_utf8_lossy(context).into_owned();
                 }
-                self.perf_stats.as_mut().map(|p| p.inc_resp_err());
             }
             MYSQL_RESPONSE_CODE_OK => {
                 info.status = L7ResponseStatus::Ok;


### PR DESCRIPTION
### This PR is for:

- Agent

###  Fixes the incorrect metrics in some protocols
#### Steps to reproduce the bug
- Some protocols do not have metrics for counting errors.
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.



