### PR TITLE
fix: add timeout to receive agent command heart beat

### DIFF
--- a/server/controller/http/router/agent_cmd.go
+++ b/server/controller/http/router/agent_cmd.go
@@ -124,10 +124,10 @@ func forwardToServerConnectedByAgent() gin.HandlerFunc {
 			}
 			forwardTimes = v
 		} else {
-			log.Infof("node ip(%s) init %s to 0", common.NodeIP, ForwardControllerTimes)
+			log.Infof("agent(key: %s), node ip(%s) init %s to 0", key, common.NodeIP, ForwardControllerTimes)
 			c.Request.Header.Set(ForwardControllerTimes, "0")
 		}
-		log.Infof("node ip(%s) forward times: %d", common.NodeIP, forwardTimes)
+		log.Infof("agent(key: %s), node ip(%s) forward times: %d", key, common.NodeIP, forwardTimes)
 		if forwardTimes > DefaultForwardControllerTimes {
 			err := fmt.Errorf("get agent(name: %s, key: %s) commands forward times > %d", agent.Name, key, DefaultForwardControllerTimes)
 			log.Error(err)
@@ -136,6 +136,8 @@ func forwardToServerConnectedByAgent() gin.HandlerFunc {
 			return
 		}
 
+		log.Infof("agent(key: %s), node ip(%s), agent cur controller ip(%s), controller ip(%s)",
+			key, common.NodeIP, agent.CurControllerIP, agent.ControllerIP)
 		// get reverse proxy host
 		newHost := common.NodeIP
 		if common.NodeIP == agent.CurControllerIP {
@@ -162,8 +164,8 @@ func forwardToServerConnectedByAgent() gin.HandlerFunc {
 		}
 
 		reverseProxy := fmt.Sprintf("http://%s:%d", newHost, common.GConfig.HTTPNodePort)
-		log.Infof("node ip(%s), reverse proxy(%s), agent current controller ip(%s), controller ip(%s)",
-			common.NodeIP, reverseProxy, agent.CurControllerIP, agent.ControllerIP)
+		log.Infof("agnet(key: %s), node ip(%s), reverse proxy(%s), agent current controller ip(%s), controller ip(%s)",
+			key, common.NodeIP, reverseProxy, agent.CurControllerIP, agent.ControllerIP)
 
 		proxyURL, err := url.Parse(reverseProxy)
 		if err != nil {

--- a/server/controller/http/service/agent_cmd.go
+++ b/server/controller/http/service/agent_cmd.go
@@ -60,20 +60,21 @@ func GetAgentCMDManagerWithoutLock(key string) *CMDManager {
 	return nil
 }
 
-func AddToCMDManagerIfNotExist(key string, requestID uint64) (exist bool) {
+func AddToCMDManagerIfNotExist(key string, requestID uint64) *CMDManager {
 	agentCMDMutex.Lock()
 	defer agentCMDMutex.Unlock()
 	if _, ok := agentCMDManager[key]; ok {
-		return true
+		return agentCMDManager[key]
 	}
 
+	log.Infof("add agent(key:%s) to cmd manager", key)
 	agentCMDManager[key] = &CMDManager{
 		requestID: requestID,
 		ExecCH:    make(chan *trident.RemoteExecRequest, 1),
 
 		requestIDToResp: make(map[uint64]*CMDResp),
 	}
-	return false
+	return agentCMDManager[key]
 }
 
 func RemoveFromCMDManager(key string, requestID uint64) {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

#### Changes to fix the bug
- This change adds a timeout mechanism for receiving agent command heartbeats. This improvement ensures that the system can close the connection in a timely manner when no heartbeat is received for an extended period, thereby enhancing system stability and resource utilization efficiency.
- Handle stream errors in advance.

#### Affected branches
- main
- v6.5