### PR TITLE
fix: agent - eBPF Remove the handling of redundant process events

### DIFF
--- a/agent/src/ebpf/user/profile/perf_profiler.c
+++ b/agent/src/ebpf/user/profile/perf_profiler.c
@@ -247,7 +247,6 @@ static void oncpu_reader_work(void *arg)
 			     get_socket_tracer_state() != TRACER_RUNNING)) {
 			if (oncpu_ctx.enable_bpf_profile)
 				set_bpf_run_enabled(t, &oncpu_ctx, 0);
-			exec_proc_info_cache_update();
 			sleep(1);
 			continue;
 		}


### PR DESCRIPTION
The process exec/exit event handling uses a multi-producer, single-consumer queue. The redundant consumer handling has been removed.



### This PR is for:


- Agent


#### Affected branches
- main
- v6.5