### PR TITLE
fix: add timeout to receive agent command heart beat

### DIFF
--- a/server/controller/http/service/agent_cmd.go
+++ b/server/controller/http/service/agent_cmd.go
@@ -61,20 +61,21 @@ func GetAgentCMDManagerWithoutLock(key string) *CMDManager {
 	return nil
 }
 
-func AddToCMDManagerIfNotExist(key string, requestID uint64) (exist bool) {
+func AddToCMDManagerIfNotExist(key string, requestID uint64) *CMDManager {
 	agentCMDMutex.Lock()
 	defer agentCMDMutex.Unlock()
 	if _, ok := agentCMDManager[key]; ok {
-		return true
+		return agentCMDManager[key]
 	}
 
+	log.Infof("add agent(key:%s) to cmd manager", key)
 	agentCMDManager[key] = &CMDManager{
 		requestID: requestID,
 		ExecCH:    make(chan *trident.RemoteExecRequest, 1),
 
 		requestIDToResp: make(map[uint64]*CMDResp),
 	}
-	return false
+	return agentCMDManager[key]
 }
 
 func RemoveFromCMDManager(key string, requestID uint64) {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

#### Changes to fix the bug
- This change adds a timeout mechanism for receiving agent command heartbeats. This improvement ensures that the system can close the connection in a timely manner when no heartbeat is received for an extended period, thereby enhancing system stability and resource utilization efficiency.
- Handle stream errors in advance.

#### Affected branches
- main
- v6.5