### PR TITLE
fix: incorrect fast path map size

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -784,7 +784,7 @@ impl Default for YamlConfig {
             default_tap_type: 3,
             debug_listen_port: 0,
             enable_qos_bypass: false,
-            fast_path_map_size: 1 << 14,
+            fast_path_map_size: 0,
             first_path_level: 0,
             src_interfaces: vec![],
             mirror_traffic_pcp: 0,

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -2581,7 +2581,7 @@ impl ModuleConfig {
 }
 
 impl YamlConfig {
-    fn get_fast_path_map_size(&self, mem_size: u64) -> usize {
+    pub fn get_fast_path_map_size(&self, mem_size: u64) -> usize {
         if self.fast_path_map_size > 0 {
             return self.fast_path_map_size;
         }

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -1548,7 +1548,7 @@ impl AgentComponents {
         let (policy_setter, policy_getter) = Policy::new(
             1.max(yaml_config.src_interfaces.len()),
             yaml_config.first_path_level as usize,
-            yaml_config.fast_path_map_size,
+            yaml_config.get_fast_path_map_size(candidate_config.dispatcher.max_memory),
             yaml_config.forward_capacity,
             yaml_config.fast_path_disabled,
         );


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

###  incorrect fast path map size
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 6.5
- 6.4
- 6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


