### PR TITLE
fix: agent - eBPF DNS cannot obtain network tuple data (#7131)

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -290,6 +290,9 @@ struct data_args_t {
 		ssize_t bytes_count;	// io event
 		ssize_t data_seq;	// Use for socket close
 	};
+	// Scenario for using sendto() with a specified address
+	__u16 port;
+	__u8 addr[16];
 } __attribute__ ((packed));
 
 struct syscall_comm_enter_ctx {
@@ -317,6 +320,18 @@ struct sched_comm_exit_ctx {
 	char comm[16];		/*     offset:8;       size:16 */
 	pid_t pid;		/*     offset:24;      size:4  */
 	int prio;		/*     offset:28;      size:4  */
+};
+
+struct syscall_sendto_enter_ctx {
+	__u64 __pad_0;
+	int __syscall_nr;  // offset:8     size:4 
+	__u32 __pad_1;     // offset:12    size:4
+	int fd;   	   //offset:16;      size:8; signed:0;
+	void * buff;       //offset:24;      size:8; signed:0;
+	size_t len;        //offset:32;      size:8; signed:0;
+	unsigned int flags;       //offset:40;      size:8; signed:0;
+	struct sockaddr * addr;   //offset:48;      size:8; signed:0;
+	int addr_len;     //offset:56;      size:8; signed:0;
 };
 
 struct sched_comm_fork_ctx {

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -125,7 +125,8 @@ struct socket_info_s {
 	 */
 	__u16 allow_reassembly: 1;
 	__u16 finish_reasm: 1; // Has the reassembly been completed?
-	__u16 unused_bits: 14; 
+	__u16 udp_pre_set_addr: 1; // Is the socket address pre-set during the system call phase in the UDP protocol?
+	__u16 unused_bits: 13; 
  	__u32 reasm_bytes; // The amount of data bytes that have been reassembled.
 
 	/*
@@ -142,7 +143,10 @@ struct socket_info_s {
 	 * involves reading 4 bytes followed by reading the remaining data.
 	 * Here, the pre-read data is stored for subsequent protocol analysis.
 	 */
-	__u8 prev_data[EBPF_CACHE_SIZE];
+	union {
+		__u8 prev_data[EBPF_CACHE_SIZE];
+		__u8 ipaddr[EBPF_CACHE_SIZE]; // IP address for UDP sendto()
+	};
 	__u8 direction: 1;
 	__u8 pre_direction: 1;
 	__u8 unused: 2;
@@ -152,6 +156,7 @@ struct socket_info_s {
 	union {
 		__u8  encoding_type;    // Currently used for OpenWire encoding inference.
 		__s32 correlation_id;   // Currently used for Kafka protocol inference.
+		__u16 port;		// Port for UDP sendto()
 	};
 
 	__u32 peer_fd;		// Used to record the peer fd for data transfer between sockets.


### PR DESCRIPTION
The `sendto` functions are generally used in UDP protocols, but can also be used in TCP after the connect function is called. `sendto()` use the datagram method to transmit data.
In the connectionless datagram socket mode, since the local socket has not established a connection with the remote machine, the destination address should be specified when sending data. The sendto() function prototype is:

`int sendto(socket s, const void *msg, int len, unsigned int flags, const
            struct sockaddr *to, int tolen);`

The sendto() function has two more parameters than the send() function. The "to" parameter specifies the IP address and port number information of the destination machine.

Our current logic is as follows: network tuple information (`IP`, `PORT`) is obtained by reading the corresponding fields of the kernel structure `struct sock_common`. Since the IP address and port are specified in the sendto() system calls, the tuple data will not be populated into the kernel structure `struct sock_common`. As a result, we cannot obtain the tuple information. Therefore, when entering these types of system calls, we need to save this information beforehand.



### This PR is for:

- Agent


#### Affected branches
- main
- v6.5
- v6.4
- v6.3
