### PR TITLE
fix: server allows empty values not to be overwritten as default values

### DIFF
--- a/server/controller/trisolaris/vtap/vtap.go
+++ b/server/controller/trisolaris/vtap/vtap.go
@@ -465,7 +465,7 @@ func isBlank(value reflect.Value) bool {
 }
 
 func JudgeField(field string) bool {
-	for _, name := range []string{"ID", "VTapGroupLcuuid", "Lcuuid", "TapInterfaceRegex"} {
+	for _, name := range []string{"ID", "VTapGroupLcuuid", "Lcuuid"} {
 		if field == name {
 			return true
 		}
@@ -474,8 +474,8 @@ func JudgeField(field string) bool {
 	return false
 }
 
-func DefaultFieldNone(filed string) bool {
-	for _, name := range []string{"CaptureBpf"} {
+func AllowEmptyField(filed string) bool {
+	for _, name := range []string{"TapInterfaceRegex"} {
 		if filed == name {
 			return true
 		}
@@ -512,6 +512,11 @@ func (v *VTapInfo) convertConfig(configs []*agent_config.AgentGroupConfigModel) 
 			field := tt.Field(i)
 			value := tv.Field(i)
 			if JudgeField(field.Name) {
+				typeOfVTapConfiguration.Field(i).Set(value)
+				continue
+			}
+			// Allow empty values not to be overwritten as default values. For example, it can be set: `tap_interface_regex: ""`
+			if AllowEmptyField(field.Name) && value.Kind() == reflect.Ptr && !value.IsNil() {
 				typeOfVTapConfiguration.Field(i).Set(value)
 				continue
 			}


### PR DESCRIPTION
### This PR is for:

- Server

### Allows empty values not to be overwritten as default values
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
