### PR TITLE
refacter: trace_tree add encoding respose statistics

### DIFF
--- a/server/libs/tracetree/tracetree.go
+++ b/server/libs/tracetree/tracetree.go
@@ -61,8 +61,9 @@ type SpanInfo struct {
 	Level0 uint8
 	Level1 uint8
 
-	ResponseDuration uint64
-	ResponseStatus   uint8
+	ResponseDurationSum            uint64
+	ResponseTotal                  uint32
+	ResponseStatusServerErrorCount uint32
 }
 
 func (t *TraceTree) Release() {
@@ -135,8 +136,9 @@ func (t *TraceTree) Encode() {
 		}
 		encoder.WriteU8(s.Level0)
 		encoder.WriteU8(s.Level1)
-		encoder.WriteVarintU64(s.ResponseDuration)
-		encoder.WriteU8(s.ResponseStatus)
+		encoder.WriteVarintU64(s.ResponseDurationSum)
+		encoder.WriteVarintU32(s.ResponseTotal)
+		encoder.WriteVarintU32(s.ResponseStatusServerErrorCount)
 	}
 	t.encodedSpans = encoder.Bytes()
 }
@@ -174,8 +176,9 @@ func (t *TraceTree) Decode(decoder *codec.SimpleDecoder) error {
 		}
 		s.Level0 = decoder.ReadU8()
 		s.Level1 = decoder.ReadU8()
-		s.ResponseDuration = decoder.ReadVarintU64()
-		s.ResponseStatus = decoder.ReadU8()
+		s.ResponseDurationSum = decoder.ReadVarintU64()
+		s.ResponseTotal = decoder.ReadVarintU32()
+		s.ResponseStatusServerErrorCount = decoder.ReadVarintU32()
 	}
 	if decoder.Failed() {
 		return fmt.Errorf("trace tree decode failed, offset is %d, buf length is %d ", decoder.Offset(), len(decoder.Bytes()))


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


