### PR TITLE
fix: agent Packet fanout can only be set in TapMode::Local mode

### DIFF
--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -1209,7 +1209,11 @@ impl DispatcherBuilder {
                     poll_timeout: POLL_TIMEOUT.as_nanos() as isize,
                     version: options.af_packet_version,
                     iface: src_interface.as_ref().unwrap_or(&"".to_string()).clone(),
-                    packet_fanout_mode: options.packet_fanout_mode,
+                    packet_fanout_mode: if options.tap_mode == TapMode::Local {
+                        Some(options.packet_fanout_mode)
+                    } else {
+                        None
+                    },
                     ..Default::default()
                 };
                 info!("Afpacket init with {:?}", afp);

--- a/agent/src/dispatcher/recv_engine/af_packet/options.rs
+++ b/agent/src/dispatcher/recv_engine/af_packet/options.rs
@@ -80,7 +80,7 @@ pub struct Options {
     pub version: OptTpacketVersion,
     pub socket_type: OptSocketType,
     pub iface: String,
-    pub packet_fanout_mode: u32,
+    pub packet_fanout_mode: Option<u32>,
 }
 
 impl Default for Options {
@@ -95,7 +95,7 @@ impl Default for Options {
             version: OptTpacketVersion::TpacketVersionHighestavailablet,
             socket_type: OptSocketType::SocketTypeRaw,
             iface: "".to_string(),
-            packet_fanout_mode: 0,
+            packet_fanout_mode: None,
         }
     }
 }

--- a/agent/src/dispatcher/recv_engine/af_packet/tpacket.rs
+++ b/agent/src/dispatcher/recv_engine/af_packet/tpacket.rs
@@ -220,9 +220,13 @@ impl Tpacket {
             info!("kernel version is lower than 3.1, skip the packet fanout setting");
             return Ok(());
         }
+        let Some(packet_fanout_mode) = self.opts.packet_fanout_mode else {
+            info!("Packet fanout can only be set in TapMode::Local mode");
+            return Ok(());
+        };
         // The first 16 bits encode the fanout group ID, and the second set of 16 bits encode the fanout mode and options.
         let fanout_group_id = process::id() & 0xffff;
-        let fanout_arg: c_uint = fanout_group_id | (self.opts.packet_fanout_mode << 16);
+        let fanout_arg: c_uint = fanout_group_id | (packet_fanout_mode << 16);
         self.setsockopt(SOL_PACKET, PACKET_FANOUT, fanout_arg)
     }
 


### PR DESCRIPTION
### This PR is for:

- Agent

Cherry-picked: #7205 