### PR TITLE
fix: recorder reports wrong sub_domain infomation in domain logs

### DIFF
--- a/server/controller/recorder/common/logger.go
+++ b/server/controller/recorder/common/logger.go
@@ -26,6 +26,7 @@ var log = logging.MustGetLogger("recorder.common")
 
 type Logger struct {
 	orgID         int
+	teamID        int
 	DomainName    string
 	SubDomainName string
 	MsgPre        string
@@ -42,12 +43,20 @@ func (l *Logger) InitMsgPre() {
 	if l.orgID != 0 {
 		l.MsgPre = fmt.Sprintf("[OID-%d] ", l.orgID)
 	}
+	if l.teamID != 0 {
+		l.MsgPre += fmt.Sprintf("[TID-%d] ", l.teamID)
+	}
 	if l.DomainName != "" {
 		l.MsgPre += fmt.Sprintf("[DN-%s] ", l.DomainName)
 	}
 	if l.SubDomainName != "" {
 		l.MsgPre += fmt.Sprintf("[SDN-%s] ", l.SubDomainName)
 	}
+}
+
+func (l *Logger) SetTeamID(id int) {
+	l.teamID = id
+	l.InitMsgPre()
 }
 
 func (l *Logger) SetDomainName(n string) {

--- a/server/controller/recorder/common/metadata.go
+++ b/server/controller/recorder/common/metadata.go
@@ -43,7 +43,7 @@ func (m *Metadata) Copy() *Metadata {
 	return &Metadata{
 		ORGID:     m.ORGID,
 		DB:        m.DB,
-		Logger:    m.Logger,
+		Logger:    m.Logger.Copy(),
 		Domain:    m.Domain,
 		SubDomain: m.SubDomain,
 	}
@@ -53,13 +53,23 @@ func (m *Metadata) GetORGID() int {
 	return m.ORGID
 }
 
+func (m *Metadata) GetTeamID() int {
+	if m.SubDomain.TeamID != 0 {
+		return m.SubDomain.TeamID
+	} else {
+		return m.Domain.TeamID
+	}
+}
+
 func (m *Metadata) SetDomain(domain mysql.Domain) {
 	m.Domain = &DomainInfo{domain}
+	m.Logger.SetTeamID(domain.TeamID)
 	m.Logger.SetDomainName(domain.Name)
 }
 
 func (m *Metadata) SetSubDomain(subDomain mysql.SubDomain) {
 	m.SubDomain = &SubDomainInfo{subDomain}
+	m.Logger.SetTeamID(subDomain.TeamID)
 	m.Logger.SetSubDomainName(subDomain.Name)
 }
 

--- a/server/controller/recorder/event/manager.go
+++ b/server/controller/recorder/event/manager.go
@@ -74,7 +74,7 @@ func (e EventManagerBase) fillEvent(
 	eventType, instanceName string, instanceType, instanceID int, options ...eventapi.TagFieldOption,
 ) {
 	event.ORGID = uint16(e.metadata.GetORGID())
-	event.TeamID = uint16(e.metadata.Domain.TeamID)
+	event.TeamID = uint16(e.metadata.GetTeamID())
 	event.Time = time.Now().Unix()
 	event.TimeMilli = time.Now().UnixMilli()
 	event.Type = eventType

--- a/server/controller/recorder/updater/updater.go
+++ b/server/controller/recorder/updater/updater.go
@@ -115,13 +115,9 @@ func newUpdaterBase[
 		cloudData:    cloudData,
 	}
 	// use teamID from subDomain if updater is for subDomain
-	teamID := u.metadata.SubDomain.TeamID
-	if teamID == 0 {
-		teamID = u.metadata.Domain.TeamID
-	}
 	u.msgMetadata = message.NewMetadata(
 		u.metadata.GetORGID(),
-		message.MetadataTeamID(teamID),
+		message.MetadataTeamID(u.metadata.GetTeamID()),
 		message.MetadataDomainID(u.metadata.Domain.ID),
 		message.MetadataSubDomainID(u.metadata.SubDomain.ID),
 	)


### PR DESCRIPTION

### This PR is for:

- Server

#### Affected branches
- main
- v6.5