### PR TITLE
fix: if using ByConity database storage, no need to deal with _local tables

### DIFF
--- a/server/ingester/prometheus/dbwriter/prometheus_writer.go
+++ b/server/ingester/prometheus/dbwriter/prometheus_writer.go
@@ -210,8 +210,12 @@ func (w *PrometheusWriter) addAppLabelColumnsOnCluster(startIndex, endIndex int,
 }
 
 func (w *PrometheusWriter) addAppLabelColumns(conn common.DBs, startIndex, endIndex int, orgDatabase string) error {
+	prometheusTables := []string{PROMETHEUS_TABLE, PROMETHEUS_TABLE + ckdb.LOCAL_SUBFFIX}
+	if w.ckdbType == ckdb.CKDBTypeByconity {
+		prometheusTables = []string{PROMETHEUS_TABLE}
+	}
 	for i := startIndex; i <= endIndex; i++ {
-		for _, table := range []string{PROMETHEUS_TABLE + "_local", PROMETHEUS_TABLE} {
+		for _, table := range prometheusTables {
 			_, err := conn.Exec(fmt.Sprintf("ALTER TABLE %s.`%s` ADD COLUMN app_label_value_id_%d %s",
 				orgDatabase, table, i, ckdb.UInt32))
 			if err != nil {


### PR DESCRIPTION

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server

#### Affected branches
- main
- 6.6.4
<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


