### PR TITLE
fix: Modify alert_policy filter

### DIFF
--- a/server/querier/engine/clickhouse/filter.go
+++ b/server/querier/engine/clickhouse/filter.go
@@ -769,13 +769,15 @@ func (t *WhereTag) Trans(expr sqlparser.Expr, w *Where, e *CHEngine) (view.Node,
 			}
 			switch noIDTag {
 			case "service", "chost", "router", "dhcpgw", "redis", "rds", "lb_listener",
-				"natgw", "lb", "host", "pod_node", "user", "region", "az", "pod_ns", "pod_group", "pod", "pod_cluster", "subnet", "gprocess",
-				"pod_ingress", "pod_service", "ip", "alert_policy":
+				"natgw", "lb", "host", "pod_node", "region", "az", "pod_ns", "pod_group", "pod", "pod_cluster", "subnet", "gprocess",
+				"pod_ingress", "pod_service", "ip":
 				if !strings.HasSuffix(strings.Trim(t.Tag, "`"), "_0") && !strings.HasSuffix(strings.Trim(t.Tag, "`"), "_1") {
 					filter = TransAlertEventNoSuffixFilter(tagItem.WhereTranslator, tagItem.WhereRegexpTranslator, op, t.Value)
 				} else {
 					filter = TransChostFilter(tagItem.WhereTranslator, tagItem.WhereRegexpTranslator, op, t.Value)
 				}
+			case "alert_policy", "user":
+				filter = TransChostFilter(tagItem.WhereTranslator, tagItem.WhereRegexpTranslator, op, t.Value)
 			case "resource_gl0", "resource_gl1", "resource_gl2", "auto_instance", "auto_service":
 				if !strings.HasSuffix(strings.Trim(t.Tag, "`"), "_0") && !strings.HasSuffix(strings.Trim(t.Tag, "`"), "_1") {
 					if strings.Contains(op, "match") {

--- a/server/querier/engine/clickhouse/tag/description.go
+++ b/server/querier/engine/clickhouse/tag/description.go
@@ -951,9 +951,9 @@ func GetAlertEventTagDescriptions(staticTag, dynamicTag *common.Result) (respons
 
 	// if dynamiic tag_name not in staticvalues, add to result
 	for _, dynamicItem := range dynamiicValues {
-		dynamicTagName := strings.TrimPrefix(dynamicItem.([]interface{})[0].(string), "_0")
-		dynamicTagName = strings.TrimPrefix(dynamicTagName, "_1")
-		dynamicTagName = strings.TrimPrefix(dynamicTagName, "_id")
+		dynamicTagName := strings.TrimSuffix(dynamicItem.([]interface{})[0].(string), "_0")
+		dynamicTagName = strings.TrimSuffix(dynamicTagName, "_1")
+		dynamicTagName = strings.TrimSuffix(dynamicTagName, "_id")
 		if valuesMap[dynamicTagName] == nil && valuesMap[dynamicItem.([]interface{})[0].(string)] == nil {
 			valuesMap[dynamicTagName] = dynamicItem
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


