### PR TITLE
fix: Fix remote exec command id from/to u32 conversion

### DIFF
--- a/agent/crates/public/src/rpc.rs
+++ b/agent/crates/public/src/rpc.rs
@@ -1,5 +1,5 @@
 pub mod remote_exec {
-    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
     pub enum CmdId {
         Community(u32),
         Enterprise(u32),
@@ -29,7 +29,7 @@ pub mod remote_exec {
         fn try_from(id: u32) -> Result<Self, Self::Error> {
             let mask = u32::MAX << CmdId::ID_BITS;
             let inner_id = id & !mask;
-            match id & mask {
+            match id >> CmdId::ID_BITS {
                 0 => Ok(Self::Community(inner_id)),
                 1 => Ok(Self::Enterprise(inner_id)),
                 2 => Ok(Self::Temporary(inner_id)),
@@ -64,5 +64,32 @@ pub mod remote_exec {
         pub output_format: OutputFormat,
         pub desc: &'static str,
         pub command_type: CommandType,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::CmdId;
+
+        #[test]
+        fn id_conversion() {
+            let ids = vec![
+                CmdId::Community(0),
+                CmdId::Community(435),
+                CmdId::Community(!(u32::MAX << CmdId::ID_BITS)),
+                CmdId::Enterprise(0),
+                CmdId::Enterprise(3451),
+                CmdId::Enterprise(341),
+                CmdId::Enterprise(!(u32::MAX << CmdId::ID_BITS)),
+                CmdId::Temporary(0),
+                CmdId::Temporary(342),
+                CmdId::Temporary(34),
+                CmdId::Temporary(!(u32::MAX << CmdId::ID_BITS)),
+            ];
+
+            for id in ids.iter() {
+                let id_u32: u32 = (*id).into();
+                assert_eq!(*id, CmdId::try_from(id_u32).unwrap());
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


