### PR TITLE
fix: agent - eBPF uprobe HTTP2 is missing setting for l7_proto

### DIFF
--- a/agent/src/ebpf/kernel/go_http2.bpf.c
+++ b/agent/src/ebpf/kernel/go_http2.bpf.c
@@ -345,6 +345,7 @@ http2_fill_common_socket_2(struct http2_header_data *data,
 
 		struct socket_info_s sk_info = {
 			.uid = send_buffer->socket_id,
+			.l7_proto = PROTO_HTTP2,
 		};
 
 		if (!socket_info_map__update(&conn_key, &sk_info)) {
@@ -1049,6 +1050,7 @@ static __inline int fill_http2_dataframe_base(struct __http2_stack *stack,
 
 		struct socket_info_s sk_info = {
 			.uid = send_buffer->socket_id,
+			.l7_proto = PROTO_HTTP2,
 		};
 
 		if (!socket_info_map__update(&conn_key, &sk_info)) {


### PR DESCRIPTION

### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
- v6.4
- v6.3
