### PR TITLE
fix: agent - eBPF Adjust syscall sendto() for IPv6 mapping to IPv4

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1275,9 +1275,16 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 					      args->addr);
 			v->tuple.addr_len = 4;
 		} else if (conn_info->skc_family == PF_INET6) {
-			bpf_probe_read_kernel(v->tuple.daddr, 16,
-					      args->addr);
-			v->tuple.addr_len = 16;
+			if (*(__u64 *)&args->addr[0] == 0 &&
+			    *(__u32 *)&args->addr[8] == 0xffff0000) {
+				*(__u32 *)v->tuple.daddr = 
+					*(__u32 *)&args->addr[12];
+				v->tuple.addr_len = 4;
+			} else {
+				bpf_probe_read_kernel(v->tuple.daddr, 16,
+						      args->addr);
+				v->tuple.addr_len = 16;
+			}
 		}
 	}
 

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1319,27 +1319,6 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		 * This is because kernel 4.14 verify reports errors("R0 invalid mem access 'inv'").
 		 */
 		v->tcp_seq = tcp_seq;
-		if (tcp_seq == 0 && conn_info->fd > 0) {
-			if (conn_info->direction == T_INGRESS) {
-				tcp_seq =
-				    get_tcp_read_seq_from_fd(conn_info->fd);
-				/*
-				 * If the current state is TCPF_CLOSE_WAIT, the FIN
-				 * frame already has been received.
-				 * Since tcp_sock->copied_seq has done such an operation +1,
-				 * need to fix the value of tcp_seq.
-				 */
-				if ((1 << conn_info->skc_state) &
-				    TCPF_CLOSE_WAIT) {
-					tcp_seq--;
-				}
-			} else {
-				tcp_seq =
-				    get_tcp_write_seq_from_fd(conn_info->fd);
-			}
-
-			v->tcp_seq = tcp_seq - syscall_len;
-		}
 	}
 
 	v->thread_trace_id = thread_trace_id;


### PR DESCRIPTION

### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
- v6.4
