### PR TITLE
fix: concurrent map read and map write

### DIFF
--- a/server/querier/engine/clickhouse/clickhouse.go
+++ b/server/querier/engine/clickhouse/clickhouse.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	//"github.com/k0kubun/pp"
@@ -51,6 +52,8 @@ var checkWithSqlRegexp = regexp.MustCompile(`WITH\s+\S+\s+AS\s+\(`)
 var letterRegexp = regexp.MustCompile("^[a-zA-Z]")
 var fromRegexp = regexp.MustCompile(`(?i)from\s+(\S+)`)
 var whereRegexp = regexp.MustCompile(`(?i)where\s+(\S.*)`)
+
+var Lock sync.Mutex
 
 // Perform regular checks on show SQL and support the following formats:
 // show tag {tag_name} values from {table_name} where xxx order by xxx limit xxx :{tag_name} and {table_name} can be any character
@@ -976,7 +979,9 @@ func (e *CHEngine) TransPrometheusTargetIDFilter(expr view.Node) (view.Node, err
 		targetOriginFilterStr := strings.Join(trgetOriginFilters, " AND ")
 		prometheusSubqueryCache := GetPrometheusSubqueryCache()
 		entryKey := common.EntryKey{ORGID: e.ORGID, Filter: targetOriginFilterStr}
+		Lock.Lock()
 		targetFilter, ok := prometheusSubqueryCache.PrometheusSubqueryCache.Get(entryKey)
+		Lock.Unlock()
 		if ok {
 			filter := targetFilter.Filter
 			filterTime := targetFilter.Time
@@ -1031,12 +1036,16 @@ func (e *CHEngine) TransPrometheusTargetIDFilter(expr view.Node) (view.Node, err
 			op := view.Operator{Type: view.AND}
 			expr = &view.BinaryExpr{Left: expr, Right: rightExpr, Op: &op}
 			entryValue := common.EntryValue{Time: time.Now(), Filter: targetFilter}
+			Lock.Lock()
 			prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+			Lock.Unlock()
 		} else if len(targetIDs) >= config.Cfg.MaxCacheableEntrySize {
 			// When you find that you can't join the cache,
 			// insert a special value into the cache so that the next time you check the cache, you will find
 			entryValue := common.EntryValue{Time: time.Now(), Filter: INVALID_PROMETHEUS_SUBQUERY_CACHE_ENTRY}
+			Lock.Lock()
 			prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+			Lock.Unlock()
 
 			targetFilter := fmt.Sprintf("toUInt64(target_id) IN (%s)", sql)
 			rightExpr := &view.Expr{Value: targetFilter}

--- a/server/querier/engine/clickhouse/filter.go
+++ b/server/querier/engine/clickhouse/filter.go
@@ -1148,7 +1148,9 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 			if appLabel.AppLabelName == nameNoPreffix {
 				isAppLabel = true
 				entryKey := common.EntryKey{ORGID: e.ORGID, Filter: originFilter}
+				Lock.Lock()
 				cacheFilter, ok := prometheusSubqueryCache.PrometheusSubqueryCache.Get(entryKey)
+				Lock.Unlock()
 				if ok {
 					filter = cacheFilter.Filter
 					timeout := cacheFilter.Time
@@ -1160,7 +1162,9 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 					filter = fmt.Sprintf("app_label_value_id_%d %s 0", appLabel.AppLabelColumnIndex, op)
 					entryValue := common.EntryValue{Time: time.Now(), Filter: filter}
 					entryKey := common.EntryKey{ORGID: e.ORGID, Filter: originFilter}
+					Lock.Lock()
 					prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+					Lock.Unlock()
 					return filter, nil
 				}
 
@@ -1195,7 +1199,9 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 					filter = fmt.Sprintf("app_label_value_id_%d IN (%s)", appLabel.AppLabelColumnIndex, valueIDFilter)
 				}
 				entryValue := common.EntryValue{Time: time.Now(), Filter: filter}
+				Lock.Lock()
 				prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+				Lock.Unlock()
 				return filter, nil
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


