### PR TITLE
feat: agent - eBPF Adjust method for checking if agent is running

### DIFF
--- a/agent/src/ebpf/test/test_pid_check.c
+++ b/agent/src/ebpf/test/test_pid_check.c
@@ -31,25 +31,24 @@
 #include "../user/load.h"
 
 #define TEST_NAME "test_pid_check"
-static int check_test_running_pid(void)
+static int check_test_is_running(void)
 {
-        int pid = find_pid_by_name(TEST_NAME, getpid());
-        if (pid > 0) {
-                ebpf_warning("The deepflow-agent with process ID %d is already "
-                             "running. You can disable the continuous profiling "
-                             "feature of the deepflow-agent to skip this check.\n",
-                             pid);
-                return ETR_EXIST;
-        }
+	int pid = find_pid_by_name(TEST_NAME, getpid());
+	if (pid > 0) {
+		return check_profiler_running_pid(pid);
+	}
 
-        return ETR_NOTEXIST;
+	return ETR_NOTEXIST;
 }
 
 int main(void)
 {
 	bpf_tracer_init(NULL, true);
-	if (check_test_running_pid() == ETR_EXIST)
-		return 0;
+	if (check_test_is_running() != ETR_NOTEXIST)
+		exit(1);
+
+	if (write_profiler_running_pid() != ETR_OK)
+		return (-1);
 
 	char buf[1024];
 	exec_command("./test_pid_check", "", buf, sizeof(buf));

--- a/agent/src/ebpf/user/profile/perf_profiler.h
+++ b/agent/src/ebpf/user/profile/perf_profiler.h
@@ -187,5 +187,7 @@ int set_profiler_cpu_aggregation(int flag);
 struct bpf_tracer *get_profiler_tracer(void);
 void set_enable_perf_sample(struct bpf_tracer *t, u64 enable_flag);
 void cpdbg_process(stack_trace_msg_t * msg);
-int check_profiler_running_pid(void);
+int check_profiler_running_pid(int pid);
+int check_profiler_is_running(void);
+int write_profiler_running_pid(void);
 #endif /* DF_USER_PERF_PROFILER_H */


### PR DESCRIPTION
To determine whether the continuous profiler is running, the previous method was to check if the 'deepflow-agent' process was running. However, this method has a limitation: if the deepflow-agent is running without the continuous profiling feature, this check will be ineffective. This commit enhances the verification by using PID information recorded when the continuous profiling feature is enabled to strengthen the validation.



### This PR is for:

- Agent

#### Affected branches
- main
- v6.5
