### PR TITLE
fix: agent - eBPF Adjust Java syms-cache update logic & error log output

### DIFF
--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -593,7 +593,6 @@ int fetch_kernel_version(int *major, int *minor, int *rev, int *num)
 		// uname -r (4.19.117.bsk.7-business-amd64)
 		has_error = true;
 	}
-
 	// Get the real version of Debian
 	// #1 SMP Debian 4.19.289-2 (2023-08-08)
 	// e.g.:
@@ -1024,7 +1023,8 @@ void df_exit_ns(int fd)
 	close(fd);
 }
 
-int exec_command(const char *cmd, const char *args)
+int exec_command(const char *cmd, const char *args,
+		 char *ret_buf, int ret_buf_size)
 {
 	FILE *fp;
 	int rc = 0;
@@ -1036,13 +1036,20 @@ int exec_command(const char *cmd, const char *args)
 			     __func__, cmd_buf, strerror(errno));
 		return -1;
 	}
-#ifdef PROFILE_JAVA_DEBUG
-	/* Read and print the output */
-	char buffer[1024];
-	while (fgets(buffer, sizeof(buffer), fp) != NULL) {
-		ebpf_info("%s", buffer);
+
+	if (ret_buf != NULL && ret_buf_size > 0) {
+		/* Read and print the output */
+		char buffer[1024];
+		int write_bytes =
+		    snprintf(ret_buf, ret_buf_size, "\n%s\n", cmd_buf);
+		while (fgets(buffer, sizeof(buffer), fp) != NULL) {
+			write_bytes +=
+			    snprintf(ret_buf + write_bytes,
+				     ret_buf_size - write_bytes, "%s", buffer);
+			if (write_bytes >= ret_buf_size)
+				break;
+		}
 	}
-#endif
 
 	rc = pclose(fp);
 	if (-1 == rc) {

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -276,7 +276,7 @@ int copy_file(const char *src_file, const char *dest_file);
 int df_enter_ns(int pid, const char *type, int *self_fd);
 void df_exit_ns(int fd);
 int gen_file_from_mem(const char *mem_ptr, int write_bytes, const char *path);
-int exec_command(const char *cmd, const char *args);
+int exec_command(const char *cmd, const char *args, char *ret_buf, int ret_buf_size);
 u64 current_sys_time_secs(void);
 int fetch_container_id_from_str(char *buff, char *id, int copy_bytes);
 int fetch_container_id(pid_t pid, char *id, int copy_bytes);

--- a/agent/src/ebpf/user/profile/java/gen_syms_file.c
+++ b/agent/src/ebpf/user/profile/java/gen_syms_file.c
@@ -62,14 +62,14 @@ void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred)
 
 	char args[PERF_PATH_SZ * 2];
 	snprintf(args, sizeof(args),
-		"%d %d," DF_AGENT_LOCAL_PATH_FMT ".map," DF_AGENT_LOCAL_PATH_FMT ".log",
-		pid, g_java_syms_write_bytes_max, pid, pid);
+		 "%d %d," DF_AGENT_LOCAL_PATH_FMT ".map,"
+		 DF_AGENT_LOCAL_PATH_FMT ".log", pid,
+		 g_java_syms_write_bytes_max, pid, pid);
 
-	i64 curr_local_sz;
-	curr_local_sz = get_local_symbol_file_sz(pid, target_ns_pid);
-
+	char ret_buf[1024];
+	memset(ret_buf, 0, sizeof(ret_buf));
 	u64 start_time = gettime(CLOCK_MONOTONIC, TIME_TYPE_NAN);
-	exec_command(DF_JAVA_ATTACH_CMD, args);
+	exec_command(DF_JAVA_ATTACH_CMD, args, ret_buf, sizeof(ret_buf));
 	u64 end_time = gettime(CLOCK_MONOTONIC, TIME_TYPE_NAN);
 
 	if (target_symbol_file_access(pid, target_ns_pid, true) != 0) {
@@ -85,12 +85,12 @@ void gen_java_symbols_file(int pid, int *ret_val, bool error_occurred)
 		  ".map, PID %d, size %ld, cost %lu us",
 		  pid, pid, new_file_sz, (end_time - start_time) / 1000ULL);
 
-	if (new_file_sz > curr_local_sz)
-		*ret_val = JAVA_SYMS_NEED_UPDATE;
+	*ret_val = JAVA_SYMS_NEED_UPDATE;
 	return;
 error:
 	*ret_val = JAVA_SYMS_ERR;
-	ebpf_warning("Generate Java symbol files failed. PID %d\n", pid);
+	ebpf_warning("Generate Java symbol files failed. PID %d\n%s\n", pid,
+		     ret_buf);
 }
 
 void clean_local_java_symbols_files(int pid)
@@ -141,8 +141,7 @@ void java_syms_update_main(void *arg)
 			if (AO_GET(&p->use) > 1) {
 				int ret;
 				gen_java_symbols_file(p->pid, &ret,
-						      p->
-						      gen_java_syms_file_err);
+						      p->gen_java_syms_file_err);
 				if (ret != JAVA_SYMS_ERR) {
 					if (ret == JAVA_SYMS_NEED_UPDATE)
 						p->cache_need_update = true;

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -1144,8 +1144,8 @@ static int create_profiler(struct bpf_tracer *tracer)
 	}
 
 	/* clear old perf files */
-	exec_command("/usr/bin/rm -rf /tmp/perf-*.map", "");
-	exec_command("/usr/bin/rm -rf /tmp/perf-*.log", "");
+	exec_command("/usr/bin/rm -rf /tmp/perf-*.map", "", NULL, 0);
+	exec_command("/usr/bin/rm -rf /tmp/perf-*.log", "", NULL, 0);
 
 	/* attach perf event */
 	tracer_hooks_attach(tracer);


### PR DESCRIPTION
Previously, the update of the Java symbol cache depended on the new symbol file being larger in size than the existing file, which was illogical because it might not account for events like 'CompiledMethodUnload' that could reduce the number of Java functions (methods). This modification removes that check. Additionally, for the runtime of deepflow-jattach during the generation of Java symbol files, if exceptions occur, log outputs have been added.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
- v6.4
- v6.3