### PR TITLE
feat: agent - eBPF Add delay threshold check for push period

### DIFF
--- a/agent/src/ebpf/kernel/include/task_struct_utils.h
+++ b/agent/src/ebpf/kernel/include/task_struct_utils.h
@@ -26,9 +26,6 @@
 #include <math.h>
 #include "utils.h"
 
-#define NSEC_PER_SEC	1000000000L
-#define USER_HZ		100
-
 static __inline void *get_socket_file_addr_with_check(struct task_struct *task,
 						      int fd_num,
 						      int files_off,

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -2372,7 +2372,14 @@ skip_copy:
 	    offsetof(typeof(struct __socket_data), data) + v->data_len;
 	v_buff->events_num++;
 
-	if (v_buff->events_num >= EVENT_BURST_NUM ||
+	/*
+	 * If the delay of the periodic push event exceeds the threshold, it
+	 * will be pushed immediately.
+	 */
+	__u64 curr_time = bpf_ktime_get_ns();
+	__u64 diff = curr_time - tracer_ctx->last_period_timestamp;
+	if (diff > PERIODIC_PUSH_DELAY_THRESHOLD_NS ||
+	    v_buff->events_num >= EVENT_BURST_NUM ||
 	    ((sizeof(v_buff->data) - v_buff->len) < sizeof(*v))) {
 		__u32 buf_size =
 		    (v_buff->len +
@@ -2399,6 +2406,17 @@ skip_copy:
 
 		v_buff->events_num = 0;
 		v_buff->len = 0;
+		if (diff > PERIODIC_PUSH_DELAY_THRESHOLD_NS) {
+			struct trace_stats *stats;
+			tracer_ctx->last_period_timestamp =
+				tracer_ctx->period_timestamp;
+			tracer_ctx->period_timestamp = curr_time;
+			stats = trace_stats_map__lookup(&k0);
+			if (stats == NULL)
+				goto clear_args_map_1;
+			if (diff > stats->period_event_max_delay)
+				stats->period_event_max_delay = diff;
+		}
 	}
 
 clear_args_map_1:

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -284,4 +284,22 @@ enum {
 #define STACKMAP_SCALING_FACTOR 3.0
 #define STACKMAP_CAPACITY_THRESHOLD 32768 // The capacity limit of the Stack trace map, power of two. 
 
+/*
+ * eBPF utilizes perf event's periodic events to push all data residing in the kernel
+ * cache. We have set this to push data from the kernel buffer every 10 milliseconds.
+ * This periodic event is implemented using the kernel's high-resolution timer (hrtimer),
+ * which triggers a timer interrupt when the specified time elapses. However, in practice,
+ * this timer does not always trigger interrupts precisely every 10 milliseconds to execute
+ * the eBPF program. This discrepancy occurs because timer interrupts may be masked off
+ * during certain operations, such as when interrupts are disabled during locking operations.
+ * Therefore, the timer may trigger interrupts after the expected time, resulting in latency
+ * for periodic events.
+ *
+ * The system call phase will check the time delay of the push period, and if it exceeds this
+ * threshold, the data will be pushed immediately. From the tests, the maximum delay is
+ * approximately in the range of 30 to 60 milliseconds. Therefore, it is appropriate to set the
+ * threshold for the system call phase check to 60 milliseconds.
+ */
+#define PERIODIC_PUSH_DELAY_THRESHOLD_NS 60000000ULL // 60 milliseconds 
+
 #endif /* DF_EBPF_CONFIG_H */


### PR DESCRIPTION
eBPF utilizes perf event's periodic events to push all data residing in the kernel cache. We have set this to push data from the kernel buffer every 10 milliseconds. This periodic event is implemented using the kernel's high-resolution timer (hrtimer), which triggers a timer interrupt when the specified time elapses. However, in practice, this timer does not always trigger interrupts precisely every 10 milliseconds to execute the eBPF program. This discrepancy occurs because timer interrupts may be masked off during certain operations, such as when interrupts are disabled during locking operations. Therefore, the timer may trigger interrupts after the expected time, resulting in latency for periodic events.

The system call phase will check the time delay of the push period, and if it exceeds this threshold, the data will be pushed immediately. From the tests, the maximum delay is approximately in the range of 30 to 60 milliseconds. Therefore, it is appropriate to set the threshold(`PERIODIC_PUSH_DELAY_THRESHOLD_NS`) for the system call phase check to 60 milliseconds.


### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
