### PR TITLE
fix: Bad cstr passed into pcap_compile_nopcap

### DIFF
--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -1060,12 +1060,10 @@ impl<'a> MetaPacket<'a> {
         let cap_len = data.cap_len as usize;
 
         packet.raw_from_ebpf = vec![0u8; cap_len as usize];
-        #[cfg(target_arch = "aarch64")]
-        data.cap_data
-            .copy_to_nonoverlapping(packet.raw_from_ebpf.as_mut_ptr() as *mut u8, cap_len);
-        #[cfg(target_arch = "x86_64")]
-        data.cap_data
-            .copy_to_nonoverlapping(packet.raw_from_ebpf.as_mut_ptr() as *mut i8, cap_len);
+        data.cap_data.copy_to_nonoverlapping(
+            packet.raw_from_ebpf.as_mut_ptr() as *mut libc::c_char,
+            cap_len,
+        );
         packet.packet_len = data.syscall_len as u32 + 54; // 目前仅支持TCP
         packet.payload_len = data.cap_len as u16;
         packet.l4_payload_len = data.cap_len as u16;
@@ -1085,16 +1083,9 @@ impl<'a> MetaPacket<'a> {
             timestamp,
             tcp_seq: data.tcp_seq as u32,
         });
-        #[cfg(target_arch = "aarch64")]
         ptr::copy(
-            data.process_kname.as_ptr() as *const u8,
-            packet.process_kname.as_mut_ptr() as *mut u8,
-            PACKET_KNAME_MAX_PADDING,
-        );
-        #[cfg(target_arch = "x86_64")]
-        ptr::copy(
-            data.process_kname.as_ptr() as *const i8,
-            packet.process_kname.as_mut_ptr() as *mut i8,
+            data.process_kname.as_ptr() as *const libc::c_char,
+            packet.process_kname.as_mut_ptr() as *mut libc::c_char,
             PACKET_KNAME_MAX_PADDING,
         );
         packet.socket_id = data.socket_id;

--- a/agent/src/common/proc_event/linux.rs
+++ b/agent/src/common/proc_event/linux.rs
@@ -150,12 +150,8 @@ impl ProcEvent {
         let data = &mut data.read_unaligned();
         let cap_len = data.cap_len as usize;
         let mut raw_data = vec![0u8; cap_len as usize]; // Copy from data.cap_data where stores event's data
-        #[cfg(target_arch = "aarch64")]
         data.cap_data
-            .copy_to_nonoverlapping(raw_data.as_mut_ptr() as *mut u8, cap_len);
-        #[cfg(target_arch = "x86_64")]
-        data.cap_data
-            .copy_to_nonoverlapping(raw_data.as_mut_ptr() as *mut i8, cap_len);
+            .copy_to_nonoverlapping(raw_data.as_mut_ptr() as *mut libc::c_char, cap_len);
 
         let mut event_data: EventData = EventData::OtherEvent;
         let start_time = data.timestamp * 1000; // The unit of data.timestamp is microsecond, and the unit of start_time is nanosecond

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -442,21 +442,14 @@ impl BpfOptions {
             bf_insns: std::ptr::null_mut(),
         };
         unsafe {
-            #[cfg(target_arch = "x86_64")]
             let ret = pcap_sys::pcap_compile_nopcap(
                 0xffff as libc::c_int,
                 1,
                 &mut prog,
-                self.capture_bpf.as_ptr() as *const i8,
-                1,
-                0xffffffff,
-            );
-            #[cfg(target_arch = "aarch64")]
-            let ret = pcap_sys::pcap_compile_nopcap(
-                0xffff as libc::c_int,
-                1,
-                &mut prog,
-                self.capture_bpf.as_ptr() as *const u8,
+                std::ffi::CString::new(self.capture_bpf.clone())
+                    .unwrap()
+                    .as_c_str()
+                    .as_ptr() as *const libc::c_char,
                 1,
                 0xffffffff,
             );

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -314,13 +314,7 @@ impl fmt::Display for SK_BPF_DATA {
             (self.tuple.rport, self.tuple.lport)
         };
         unsafe {
-            #[cfg(target_arch = "aarch64")]
-            let process_kname = CStr::from_ptr(self.process_kname.as_ptr() as *const u8)
-                .to_str()
-                .unwrap();
-
-            #[cfg(target_arch = "x86_64")]
-            let process_kname = CStr::from_ptr(self.process_kname.as_ptr() as *const i8)
+            let process_kname = CStr::from_ptr(self.process_kname.as_ptr() as *const c_char)
                 .to_str()
                 .unwrap();
 
@@ -534,10 +528,7 @@ extern "C" {
     //   is_stdout 日志是否输出到标准输出，true 写到标准输出，false 不写到标准输出。
     // 返回值：
     //   成功返回0，否则返回非0
-    #[cfg(target_arch = "x86_64")]
-    pub fn bpf_tracer_init(log_file: *const i8, is_stdout: bool) -> c_int;
-    #[cfg(target_arch = "aarch64")]
-    pub fn bpf_tracer_init(log_file: *const u8, is_stdout: bool) -> c_int;
+    pub fn bpf_tracer_init(log_file: *const c_char, is_stdout: bool) -> c_int;
 
     // 所有tracer启动完毕后，最后显示调用bpf_tracer_finish()来通知主程序
     pub fn bpf_tracer_finish();

--- a/agent/src/rpc/remote_exec.rs
+++ b/agent/src/rpc/remote_exec.rs
@@ -714,10 +714,7 @@ fn username_by_uid(uid: u32) -> Result<String> {
     } else {
         conf as usize
     };
-    #[cfg(target_arch = "x86_64")]
-    let mut buffer: Vec<i8> = Vec::with_capacity(buf_size);
-    #[cfg(target_arch = "aarch64")]
-    let mut buffer: Vec<u8> = Vec::with_capacity(buf_size);
+    let mut buffer: Vec<libc::c_char> = Vec::with_capacity(buf_size);
     let mut passwd = libc::passwd {
         pw_name: ptr::null_mut(),
         pw_passwd: ptr::null_mut(),


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Fixes #8167 

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


