### PR TITLE
fix: agent Redis cannot close obfuscation

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -509,10 +509,15 @@ impl ExtraLogFields {
     }
 }
 
+fn default_obfuscate_enabled_protocols() -> Vec<String> {
+    vec!["Redis".to_string()]
+}
+
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct L7ProtocolAdvancedFeatures {
     pub http_endpoint_extraction: HttpEndpointExtraction,
+    #[serde(default = "default_obfuscate_enabled_protocols")]
     pub obfuscate_enabled_protocols: Vec<String>,
     pub extra_log_fields: ExtraLogFields,
     pub unconcerned_dns_nxdomain_response_suffixes: Vec<String>,
@@ -896,13 +901,6 @@ impl YamlConfig {
 
         if c.packet_fanout_mode > Self::PACKET_FANOUT_MODE_MAX {
             c.packet_fanout_mode = 0;
-        }
-
-        if c.l7_protocol_advanced_features
-            .obfuscate_enabled_protocols
-            .is_empty()
-        {
-            c.l7_protocol_advanced_features.obfuscate_enabled_protocols = vec!["Redis".to_string()];
         }
 
         if c.mirror_traffic_pcp > 9 {


### PR DESCRIPTION
### This PR is for:

- Agent
- Server

### Fixes agent Redis cannot close obfuscation
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
