### PR TITLE
fix: abnormal stats data, causing deepflow-server to panic

### DIFF
--- a/server/ingester/ext_metrics/dbwriter/ext_metrics.go
+++ b/server/ingester/ext_metrics/dbwriter/ext_metrics.go
@@ -51,6 +51,10 @@ type ExtMetrics struct {
 	MetricsFloatValues []float64
 }
 
+func (m *ExtMetrics) IsValid() bool {
+	return len(m.TagNames) == len(m.TagValues) && len(m.MetricsFloatNames) == len(m.MetricsFloatValues)
+}
+
 func (m *ExtMetrics) DatabaseName() string {
 	switch m.MsgType {
 	case datatype.MESSAGE_TYPE_DFSTATS:
@@ -180,6 +184,10 @@ func (m *ExtMetrics) GenerateNewFlowTags(cache *flow_tag.FlowTagCache) {
 	cache.Fields = cache.Fields[:0]
 	cache.FieldValues = cache.FieldValues[:0]
 
+	if !m.IsValid() {
+		log.Warningf("ext metrics is invalid. %+v", m)
+		return
+	}
 	// tags
 	flowTagInfo.FieldType = flow_tag.FieldTag
 	for i, name := range m.TagNames {

--- a/server/ingester/ext_metrics/decoder/decoder.go
+++ b/server/ingester/ext_metrics/decoder/decoder.go
@@ -168,7 +168,7 @@ func (d *Decoder) sendTelegraf(vtapID uint16, point models.Point) {
 		log.Debugf("decoder %d vtap %d recv telegraf point: %v", d.index, vtapID, point)
 	}
 	extMetrics, err := d.PointToExtMetrics(vtapID, point)
-	if err != nil {
+	if err != nil || !extMetrics.IsValid() {
 		if d.counter.ErrMetrics == 0 {
 			log.Warning(err)
 		}
@@ -202,6 +202,13 @@ func (d *Decoder) handleDeepflowStats(vtapID uint16, decoder *codec.SimpleDecode
 			log.Debugf("decoder %d vtap %d recv deepflow stats: %v", d.index, vtapID, pbStats)
 		}
 		metrics, dbId := d.StatsToExtMetrics(vtapID, pbStats)
+		if !metrics.IsValid() {
+			if d.counter.ErrMetrics == 0 {
+				log.Warningf("ext metrics is invalid. %+v", metrics)
+			}
+			d.counter.ErrMetrics++
+			continue
+		}
 		d.extMetricsWriters[dbId].Write(metrics)
 		d.counter.OutCount++
 	}

--- a/server/ingester/flow_log/log_data/otlp_export.go
+++ b/server/ingester/flow_log/log_data/otlp_export.go
@@ -137,7 +137,7 @@ func (l7 *L7FlowLog) EncodeToOtlp(utags *utag.UniversalTagsManager, dataTypeBits
 	span := resSpan.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
 	spanAttrs := span.Attributes()
 
-	if dataTypeBits&config.NATIVE_TAG != 0 {
+	if dataTypeBits&config.NATIVE_TAG != 0 && len(l7.AttributeNames) == len(l7.AttributeValues) {
 		for i := range l7.AttributeNames {
 			putStrWithoutEmpty(spanAttrs, l7.AttributeNames[i], l7.AttributeValues[i])
 		}

--- a/server/libs/stats/udp.go
+++ b/server/libs/stats/udp.go
@@ -19,6 +19,7 @@ package stats
 import (
 	"io"
 	"net"
+	"sync"
 
 	"github.com/deepflowio/deepflow/server/libs/datatype"
 )
@@ -88,9 +89,11 @@ type UDPClient struct {
 	payloadSize int
 	buffer      []byte
 	header      []byte // 需要封装消息类型头
+	lock        sync.Mutex
 }
 
 func (uc *UDPClient) Write(bs []byte) error {
+	uc.lock.Lock()
 	var err error
 	n := len(bs)
 
@@ -105,5 +108,6 @@ func (uc *UDPClient) Write(bs []byte) error {
 	}
 	uc.buffer = append(uc.buffer, bs...)
 
+	uc.lock.Unlock()
 	return err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


