### PR TITLE
fix: server if agent get hostname is same, vm table will update, not add

### DIFF
--- a/server/controller/genesis/updater.go
+++ b/server/controller/genesis/updater.go
@@ -397,9 +397,9 @@ func (v *GenesisSyncRpcUpdater) ParseHostAsVmPlatformInfo(info VIFRPCMessage, pe
 	vpcs := []model.GenesisVpc{vpc}
 
 	vm := model.GenesisVM{
-		Name:         hostName,
-		Label:        hostName,
-		Lcuuid:       common.GetUUIDByOrgID(info.orgID, hostName),
+		Name:         peer + "-" + hostName,
+		Label:        peer + "-" + hostName,
+		Lcuuid:       common.GetUUIDByOrgID(info.orgID, peer + "-" + hostName),
 		VPCLcuuid:    vpc.Lcuuid,
 		LaunchServer: "127.0.0.1",
 		State:        common.VM_STATE_RUNNING,


### PR DESCRIPTION
### This PR is for:


- Server

In a certain scenario, we add a legacy-host (follow this doc [legacy-host](https://www.deepflow.io/docs/zh/ce-install/legacy-host)).
We had some same hostname x86 agents,eg: localhost, we found Mysql table vm and vtap got only one agent, and the `device_id` is same(in the agents who have same hostname), found the `hostname` is the issue, so we add `peer` and `-` prefix the `hostname`。