### PR TITLE
fix: agent fix check_params failed when param is empty

### DIFF
--- a/agent/crates/public/src/rpc.rs
+++ b/agent/crates/public/src/rpc.rs
@@ -122,9 +122,10 @@ pub mod remote_exec {
                     }
                     _ => continue,
                 };
-                if !regex::Regex::new(&p.regex.unwrap_or(DEFAULT_PARAM_REGEX))
-                    .unwrap()
-                    .is_match(value)
+                if !value.is_empty()
+                    && !regex::Regex::new(&p.regex.unwrap_or(DEFAULT_PARAM_REGEX))
+                        .unwrap()
+                        .is_match(value)
                 {
                     return Err(Error::ParamInvalid(p.name.to_owned()));
                 }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes check_params failed when param is empty
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
