### PR TITLE
feat: server uses sub_domain team id first when publishing message to tagrecorder

### DIFF
--- a/server/controller/http/service/resource/domain.go
+++ b/server/controller/http/service/resource/domain.go
@@ -636,7 +636,7 @@ func deleteDomain(domain *mysql.Domain, db *mysql.DB, userInfo *httpcommon.UserI
 	db.Delete(&domain)
 
 	// pub to tagrecorder
-	metadata := message.NewMetadata(db.ORGID, domain.TeamID, domain.ID)
+	metadata := message.NewMetadata(db.ORGID, message.MetadataTeamID(domain.TeamID), message.MetadataDomainID(domain.ID))
 	for _, s := range tagrecorder.GetSubscriberManager().GetSubscribers("domain") {
 		s.OnDomainDeleted(metadata)
 	}
@@ -946,7 +946,7 @@ func DeleteSubDomain(lcuuid string, db *mysql.DB, userInfo *httpcommon.UserInfo,
 	}
 
 	// pub to tagrecorder
-	metadata := message.NewMetadata(db.ORGID, 0, 0, message.MetadataSubDomainID(subDomain.ID))
+	metadata := message.NewMetadata(db.ORGID, message.MetadataSubDomainID(subDomain.ID))
 	for _, s := range tagrecorder.GetSubscriberManager().GetSubscribers("sub_domain") {
 		s.OnSubDomainDeleted(metadata)
 	}

--- a/server/controller/recorder/cleaner.go
+++ b/server/controller/recorder/cleaner.go
@@ -537,7 +537,7 @@ func (t *toolData) load(db *mysql.DB) error {
 	domainLcuuidToID := make(map[string]int)
 	for _, domain := range domains {
 		domainLcuuidToID[domain.Lcuuid] = domain.ID
-		t.domainLcuuidToMsgMetadata[domain.Lcuuid] = message.NewMetadata(db.ORGID, domain.TeamID, domain.ID)
+		t.domainLcuuidToMsgMetadata[domain.Lcuuid] = message.NewMetadata(db.ORGID, message.MetadataTeamID(domain.TeamID), message.MetadataDomainID(domain.ID))
 	}
 	var subDomains []*mysql.SubDomain
 	if err := db.Find(&subDomains).Error; err != nil {
@@ -545,8 +545,9 @@ func (t *toolData) load(db *mysql.DB) error {
 		return err
 	}
 	for _, subDomain := range subDomains {
-		md := message.NewMetadata(db.ORGID, subDomain.TeamID, domainLcuuidToID[subDomain.Domain], message.MetadataSubDomainID(subDomain.ID))
-		t.subDomainLcuuidToMsgMetadata[subDomain.Lcuuid] = md
+		t.subDomainLcuuidToMsgMetadata[subDomain.Lcuuid] = message.NewMetadata(
+			db.ORGID, message.MetadataTeamID(subDomain.TeamID), message.MetadataDomainID(domainLcuuidToID[subDomain.Domain]), message.MetadataSubDomainID(subDomain.ID),
+		)
 	}
 	return nil
 }

--- a/server/controller/recorder/pubsub/message/metadata.go
+++ b/server/controller/recorder/pubsub/message/metadata.go
@@ -23,11 +23,9 @@ type Metadata struct {
 	SubDomainID int
 }
 
-func NewMetadata(orgID, teamID, domainID int, options ...func(*Metadata)) *Metadata {
+func NewMetadata(orgID int, options ...func(*Metadata)) *Metadata {
 	md := &Metadata{
-		ORGID:    orgID,
-		TeamID:   teamID,
-		DomainID: domainID,
+		ORGID: orgID,
 	}
 	for _, option := range options {
 		option(md)
@@ -38,5 +36,17 @@ func NewMetadata(orgID, teamID, domainID int, options ...func(*Metadata)) *Metad
 func MetadataSubDomainID(id int) func(*Metadata) {
 	return func(m *Metadata) {
 		m.SubDomainID = id
+	}
+}
+
+func MetadataTeamID(id int) func(*Metadata) {
+	return func(m *Metadata) {
+		m.TeamID = id
+	}
+}
+
+func MetadataDomainID(id int) func(*Metadata) {
+	return func(m *Metadata) {
+		m.DomainID = id
 	}
 }

--- a/server/controller/recorder/updater/updater.go
+++ b/server/controller/recorder/updater/updater.go
@@ -112,7 +112,17 @@ func newUpdaterBase[
 		diffBaseData: diffBaseData,
 		cloudData:    cloudData,
 	}
-	u.msgMetadata = message.NewMetadata(u.metadata.GetORGID(), u.metadata.Domain.TeamID, u.metadata.Domain.ID, message.MetadataSubDomainID(u.metadata.SubDomain.ID))
+	// use teamID from subDomain if updater is for subDomain
+	teamID := u.metadata.SubDomain.TeamID
+	if teamID == 0 {
+		teamID = u.metadata.Domain.TeamID
+	}
+	u.msgMetadata = message.NewMetadata(
+		u.metadata.GetORGID(),
+		message.MetadataTeamID(teamID),
+		message.MetadataDomainID(u.metadata.Domain.ID),
+		message.MetadataSubDomainID(u.metadata.SubDomain.ID),
+	)
 
 	log.Infof(u.metadata.Logf("new updater for resource type: %s, message metadata: %#v", resourceType, u.msgMetadata)) // TODO debug
 	u.initPubSub()


### PR DESCRIPTION

### This PR is for:

- Server

#### Affected branches
- main
- v6.5