### PR TITLE
perf: speed up the update of ClickHouse table structure

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -892,7 +892,7 @@ func Query(connect *sql.DB, sql string) (*sql.Rows, error) {
 	retryTimes := RETRY_COUNT
 	for err != nil && retryTimes > 0 {
 		log.Warningf("Query SQL (%s) failed: %s, will retry", sql, err)
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		rows, err = connect.Query(sql)
 		if err == nil {
 			log.Infof("Retry query SQL (%s) success", sql)
@@ -908,7 +908,7 @@ func Exec(connect *sql.DB, sql string) (sql.Result, error) {
 	retryTimes := RETRY_COUNT
 	for err != nil && retryTimes > 0 {
 		log.Warningf("Exec SQL (%s) failed: %s, will retry", sql, err)
-		time.Sleep(time.Second)
+		time.Sleep(100 * time.Millisecond)
 		result, err = connect.Exec(sql)
 		if err == nil {
 			log.Infof("Retry exec SQL (%s) success", sql)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


