### PR TITLE
feat: agent - eBPF Improve aggregation efficiency of stack-trace string

### DIFF
--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -1593,6 +1593,17 @@ int find_pid_by_name(const char *process_name, int exclude_pid)
 #undef NAME_SIZE
 }
 
+// DJB2 hash function with 32-bit output
+u32 djb2_32bit(const char *str)
+{
+	u32 hash = 5381;
+	int c;
+	while ((c = *str++)) {
+		hash = ((hash << 5) + hash) + c; // hash * 33 + c
+	}
+	return hash; // 32-bit output
+}
+
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t * t, void *fn, void *arg)
 {

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -310,6 +310,7 @@ u64 kallsyms_lookup_name(const char *name);
 bool substring_starts_with(const char *haystack, const char *needle);
 char *get_timestamp_from_us(u64 microseconds);
 int find_pid_by_name(const char *process_name, int exclude_pid);
+u32 djb2_32bit(const char *str);
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -154,6 +154,12 @@ enum {
 #define PROC_RING_SZ 16384
 
 /*
+ * During stack trace string aggregation and statistics, thread names
+ * are hashed using the DJB2 algorithm.
+ */
+#define USE_DJB2_HASH
+
+/*
  * Process information recalibration time, this time is the number of seconds
  * lost from the process startup time to the current time.
  * For Java :

--- a/agent/src/ebpf/user/proc.c
+++ b/agent/src/ebpf/user/proc.c
@@ -175,6 +175,9 @@ void free_proc_cache(struct symbolizer_proc_info *p)
 		bcc_free_symcache((void *)p->syms_cache, p->pid);
 		free_symcache_count++;
 	}
+
+	vec_free(p->thread_names);
+	p->thread_names = NULL;
 	p->syms_cache = 0;
 	clib_mem_free((void *)p);
 }
@@ -541,6 +544,8 @@ static int config_symbolizer_proc_info(struct symbolizer_proc_info *p, int pid)
 	p->lock = 0;
 	pthread_mutex_init(&p->mutex, NULL);
 	p->syms_cache = 0;
+	p->thread_names = NULL;
+	p->thread_names_lock = 0;
 	p->netns_id = get_netns_id_from_pid(pid);
 	if (p->netns_id == 0)
 		return ETR_INVAL;

--- a/agent/src/ebpf/user/proc.h
+++ b/agent/src/ebpf/user/proc.h
@@ -48,6 +48,17 @@ struct symbol_cache_pids {
 	volatile u32 *lock;
 };
 
+/*
+ * The information used to record the names of threads or processes obtained in
+ * the process currently mainly includes the name and its corresponding index
+ * value. It is used for statistical aggregation in tracking stack strings.
+ */
+struct task_comm_info_s {
+	int idx;
+	/* Add a prefix here: 'P' for processes and 'T' for threads. */
+	char comm[TASK_COMM_LEN + 1];
+};
+
 struct symbolizer_proc_info {
 	int pid;
 	/* The process creation time since
@@ -79,6 +90,9 @@ struct symbolizer_proc_info {
 	u64 update_syms_table_time;
 	/* process name */
 	char comm[TASK_COMM_LEN];
+	/* Thread names vector */
+	struct task_comm_info_s *thread_names;
+	u32 thread_names_lock;
 	/* container id */
 	char container_id[CONTAINER_ID_SIZE];
 	/* reference counting */
@@ -92,6 +106,17 @@ struct symbolizer_proc_info {
 	/* Recording symbol resolution cache. */
 	volatile uword syms_cache;
 };
+
+static inline void thread_names_lock(struct symbolizer_proc_info *p)
+{
+	while (__atomic_test_and_set(&p->thread_names_lock, __ATOMIC_ACQUIRE))
+		CLIB_PAUSE();
+}
+
+static inline void thread_names_unlock(struct symbolizer_proc_info *p)
+{
+	__atomic_clear(&p->thread_names_lock, __ATOMIC_RELEASE);
+}
 
 static inline void symbolizer_proc_lock(struct symbolizer_proc_info *p)
 {
@@ -187,13 +212,14 @@ typedef struct {
 	pthread_mutex_t m;
 } proc_event_list_t;
 
-void add_event_to_proc_list(proc_event_list_t *list, struct bpf_tracer *tracer, int pid);
-void remove_event(proc_event_list_t *list, struct process_create_event *event);
-struct process_create_event *get_first_event(proc_event_list_t *list);
+void add_event_to_proc_list(proc_event_list_t * list, struct bpf_tracer *tracer,
+			    int pid);
+void remove_event(proc_event_list_t * list, struct process_create_event *event);
+struct process_create_event *get_first_event(proc_event_list_t * list);
 
 char *get_so_path_by_pid_and_name(int pid, const char *so_name);
 int add_probe_sym_to_tracer_probes(int pid, const char *path,
-					  struct tracer_probes_conf *conf,
-					  struct symbol symbols[], size_t n_symbols);
+				   struct tracer_probes_conf *conf,
+				   struct symbol symbols[], size_t n_symbols);
 
 #endif /* _USER_PROC_H_ */

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -79,6 +79,13 @@ typedef struct {
 		struct {
 			u8 comm[TASK_COMM_LEN];
 			u64 pid:26, reserved:26, cpu:12;
+			/*
+			 * Add padding fields to ensure that the hash key part reaches 32
+			 * bytes (using a hash with a 32-byte key and a 1-byte value for
+			 * stack tracing data), and set the 'padding' value to 0 in the
+			 * key configuration.
+			 */
+			u64 padding;
 		} c_k;
 	};
 

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -47,23 +47,23 @@
  * stack trace messages for push-hash kvp.
  */
 
-#define BIT_26_MAX_VAL	0x3ffffffU
-#define PID_MAX_VAL	BIT_26_MAX_VAL
-#define STACK_ID_MAX	BIT_26_MAX_VAL
-#define CPU_INVALID	0xFFF
+#define BIT_24_MAX_VAL	0xFFFFFFU
+#define PID_MAX_VAL	BIT_24_MAX_VAL
+#define STACK_ID_MAX	BIT_24_MAX_VAL
+#define CPU_INVALID	0xFF
 typedef struct {
 	union {
 		struct {
 			/*
-			 * tgid:(max 67,108,864)
+			 * tgid:
 			 *   The tgid (Thread Group ID) in kernel space
 			 *   is equivalent to the process ID in user space.
-			 * pid:(max 67,108,864)
+			 * pid:
 			 *   The process ID or thread ID in kernel space.
-			 * cpu: (max 4,096)
+			 * cpu:
 			 *   Which CPU core does the perf event occur on?
 			 */
-			u64 tgid:26, pid:26, cpu:12;
+			u64 tgid:24, pid:32, cpu:8;
 
 			/*
 			 * process start time(the number of millisecond
@@ -78,7 +78,7 @@ typedef struct {
 		/* Matching and combining for process/thread name. */
 		struct {
 			u8 comm[TASK_COMM_LEN];
-			u64 pid:26, reserved:26, cpu:12;
+			u64 pid:24, reserved:32, cpu:8;
 			/*
 			 * Add padding fields to ensure that the hash key part reaches 32
 			 * bytes (using a hash with a 32-byte key and a 1-byte value for

--- a/agent/src/ebpf/user/profile/profile_common.c
+++ b/agent/src/ebpf/user/profile/profile_common.c
@@ -50,6 +50,8 @@
 #include "../proc.h"
 #include "stringifier.h"
 
+#define UNKNOWN_JAVA_SYMBOL_STR "Unknown"
+
 /*
  * This section is for symbolization of Java addresses, and we need
  * to prepare two so librarys, one for GNU and the other for MUSL:
@@ -545,15 +547,16 @@ static void set_msg_kvp_by_comm(stack_trace_msg_kv_t * kvp,
 	kvp->c_k.cpu = v->cpu;
 	kvp->c_k.pid = v->tgid;
 	kvp->c_k.reserved = 0;
+	kvp->c_k.padding = 0;
 	kvp->msg_ptr = pointer_to_uword(msg_value);
 }
 
 static void set_msg_kvp(struct profiler_context *ctx,
 			stack_trace_msg_kv_t * kvp,
-			struct stack_trace_key_t *v, u64 stime, void *msg_value)
+			struct stack_trace_key_t *v, u64 stime, void *msg_value,
+			struct symbolizer_proc_info *p)
 {
 	kvp->k.tgid = v->tgid;
-	kvp->k.pid = v->pid;
 	kvp->k.stime = stime;
 	kvp->k.cpu = v->cpu;
 	kvp->k.u_stack_id = (u32) v->userstack;
@@ -563,7 +566,42 @@ static void set_msg_kvp(struct profiler_context *ctx,
 	} else {
 		kvp->k.e_stack_id = 0;
 	}
+
 	kvp->msg_ptr = pointer_to_uword(msg_value);
+
+	/*
+	 * It is possible that multiple threads of a process (or the process itself)
+	 * use the same task name (kernel structure: 'task_struct.comm[]'). To improve
+	 * aggregation efficiency, we use a unique value to fill 'kvp->k.pid' for
+	 * threads with the same name.
+	 */
+	struct task_comm_info_s *name, matched_name;
+	if (v->tgid == v->pid)
+		snprintf(matched_name.comm, sizeof(matched_name.comm), "P%s",
+			 v->comm);
+	else
+		snprintf(matched_name.comm, sizeof(matched_name.comm), "T%s",
+			 v->comm);
+
+	thread_names_lock(p);
+	vec_foreach(name, p->thread_names) {
+		if (strcmp(name->comm, matched_name.comm) == 0) {
+			kvp->k.pid = name->idx;
+			thread_names_unlock(p);
+			return;
+		}
+	}
+
+	kvp->k.pid = vec_len(p->thread_names);
+	matched_name.idx = kvp->k.pid;
+	int ret = VEC_OK;
+	vec_add1(p->thread_names, matched_name, ret);
+	if (ret != VEC_OK) {
+		ebpf_warning("vec add failed\n");
+		kvp->k.pid = v->pid;
+	}
+
+	thread_names_unlock(p);
 }
 
 static void set_stack_trace_msg(struct profiler_context *ctx,
@@ -720,9 +758,9 @@ static inline void update_matched_process_in_total(struct profiler_context *ctx,
 	}
 }
 
-#define UNKNOWN_JAVA_SYMBOL_STR "Unknown"
-
-static char *get_java_symbol(struct bpf_tracer *t, struct java_symbol_map_key *key) {
+static char *get_java_symbol(struct bpf_tracer *t,
+			     struct java_symbol_map_key *key)
+{
 	char value[JAVA_SYMBOL_MAX_LENGTH];
 	memset(value, 0, JAVA_SYMBOL_MAX_LENGTH * sizeof(char));
 	if (!bpf_table_get(t, MAP_MEMORY_JAVA_SYMBOL_MAP_NAME, key, value)) {
@@ -859,7 +897,8 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 			}
 
 			if (matched)
-				set_msg_kvp(ctx, &kv, v, stime, (void *)0);
+				set_msg_kvp(ctx, &kv, v, stime, (void *)0,
+					    __info_p);
 			else {
 				if (ctx->only_matched_data) {
 					if (__info_p)
@@ -895,17 +934,18 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 		     (stack_trace_msg_hash_kv *) & kv) == 0) {
 			__sync_fetch_and_add(&msg_hash->hit_hash_count, 1);
 			if (ctx->type == PROFILER_TYPE_MEMORY) {
-				((stack_trace_msg_t *) kv.msg_ptr)->count += v->ext_data.memory.size;
+				((stack_trace_msg_t *) kv.msg_ptr)->count +=
+				    v->ext_data.memory.size;
 			} else if (ctx->use_delta_time) {
 				if (ctx->sample_period > 0) {
 					((stack_trace_msg_t *) kv.
 					 msg_ptr)->count +=
-		   				(ctx->sample_period / 1000);
+					   (ctx->sample_period / 1000);
 				} else {
 					// Using microseconds for storage.
 					((stack_trace_msg_t *) kv.
 					 msg_ptr)->count +=
-		 				(v->ext_data.off_cpu.duration_ns / 1000);
+					   (v->ext_data.off_cpu.duration_ns / 1000);
 				}
 			} else {
 				((stack_trace_msg_t *) kv.msg_ptr)->count++;
@@ -927,7 +967,9 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 		char *trace_str =
 		    resolve_and_gen_stack_trace_str(t, v, stack_map_name,
 						    stack_str_hash, matched,
-						    process_name, info_p, ctx->type == PROFILER_TYPE_MEMORY);
+						    process_name, info_p,
+						    ctx->type ==
+						    PROFILER_TYPE_MEMORY);
 		if (trace_str) {
 			/*
 			 * append process/thread name to stack string
@@ -941,7 +983,8 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 
 			char *class_name = NULL;
 
-			if (ctx->type == PROFILER_TYPE_MEMORY && v->ext_data.memory.class_id != 0) {
+			if (ctx->type == PROFILER_TYPE_MEMORY
+			    && v->ext_data.memory.class_id != 0) {
 				struct java_symbol_map_key key = { 0 };
 				key.tgid = v->tgid;
 				key.class_id = v->ext_data.memory.class_id;
@@ -949,7 +992,8 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 				if (class_name) {
 					str_len += strlen(class_name) + 1;
 				} else {
-					str_len += strlen(UNKNOWN_JAVA_SYMBOL_STR) + 1;
+					str_len +=
+					    strlen(UNKNOWN_JAVA_SYMBOL_STR) + 1;
 				}
 			}
 
@@ -977,16 +1021,26 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 			char *msg_str = (char *)&msg->data[0];
 			int offset = 0;
 			if (matched) {
-				offset += snprintf(msg_str + offset, str_len - offset, "%s%s;", pre_tag, v->comm);
+				offset +=
+				    snprintf(msg_str + offset, str_len - offset,
+					     "%s%s;", pre_tag, v->comm);
 			}
-			offset += snprintf(msg_str + offset, str_len - offset, "%s", trace_str);
+			offset +=
+			    snprintf(msg_str + offset, str_len - offset, "%s",
+				     trace_str);
 			if (ctx->type == PROFILER_TYPE_MEMORY) {
 				if (class_name) {
-					offset += snprintf(msg_str + offset, str_len - offset, ";%s", class_name);
+					offset +=
+					    snprintf(msg_str + offset,
+						     str_len - offset, ";%s",
+						     class_name);
 					clib_mem_free(class_name);
 					class_name = NULL;
 				} else {
-					offset += snprintf(msg_str + offset, str_len - offset, ";%s", UNKNOWN_JAVA_SYMBOL_STR);
+					offset +=
+					    snprintf(msg_str + offset,
+						     str_len - offset, ";%s",
+						     UNKNOWN_JAVA_SYMBOL_STR);
 				}
 			}
 


### PR DESCRIPTION
It is possible that multiple threads of a process (or the process itself) use the same task name (kernel structure: `task_struct->comm`). To improve the aggregation efficiency of function stack tracing strings, we use a unique value to fill `kvp->k.pid` for threads with the same name.


### This PR is for:


- Agent

#### Affected branches
- main
- v6.5