### PR TITLE
feat: Using libpcap without restarting when the network card does not…

### DIFF
--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -1227,11 +1227,6 @@ impl DispatcherBuilder {
                 )))
             }
             TapMode::Mirror | TapMode::Local if options.libpcap_enabled => {
-                if pcap_interfaces.is_none() || pcap_interfaces.as_ref().unwrap().is_empty() {
-                    return Err(error::Error::Libpcap(
-                        "libpcap capture must give interface to capture packet".into(),
-                    ));
-                }
                 #[cfg(target_os = "windows")]
                 let src_ifaces = pcap_interfaces
                     .as_ref()


### PR DESCRIPTION

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

### Using libpcap without restarting when the network card does not match
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- main
- 6.5

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


