### PR TITLE
fix: concurrent map read and map write

### DIFF
--- a/server/querier/engine/clickhouse/clickhouse.go
+++ b/server/querier/engine/clickhouse/clickhouse.go
@@ -962,7 +962,7 @@ func (e *CHEngine) TransPrometheusTargetIDFilter(expr view.Node) (view.Node, err
 		targetOriginFilterStr := strings.Join(trgetOriginFilters, " AND ")
 		prometheusSubqueryCache := GetPrometheusSubqueryCache()
 		entryKey := common.EntryKey{ORGID: e.ORGID, Filter: targetOriginFilterStr}
-		targetFilter, ok := prometheusSubqueryCache.PrometheusSubqueryCache.Get(entryKey)
+		targetFilter, ok := prometheusSubqueryCache.Get(entryKey)
 		if ok {
 			filter := targetFilter.Filter
 			filterTime := targetFilter.Time
@@ -1017,13 +1017,12 @@ func (e *CHEngine) TransPrometheusTargetIDFilter(expr view.Node) (view.Node, err
 			op := view.Operator{Type: view.AND}
 			expr = &view.BinaryExpr{Left: expr, Right: rightExpr, Op: &op}
 			entryValue := common.EntryValue{Time: time.Now(), Filter: targetFilter}
-			prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+			prometheusSubqueryCache.Add(entryKey, entryValue)
 		} else if len(targetIDs) >= config.Cfg.MaxCacheableEntrySize {
 			// When you find that you can't join the cache,
 			// insert a special value into the cache so that the next time you check the cache, you will find
 			entryValue := common.EntryValue{Time: time.Now(), Filter: INVALID_PROMETHEUS_SUBQUERY_CACHE_ENTRY}
-			prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
-
+			prometheusSubqueryCache.Add(entryKey, entryValue)
 			targetFilter := fmt.Sprintf("toUInt64(target_id) IN (%s)", sql)
 			rightExpr := &view.Expr{Value: targetFilter}
 			op := view.Operator{Type: view.AND}

--- a/server/querier/engine/clickhouse/filter.go
+++ b/server/querier/engine/clickhouse/filter.go
@@ -1050,7 +1050,7 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 			if appLabel.AppLabelName == nameNoPreffix {
 				isAppLabel = true
 				entryKey := common.EntryKey{ORGID: e.ORGID, Filter: originFilter}
-				cacheFilter, ok := prometheusSubqueryCache.PrometheusSubqueryCache.Get(entryKey)
+				cacheFilter, ok := prometheusSubqueryCache.Get(entryKey)
 				if ok {
 					filter = cacheFilter.Filter
 					timeout := cacheFilter.Time
@@ -1062,7 +1062,7 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 					filter = fmt.Sprintf("app_label_value_id_%d %s 0", appLabel.AppLabelColumnIndex, op)
 					entryValue := common.EntryValue{Time: time.Now(), Filter: filter}
 					entryKey := common.EntryKey{ORGID: e.ORGID, Filter: originFilter}
-					prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+					prometheusSubqueryCache.Add(entryKey, entryValue)
 					return filter, nil
 				}
 
@@ -1097,7 +1097,7 @@ func GetRemoteReadFilter(promTag, table, op, value, originFilter string, e *CHEn
 					filter = fmt.Sprintf("app_label_value_id_%d IN (%s)", appLabel.AppLabelColumnIndex, valueIDFilter)
 				}
 				entryValue := common.EntryValue{Time: time.Now(), Filter: filter}
-				prometheusSubqueryCache.PrometheusSubqueryCache.Add(entryKey, entryValue)
+				prometheusSubqueryCache.Add(entryKey, entryValue)
 				return filter, nil
 			}
 		}

--- a/server/querier/engine/clickhouse/prometheus_subquery_cache.go
+++ b/server/querier/engine/clickhouse/prometheus_subquery_cache.go
@@ -31,6 +31,7 @@ var (
 
 type PrometheusSubqueryCache struct {
 	PrometheusSubqueryCache *lru.Cache[common.EntryKey, common.EntryValue]
+	Lock                    sync.Mutex
 }
 
 func GetPrometheusSubqueryCache() *PrometheusSubqueryCache {
@@ -40,4 +41,18 @@ func GetPrometheusSubqueryCache() *PrometheusSubqueryCache {
 		}
 	})
 	return prometheusSubqueryCacheIns
+}
+
+func (c *PrometheusSubqueryCache) Get(key common.EntryKey) (value common.EntryValue, ok bool) {
+	c.Lock.Lock()
+	value, ok = c.PrometheusSubqueryCache.Get(key)
+	c.Lock.Unlock()
+	return
+}
+
+func (c *PrometheusSubqueryCache) Add(key common.EntryKey, value common.EntryValue) {
+	c.Lock.Lock()
+	c.PrometheusSubqueryCache.Add(key, value)
+	c.Lock.Unlock()
+	return
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


