### PR TITLE
[eBPF] Fix kprobe-type fork()/clone() cannot obtain the PID

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -262,7 +262,8 @@ struct event_meta {
 // Process execution or exit event data 
 struct process_event_t {
 	struct event_meta meta;
-	__u32 pid; // process ID
+	__u32 pid: 31; // process ID
+	__u32 maybe_thread: 1;
 	__u8 name[TASK_COMM_LEN]; // process name
 };
 

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -617,6 +617,8 @@ static inline bool need_proto_reconfirm(uint16_t l7_proto)
 static void process_event(struct process_event_t *e)
 {
 	if (e->meta.event_type == EVENT_TYPE_PROC_EXEC) {
+		if (e->maybe_thread && !is_user_process(e->pid))
+			return;	
 		update_proc_info_cache(e->pid, PROC_EXEC);
 		go_process_exec(e->pid);
 		ssl_process_exec(e->pid);


### PR DESCRIPTION
In Linux 4.14 and 3.10.0-957, it was found that after restarting the Nginx process, the restarted process could not be captured. This commit is intended to resolve this issue.


### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
