### PR TITLE
perf: enhance profile api performance

### DIFF
--- a/server/querier/profile/model/model.go
+++ b/server/querier/profile/model/model.go
@@ -33,11 +33,10 @@ type ProfileTracing struct {
 }
 
 type ProfileTreeNode struct {
-	LocationID   int `json:"_location_id"`
-	NodeID       int `json:"node_id"`
-	ParentNodeID int `json:"parent_node_id"`
-	SelfValue    int `json:"self_value"`
-	TotalValue   int `json:"total_value"`
+	LocationID   int
+	ParentNodeID int
+	SelfValue    int
+	TotalValue   int
 }
 
 type Debug struct {


### PR DESCRIPTION
## This PR is for:

- Server


## Improves the performance of querier

### before

query a profile (off-cpu profile of deepflow-server) with 670k node cost `4.17s`:

![企业微信截图_1ac4b99f-bb1a-4b8e-9fac-00fcb52b183a](https://github.com/user-attachments/assets/7625ef35-b3a3-4685-b797-197507dc7348)

![企业微信截图_4b6072fd-20e5-459c-91d9-184607bfdc04](https://github.com/user-attachments/assets/e63aeb18-2ed7-4c68-87cc-48ee65f9e165)

The on-cpu profile of querier:

![企业微信截图_ae21e6be-dc6e-4ef1-a242-8b71fdb5b299](https://github.com/user-attachments/assets/e9d52e70-37ff-4fd6-a80e-8e4a99d3fd35)

### after

TODO