### PR TITLE
refactor: agent modify the system free memory alert logic

### DIFF
--- a/agent/src/rpc/synchronizer.rs
+++ b/agent/src/rpc/synchronizer.rs
@@ -840,7 +840,7 @@ impl Synchronizer {
         drop(status_guard);
 
         let (trident_state, cvar) = &**trident_state;
-        if !runtime_config.enabled || exception_handler.has(Exception::SystemLoadCircuitBreaker) {
+        if !runtime_config.enabled || exception_handler.has(Exception::SystemLoadCircuitBreaker) || exception_handler.has(Exception::FreeMemExceeded) {
             *trident_state.lock().unwrap() = trident::State::Disabled(Some(runtime_config));
         } else {
             *trident_state.lock().unwrap() = trident::State::ConfigChanged(ChangedConfig {

--- a/server/agent_config/example.yaml
+++ b/server/agent_config/example.yaml
@@ -28,8 +28,13 @@ vtap_group_id: g-xxxxxx
 ## System Free Memory Limit
 ## Unit: %. Default: 0. Range: [0, 100]
 ## Note: The limit of the percentage of system free memory.
-##   When the free percentage is lower than 90% of this value,
-##   the agent will automatically restart.
+##   Setting sys_free_memory_limit to 0 indicates that the system free memory ratio is not checked.
+##   1. When the current system free memory ratio is below sys_free_memory_limit * 70%, 
+##      the agent will automatically restart.
+##   2. When the current system free memory ratio is below sys_free_memory_limit but above 70%, 
+##      the agent enters the disabled state.
+##   3. When the current system free memory ratio remains above sys_free_memory_limit * 110%,
+##      the agent recovers from the disabled state.
 #sys_free_memory_limit: 0
 
 ## Packet Capture Rate Limit


### PR DESCRIPTION
### This PR is for:

- Agent

### Modify the system free memory alert logic

#### Changes 
- When the current system free memory ratio is below sys_free_memory_limit * 70%,  the agent will automatically restart.
- When the current system free memory ratio is below sys_free_memory_limit but above 70%, the agent enters the disabled state.
- When the current system free memory ratio remains above sys_free_memory_limit * 110%, the agent recovers from the disabled state.
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
