### PR TITLE
fix: agent - eBPF fentry/fexit Check for '__sys_recvmmsg'

### DIFF
--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -25,7 +25,14 @@
 #define SYSCALL_FORK_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_fork"
 #define SYSCALL_CLONE_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_clone"
 #define FTRACE_SYSCALLS_PATH "/sys/kernel/debug/tracing/events/syscalls"
-#define TEST_KFUNC_NAME "__sys_sendmsg"
+/*
+ * The `__sys_recvmmsg` interface underwent a change in its parameter list starting
+ * from Linux kernel version 5.0. If earlier kernel versions support the `fentry/fexit`
+ * feature, attempting to load BPF programs on this interface may fail. Therefore, we
+ * use this interface to check whether to load a version of the BPF bytecode binary
+ * that supports `fentry/fexit`.
+ */
+#define TEST_KFUNC_NAME "__sys_recvmmsg"
 // use for inference struct offset.
 #define OFFSET_INFER_SERVER_ADDR "127.0.0.1"
 #define OFFSET_INFER_SERVER_PORT 54583


### PR DESCRIPTION
The `__sys_recvmmsg` interface underwent a change in its parameter list starting from Linux kernel version 5.0. If earlier kernel versions support the `fentry/fexit` feature, attempting to load BPF programs on this interface may fail. Therefore, we use this interface to check whether to load a version of the BPF bytecode binary that supports `fentry/fexit`.


### This PR is for:


- Agent


#### Affected branches
- main
- v6.5

Fixes #7988