### PR TITLE
fix: agent - eBPF Ensure the Sofa protocol can reassemble

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -126,7 +126,13 @@ struct socket_info_s {
 	__u16 allow_reassembly: 1;
 	__u16 finish_reasm: 1; // Has the reassembly been completed?
 	__u16 udp_pre_set_addr: 1; // Is the socket address pre-set during the system call phase in the UDP protocol?
-	__u16 unused_bits: 13; 
+	/*
+	 * Indicate that the current and next data must be pushed in
+	 * the form of data reorganization.
+	 * Currently only protocol inference is available on sofarpc.
+	 */
+	__u16 force_reasm: 1;
+	__u16 unused_bits: 12; 
  	__u32 reasm_bytes; // The amount of data bytes that have been reassembled.
 
 	/*


### PR DESCRIPTION
The system call behavior of sofarpc protocol is to first receive 64 bytes when receiving, and then receive the following content. We make sure that this type of data is reassembled.



### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
