### PR TITLE
fix: agent - eBPF Adjust Java syms-cache update logic & error log output

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -287,7 +287,7 @@ int copy_file(const char *src_file, const char *dest_file);
 int df_enter_ns(int pid, const char *type, int *self_fd);
 void df_exit_ns(int fd);
 int gen_file_from_mem(const char *mem_ptr, int write_bytes, const char *path);
-int exec_command(const char *cmd, const char *args);
+int exec_command(const char *cmd, const char *args, char *ret_buf, int ret_buf_size);
 u64 current_sys_time_secs(void);
 int fetch_container_id_from_str(char *buff, char *id, int copy_bytes);
 int fetch_container_id(pid_t pid, char *id, int copy_bytes);

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -340,8 +340,8 @@ static int create_profiler(struct bpf_tracer *tracer)
 		return ETR_LOAD;
 
 	/* clear old perf files */
-	exec_command("/usr/bin/rm -rf /tmp/perf-*.map", "");
-	exec_command("/usr/bin/rm -rf /tmp/perf-*.log", "");
+	exec_command("/usr/bin/rm -rf /tmp/perf-*.map", "", NULL, 0);
+	exec_command("/usr/bin/rm -rf /tmp/perf-*.log", "", NULL, 0);
 
 	ret = create_work_thread("java_update",
 				 &java_syms_update_thread,


### PR DESCRIPTION
Previously, the update of the Java symbol cache depended on the new symbol file being larger in size than the existing file, which was illogical because it might not account for events like 'CompiledMethodUnload' that could reduce the number of Java functions (methods). This modification removes that check. Additionally, for the runtime of deepflow-jattach during the generation of Java symbol files, if exceptions occur, log outputs have been added.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
- v6.4
