### PR TITLE
fix: agent - eBPF uprobe HTTP2 is missing setting for l7_proto

### DIFF
--- a/agent/src/ebpf/kernel/go_http2.bpf.c
+++ b/agent/src/ebpf/kernel/go_http2.bpf.c
@@ -345,6 +345,7 @@ http2_fill_common_socket_2(struct http2_header_data *data,
 
 		struct socket_info_s sk_info = {
 			.uid = send_buffer->socket_id,
+			.l7_proto = PROTO_HTTP2,
 		};
 
 		if (!socket_info_map__update(&conn_key, &sk_info)) {
@@ -1049,6 +1050,7 @@ static __inline int fill_http2_dataframe_base(struct __http2_stack *stack,
 
 		struct socket_info_s sk_info = {
 			.uid = send_buffer->socket_id,
+			.l7_proto = PROTO_HTTP2,
 		};
 
 		if (!socket_info_map__update(&conn_key, &sk_info)) {


### PR DESCRIPTION
If the l7_proto is not set for Golang uprobe HTTP/2, its value becomes unpredictable. If this value happens to be PROTO_MYSQL, the MySQL inference might mistakenly interpret this Golang uprobe HTTP/2 data as MySQL data, resulting in duplicate data retrieval (one from uprobe HTTP/2 and one from kprobe MySQL). This misidentification of HTTP/2 as MySQL can also cause issues with uprobe syscall deduplication during Rust processing.


### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
- v6.4
- v6.3
