### PR TITLE
[eBPF] Modify iovecs_copy() to prevent data read loss

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -247,10 +247,14 @@ static __inline int iovecs_copy(struct __socket_data *v,
 				size_t syscall_len,
 				__u32 send_len)
 {
-#define LOOP_LIMIT 12
+/*
+ * The number of loops in eBPF is limited; tests have shown that the
+ * Linux 4.14 kernel supports a maximum of 27 iterations.
+ */
+#define LOOP_LIMIT 27
 
 	struct copy_data_s {
-		char data[CAP_DATA_SIZE];
+		char data[sizeof(v->data)];
 	};
 
 	int bytes_copy = 0;


### PR DESCRIPTION
### This PR is for:

- Agent


#### Affected branches
- main
- v6.5
- v6.4
- v6.3