### PR TITLE
fix: agent - eBPF DNS cannot obtain network tuple data (#7131)

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -281,6 +281,9 @@ struct data_args_t {
 		ssize_t bytes_count;	// io event
 		ssize_t data_seq;	// Use for socket close
 	};
+	// Scenario for using sendto() with a specified address
+	__u16 port;
+	__u8 addr[16];
 } __attribute__ ((packed));
 
 struct syscall_comm_enter_ctx {
@@ -308,6 +311,18 @@ struct sched_comm_exit_ctx {
 	char comm[16];		/*     offset:8;       size:16 */
 	pid_t pid;		/*     offset:24;      size:4  */
 	int prio;		/*     offset:28;      size:4  */
+};
+
+struct syscall_sendto_enter_ctx {
+	__u64 __pad_0;
+	int __syscall_nr;  // offset:8     size:4 
+	__u32 __pad_1;     // offset:12    size:4
+	int fd;   	   //offset:16;      size:8; signed:0;
+	void * buff;       //offset:24;      size:8; signed:0;
+	size_t len;        //offset:32;      size:8; signed:0;
+	unsigned int flags;       //offset:40;      size:8; signed:0;
+	struct sockaddr * addr;   //offset:48;      size:8; signed:0;
+	int addr_len;     //offset:56;      size:8; signed:0;
 };
 
 struct sched_comm_fork_ctx {

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -117,14 +117,21 @@ struct socket_info_t {
 	 * involves reading 4 bytes followed by reading the remaining data.
 	 * Here, the pre-read data is stored for subsequent protocol analysis.
 	 */
-	__u8 prev_data[EBPF_CACHE_SIZE];
+	union {
+		__u8 prev_data[EBPF_CACHE_SIZE];
+		__u8 ipaddr[EBPF_CACHE_SIZE]; // IP address for UDP sendto()
+	};
 	__u8 direction: 1;
 	__u8 pre_direction: 1;
 	__u8 msg_type: 2;	// Store data type, values are MSG_UNKNOWN(0), MSG_REQUEST(1), MSG_RESPONSE(2)
-	__u8 role: 3;           // Socket role identifier: ROLE_CLIENT, ROLE_SERVER, ROLE_UNKNOWN
+	__u8 role: 2;           // Socket role identifier: ROLE_CLIENT, ROLE_SERVER, ROLE_UNKNOWN
+	__u8 udp_pre_set_addr: 1; // Is the socket address pre-set during the system call phase in the UDP protocol?
 	__u8 tls_end: 1;	// Use the Identity TLS protocol to infer whether it has been completed
 	bool need_reconfirm;    // L7 protocol inference requiring confirmation.
-	__s32 correlation_id;   // Currently used for Kafka protocol inference.
+	union {
+		__s32 correlation_id;   // Currently used for Kafka protocol inference.
+		__u16 port;		// Port for UDP sendto()
+	};
 
 	__u32 peer_fd;		// Used to record the peer fd for data transfer between sockets.
 

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -19,6 +19,8 @@
  * SPDX-License-Identifier: GPL-2.0
  */
 
+#include <arpa/inet.h>
+#include <linux/bpf_perf_event.h>
 #include "config.h"
 #include "include/socket_trace.h"
 #include "include/task_struct_utils.h"
@@ -171,6 +173,8 @@ static __inline void delete_socket_info(__u64 conn_key,
 	if (!socket_info_map__delete(&conn_key)) {
 		__sync_fetch_and_add(&trace_stats->socket_map_count, -1);
 	}
+
+	socket_role_map__delete(&conn_key);
 }
 
 static __u32 __inline get_tcp_write_seq_from_fd(int fd)
@@ -1172,6 +1176,14 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		sk_info.update_time = time_stamp / NS_PER_SEC;
 		sk_info.need_reconfirm = conn_info->need_reconfirm;
 		sk_info.correlation_id = conn_info->correlation_id;
+		if (conn_info->tuple.l4_protocol == IPPROTO_UDP &&
+		    args->port > 0) {
+			bpf_probe_read_kernel(sk_info.ipaddr,
+					      sizeof(sk_info.ipaddr),
+					      args->addr);
+			sk_info.udp_pre_set_addr = 1;
+			sk_info.port = args->port;
+		}
 
 		/*
 		 * MSG_PRESTORE 目前只用于MySQL, Kafka协议推断
@@ -1256,6 +1268,18 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 	v->tuple.dport = conn_info->tuple.dport;
 	v->tuple.num = conn_info->tuple.num;
 	v->data_type = conn_info->protocol;
+	if (conn_info->tuple.l4_protocol == IPPROTO_UDP &&
+	    args->port > 0) {
+		if (conn_info->skc_family == PF_INET) {
+			bpf_probe_read_kernel(v->tuple.daddr, 4,
+					      args->addr);
+			v->tuple.addr_len = 4;
+		} else if (conn_info->skc_family == PF_INET6) {
+			bpf_probe_read_kernel(v->tuple.daddr, 16,
+					      args->addr);
+			v->tuple.addr_len = 16;
+		}
+	}
 
 	__u32 *socket_role = socket_role_map__lookup(&conn_key);
 	v->socket_role = socket_role ? *socket_role : 0;
@@ -1372,7 +1396,7 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 
 static __inline int process_data(struct pt_regs *ctx, __u64 id,
 				 const enum traffic_direction direction,
-				 const struct data_args_t *args,
+				 struct data_args_t *args,
 				 ssize_t bytes_count,
 				 const struct process_data_extra *extra)
 {
@@ -1412,6 +1436,18 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 	}
 
 	init_conn_info(id >> 32, args->fd, conn_info, sk, offset);
+	if (conn_info->tuple.l4_protocol == IPPROTO_UDP &&
+	    conn_info->tuple.dport == 0) {
+		conn_info->tuple.dport = args->port;
+		if (conn_info->tuple.dport == 0 &&
+		    is_socket_info_valid(conn_info->socket_info_ptr) &&
+		    conn_info->socket_info_ptr->udp_pre_set_addr) {
+			conn_info->tuple.dport = conn_info->socket_info_ptr->port;
+			args->port = conn_info->tuple.dport;
+			bpf_probe_read_kernel(args->addr, sizeof(args->addr),
+					      conn_info->socket_info_ptr->ipaddr);
+		}
+	}
 
 	conn_info->direction = direction;
 
@@ -1480,7 +1516,7 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 static __inline void process_syscall_data(struct pt_regs *ctx, __u64 id,
 					  const enum traffic_direction
 					  direction,
-					  const struct data_args_t *args,
+					  struct data_args_t *args,
 					  ssize_t bytes_count)
 {
 	struct process_data_extra extra = {
@@ -1501,7 +1537,7 @@ static __inline void process_syscall_data(struct pt_regs *ctx, __u64 id,
 static __inline void process_syscall_data_vecs(struct pt_regs *ctx, __u64 id,
 					       const enum traffic_direction
 					       direction,
-					       const struct data_args_t *args,
+					       struct data_args_t *args,
 					       ssize_t bytes_count)
 {
 	struct process_data_extra extra = {
@@ -1589,8 +1625,28 @@ TPPROG(sys_exit_read) (struct syscall_comm_exit_ctx * ctx) {
 	return 0;
 }
 
-// ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
-//              const struct sockaddr *dest_addr, socklen_t addrlen);
+/*
+ * The `sendto` functions are generally used in UDP protocols, but can also be used
+ * in TCP after the connect function is called. `sendto()` use the datagram method
+ * to transmit data.
+ * In the connectionless datagram socket mode, since the local socket has not
+ * established a connection with the remote machine, the destination address should
+ * be specified when sending data. The sendto() function prototype is:
+ *
+ * `int sendto(socket s, const void *msg, int len, unsigned int flags, const
+ *             struct sockaddr *to, int tolen);`
+ *
+ * The sendto() function has two more parameters than the send() function. The "to"
+ * parameter specifies the IP address and port number information of the destination
+ * machine.
+ * 
+ * Our current logic is as follows: network tuple information (IP, PORT) is obtained
+ * by reading the corresponding fields of the kernel structure 'struct sock_common'.
+ * Since the IP address and port are specified in the sendto() system calls,
+ * the tuple data will not be populated into the kernel structure 'struct sock_common'.
+ * As a result, we cannot obtain the tuple information. Therefore, when entering these
+ * types of system calls, we need to save this information beforehand.
+ */
 TPPROG(sys_enter_sendto) (struct syscall_comm_enter_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	int sockfd = (int)ctx->fd;
@@ -1605,6 +1661,25 @@ TPPROG(sys_enter_sendto) (struct syscall_comm_enter_ctx * ctx) {
 	write_args.buf = buf;
 	write_args.enter_ts = bpf_ktime_get_ns();
 	write_args.tcp_seq = get_tcp_write_seq_from_fd(sockfd);
+	if (write_args.tcp_seq == 0) {
+		struct syscall_sendto_enter_ctx *sendto_ctx =
+			(struct syscall_sendto_enter_ctx *)ctx;
+		struct sockaddr_in addr = { 0 };
+		bpf_probe_read_user(&addr, sizeof(addr), sendto_ctx->addr);
+		write_args.port = __bpf_ntohs(addr.sin_port);
+		if (write_args.port > 0 && addr.sin_family == AF_INET) {
+			*(__u32 *)write_args.addr =
+				__bpf_ntohl(addr.sin_addr.s_addr);
+		} else if (write_args.port > 0 &&
+			   addr.sin_family == AF_INET6) {
+			struct sockaddr_in6 addr = { 0 };
+			bpf_probe_read_user(&addr, sizeof(addr),
+					    sendto_ctx->addr);
+			bpf_probe_read_kernel(&write_args.addr[0], 16,
+					      &addr.sin6_addr.s6_addr[0]);
+                }
+	}
+
 	active_write_args_map__update(&id, &write_args);
 
 	return 0;
@@ -1615,11 +1690,6 @@ TPPROG(sys_exit_sendto) (struct syscall_comm_exit_ctx * ctx) {
 	__u64 id = bpf_get_current_pid_tgid();
 	ssize_t bytes_count = ctx->ret;
 
-	// 潜在的问题:如果sentto() addr是由TCP连接提供的，系统调用可能会忽略它，但我们仍然会跟踪它。在实践中，TCP连接不应该使用带addr参数的sendto()。
-	// 在手册页中:
-	//     如果sendto()用于连接模式(SOCK_STREAM, SOCK_SEQPACKET)套接字，参数
-	//     dest_addr和addrlen会被忽略(如果不是，可能会返回EISCONN错误空和0)
-	//
 	// Unstash arguments, and process syscall.
 	struct data_args_t *write_args = active_write_args_map__lookup(&id);
 	if (write_args != NULL) {
@@ -2010,7 +2080,6 @@ TPPROG(sys_enter_close) (struct syscall_comm_enter_ctx * ctx) {
 	if (socket_info_ptr->uid)
 		__sync_fetch_and_add(&socket_info_ptr->seq, 1);
 	delete_socket_info(conn_key, socket_info_ptr);
-	socket_role_map__delete(&conn_key);
 	__push_close_event(id, socket_info_ptr->uid, socket_info_ptr->seq,
 			   offset, ctx);
 	return 0;


### PR DESCRIPTION
The `sendto` functions are generally used in UDP protocols, but can also be used in TCP after the connect function is called. `sendto()` use the datagram method to transmit data.
In the connectionless datagram socket mode, since the local socket has not established a connection with the remote machine, the destination address should be specified when sending data. The sendto() function prototype is:

`int sendto(socket s, const void *msg, int len, unsigned int flags, const
            struct sockaddr *to, int tolen);`

The sendto() function has two more parameters than the send() function. The "to" parameter specifies the IP address and port number information of the destination machine.

Our current logic is as follows: network tuple information (`IP`, `PORT`) is obtained by reading the corresponding fields of the kernel structure `struct sock_common`. Since the IP address and port are specified in the sendto() system calls, the tuple data will not be populated into the kernel structure `struct sock_common`. As a result, we cannot obtain the tuple information. Therefore, when entering these types of system calls, we need to save this information beforehand.



### This PR is for:

- Agent


#### Affected branches
- main
- v6.5
- v6.4

