### PR TITLE
fix: Tars parse failure cause agent exit

### DIFF
--- a/agent/src/flow_generator/error.rs
+++ b/agent/src/flow_generator/error.rs
@@ -16,6 +16,7 @@
 
 use std::str::Utf8Error;
 
+use public::l7_protocol::L7Protocol;
 use thiserror::Error;
 
 use super::MetaAppProto;
@@ -102,6 +103,8 @@ pub enum Error {
     SoReturnUnexpectVal,
     #[error("so plugin parse fail")]
     SoParseFail,
+    #[error("{proto:?} log parse failed: {reason}")]
+    L7LogParseFailed { proto: L7Protocol, reason: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/agent/src/flow_generator/protocol_logs/rpc/tars.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/tars.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     config::handler::LogParserConfig,
     flow_generator::{
-        error::Result,
+        error::{Error, Result},
         protocol_logs::{
             pb_adapter::{ExtendedInfo, L7ProtocolSendLog, L7Request, L7Response},
             AppProtoHead, L7ResponseStatus, LogMessageType,
@@ -362,7 +362,12 @@ impl L7ProtocolParserInterface for TarsLog {
         if self.perf_stats.is_none() {
             self.perf_stats = Some(L7PerfStats::default())
         };
-        let mut info = TarsInfo::parse(payload, param).unwrap().1;
+        let mut info = TarsInfo::parse(payload, param)
+            .ok_or(Error::L7LogParseFailed {
+                proto: L7Protocol::Tars,
+                reason: "parse result empty".to_owned(),
+            })?
+            .1;
 
         if let Some(config) = param.parse_config {
             info.set_is_on_blacklist(config);


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Remove `unwrap`

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


