### PR TITLE
feat: agent - eBPF Adjust method for checking if agent is running

### DIFF
--- a/agent/src/ebpf/test/test_pid_check.c
+++ b/agent/src/ebpf/test/test_pid_check.c
@@ -31,25 +31,24 @@
 #include "../user/load.h"
 
 #define TEST_NAME "test_pid_check"
-static int check_test_running_pid(void)
+static int check_test_is_running(void)
 {
-        int pid = find_pid_by_name(TEST_NAME, getpid());
-        if (pid > 0) {
-                ebpf_warning("The deepflow-agent with process ID %d is already "
-                             "running. You can disable the continuous profiling "
-                             "feature of the deepflow-agent to skip this check.\n",
-                             pid);
-                return ETR_EXIST;
-        }
+	int pid = find_pid_by_name(TEST_NAME, getpid());
+	if (pid > 0) {
+		return check_profiler_running_pid(pid);
+	}
 
-        return ETR_NOTEXIST;
+	return ETR_NOTEXIST;
 }
 
 int main(void)
 {
 	bpf_tracer_init(NULL, true);
-	if (check_test_running_pid() == ETR_EXIST)
-		return 0;
+	if (check_test_is_running() != ETR_NOTEXIST)
+		exit(1);
+
+	if (write_profiler_running_pid() != ETR_OK)
+		return (-1);
 
 	char buf[1024];
 	exec_command("./test_pid_check", "", buf, sizeof(buf));

--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -568,18 +568,88 @@ static struct tracer_sockopts cpdbg_sockopts = {
 };
 
 // Function to check if the recorded PID and its start time are correct
-int check_profiler_running_pid(void)
+int check_profiler_running_pid(int pid)
 {
-	int pid = find_pid_by_name(DEEPFLOW_AGENT_NAME, getpid());
-	if (pid > 0) {
+	char path[MAX_PATH_LENGTH];
+	snprintf(path, sizeof(path), "/proc/%d/root%s", pid,
+		 DEEPFLOW_RUNNING_PID_PATH);
+	FILE *file = fopen(path, "r");
+	if (!file) {
+		if (errno == ENOENT) {
+			return ETR_NOTEXIST;
+		}
+		ebpf_warning("fopen() failed, with %s(%d)\n", strerror(errno),
+			     errno);
+		return ETR_IO;
+	}
+
+	pid_t recorded_pid;
+	u64 recorded_start_time;
+	if (fscanf(file, "%d,%lu", &recorded_pid, &recorded_start_time) != 2) {
+		ebpf_warning("fscanf() failed, with %s(%d)\n", strerror(errno),
+			     errno);
+		fclose(file);
+		return ETR_INVAL;
+	}
+	fclose(file);
+
+	// Check if the process exists
+	if (kill(recorded_pid, 0) == -1 && errno == ESRCH) {
+		return ETR_NOTEXIST;
+	}
+	// Get the actual start time of the process
+	u64 actual_start_time =
+	    get_process_starttime_and_comm(recorded_pid, NULL, 0);
+	if (actual_start_time == 0) {
+		return ETR_NOTEXIST;
+	}
+	// Compare the recorded and actual start times
+	if (recorded_start_time == actual_start_time) {
 		ebpf_warning("The deepflow-agent with process ID %d is already "
 			     "running. You can disable the continuous profiling "
 			     "feature of the deepflow-agent to skip this check.\n",
-			     pid);
+			     recorded_pid);
 		return ETR_EXIST;
+	} else {
+		ebpf_info("Recorded PID(%d) and its startup time(%lu) do not"
+			  " match(actual start time: %lu); this is an outdated"
+			  " process.\n", recorded_pid, recorded_start_time,
+			  actual_start_time);
 	}
 
 	return ETR_NOTEXIST;
+}
+
+int check_profiler_is_running(void)
+{
+	int pid = find_pid_by_name(DEEPFLOW_AGENT_NAME, getpid());
+	if (pid > 0) {
+		return check_profiler_running_pid(pid);
+	}
+
+	return ETR_NOTEXIST;
+}
+
+int write_profiler_running_pid(void)
+{
+	FILE *file = fopen(DEEPFLOW_RUNNING_PID_PATH, "w");
+	if (!file) {
+		ebpf_warning("fopen failed, with %s(%d)",
+			     strerror(errno), errno);
+		return ETR_IO;
+	}
+
+	pid_t pid = getpid();
+	u64 start_time = get_process_starttime_and_comm(pid, NULL, 0);
+	if (start_time == 0) {
+		ebpf_warning("get_process_starttime_and_comm() failed.");
+		fclose(file);
+		return ETR_INVAL;
+	}
+
+	fprintf(file, "%d,%lu", pid, start_time);
+	fclose(file);
+	return ETR_OK;
 }
 
 /*
@@ -606,7 +676,7 @@ int start_continuous_profiler(int freq, int java_syms_update_delay,
 	 * one profiler can be active due to the persistence required for Java symbol
 	 * generation, which is incompatible with multiple agents.
 	 */
-	if (check_profiler_running_pid() == ETR_EXIST)
+	if (check_profiler_is_running() != ETR_NOTEXIST)
 		exit(EXIT_FAILURE);
 
 	if (!run_conditions_check())
@@ -667,6 +737,10 @@ int start_continuous_profiler(int freq, int java_syms_update_delay,
 		return (-1);
 
 	tracer->state = TRACER_RUNNING;
+
+	if (write_profiler_running_pid() != ETR_OK)
+		return (-1);
+
 	return (0);
 }
 

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -169,5 +169,7 @@ int set_profiler_cpu_aggregation(int flag);
 struct bpf_tracer *get_profiler_tracer(void);
 void set_enable_perf_sample(struct bpf_tracer *t, u64 enable_flag);
 void cpdbg_process(stack_trace_msg_t * msg);
-int check_profiler_running_pid(void);
+int check_profiler_running_pid(int pid);
+int check_profiler_is_running(void);
+int write_profiler_running_pid(void);
 #endif /* DF_USER_PERF_PROFILER_H */


### PR DESCRIPTION
To determine whether the continuous profiler is running, the previous method was to check if the 'deepflow-agent' process was running. However, this method has a limitation: if the deepflow-agent is running without the continuous profiling feature, this check will be ineffective. This commit enhances the verification by using PID information recorded when the continuous profiling feature is enabled to strengthen the validation.

### This PR is for:


- Agent


#### Affected branches
- main
- v6.5