### PR TITLE
fix: agent - eBPF Modify the whitelist restructuring format

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1568,9 +1568,6 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 
 	if (conn_info->protocol == PROTO_CUSTOM) {
 		if (conn_info->enable_reasm) {
-			if (conn_info->socket_info_ptr) {
-				conn_info->socket_info_ptr->finish_reasm = true;
-			}
 			conn_info->is_reasm_seg = true;
 		}
 	}


### PR DESCRIPTION
It is marked in the following form:

in ------ marked as: MSG_REASM_START -----
  in ------ marked as: MSG_REASM_SEG
  in -----  marked as: MSG_REASM_SEG
  in -----  marked as: MSG_REASM_SEG
out ------ marked as: MSG_REASM_START -----
  out ------ marked as: MSG_REASM_SEG
  out -----  marked as: MSG_REASM_SEG
  out -----  marked as: MSG_REASM_SEG


### This PR is for:

- Agent



#### Affected branches
- main
- v6.5
