### PR TITLE
fix: agent - Other eBPF bin-file will be selected when kfunc loading fails

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -2051,6 +2051,76 @@ static int check_dependencies(void)
 	return 0;
 }
 
+static int select_bpf_binary(char load_name[NAME_LEN], void **bin_buffer,
+			     int *bin_buf_size, bool skip_kfunc)
+{
+	void *bpf_bin_buffer;
+	int buffer_sz;
+	char sys_type_str[16];
+	memset(sys_type_str, 0, sizeof(sys_type_str));
+	if (fetch_system_type(sys_type_str, sizeof(sys_type_str) - 1) != ETR_OK) {
+		ebpf_warning("Fetch system type faild.\n");
+	}
+
+	if (!skip_kfunc && fentry_can_attach(TEST_KFUNC_NAME)
+	    && get_kfunc_params_num(TEST_KFUNC_NAME) == TEST_KFUNC_PARAMS_NUM) {
+		g_k_type = K_TYPE_KFUNC;
+		snprintf(load_name, NAME_LEN, "socket-trace-bpf-linux-kfunc");
+		bpf_bin_buffer = (void *)socket_trace_kfunc_ebpf_data;
+		buffer_sz = sizeof(socket_trace_kfunc_ebpf_data);
+	} else if (strcmp(sys_type_str, "ky10") == 0) {
+		g_k_type = K_TYPE_KYLIN;
+		snprintf(load_name, NAME_LEN, "socket-trace-bpf-linux-kylin");
+		bpf_bin_buffer = (void *)socket_trace_kylin_ebpf_data;
+		buffer_sz = sizeof(socket_trace_kylin_ebpf_data);
+	} else if (major > 5 || (major == 5 && minor >= 2)) {
+		g_k_type = K_TYPE_VER_5_2_PLUS;
+		snprintf(load_name, NAME_LEN,
+			 "socket-trace-bpf-linux-5.2_plus");
+		bpf_bin_buffer = (void *)socket_trace_5_2_plus_ebpf_data;
+		buffer_sz = sizeof(socket_trace_5_2_plus_ebpf_data);
+	} else if (major == 3 && minor == 10) {
+		g_k_type = K_TYPE_VER_3_10;
+		snprintf(load_name, NAME_LEN, "socket-trace-bpf-linux-3.10.0");
+		bpf_bin_buffer = (void *)socket_trace_3_10_0_ebpf_data;
+		buffer_sz = sizeof(socket_trace_3_10_0_ebpf_data);
+	} else {
+		g_k_type = K_TYPE_COMM;
+		snprintf(load_name, NAME_LEN, "socket-trace-bpf-linux-common");
+		bpf_bin_buffer = (void *)socket_trace_common_ebpf_data;
+		buffer_sz = sizeof(socket_trace_common_ebpf_data);
+	}
+
+	*bin_buffer = bpf_bin_buffer;
+	*bin_buf_size = buffer_sz;
+	return 0;
+}
+
+static void reconfig_load_resources(struct bpf_tracer *tracer, char *load_name,
+				    void *bin_buffer, int buffer_sz,
+				    struct tracer_probes_conf *tps)
+{
+	int i;
+	snprintf(tracer->bpf_load_name,
+		 sizeof(tracer->bpf_load_name), "%s", load_name);
+	tracer->bpf_load_name[sizeof(tracer->bpf_load_name) - 1] = '\0';
+	tracer->buffer_ptr = bin_buffer;
+	tracer->buffer_sz = buffer_sz;
+	for (i = 0; i < tps->kprobes_nr; i++)
+		free(tps->ksymbols[i].func);
+	tps->kprobes_nr = 0;
+	for (i = 0; i < tps->tps_nr; i++)
+		free(tps->tps[i].name);
+	tps->tps_nr = 0;
+	for (i = 0; i < tps->kfuncs_nr; i++)
+		free(tps->kfuncs[i].name);
+	tps->kfuncs_nr = 0;
+	if (g_k_type == K_TYPE_KFUNC)
+		config_probes_for_kfunc(tps);
+	else
+		config_probes_for_kprobe_and_tracepoint(tps);
+}
+
 /**
  * Start socket tracer
  *
@@ -2109,44 +2179,8 @@ int running_socket_tracer(tracer_callback_t handle,
 		return -EINVAL;
 	}
 
-	char sys_type_str[16];
-	memset(sys_type_str, 0, sizeof(sys_type_str));
-	if (fetch_system_type(sys_type_str, sizeof(sys_type_str) - 1) != ETR_OK) {
-		ebpf_warning("Fetch system type faild.\n");
-	}
-
-	if (fentry_can_attach(TEST_KFUNC_NAME)
-	    && get_kfunc_params_num(TEST_KFUNC_NAME) == TEST_KFUNC_PARAMS_NUM) {
-		g_k_type = K_TYPE_KFUNC;
-		snprintf(bpf_load_buffer_name, NAME_LEN,
-			 "socket-trace-bpf-linux-kfunc");
-		bpf_bin_buffer = (void *)socket_trace_kfunc_ebpf_data;
-		buffer_sz = sizeof(socket_trace_kfunc_ebpf_data);
-	} else if (strcmp(sys_type_str, "ky10") == 0) {
-		g_k_type = K_TYPE_KYLIN;
-		snprintf(bpf_load_buffer_name, NAME_LEN,
-			 "socket-trace-bpf-linux-kylin");
-		bpf_bin_buffer = (void *)socket_trace_kylin_ebpf_data;
-		buffer_sz = sizeof(socket_trace_kylin_ebpf_data);
-	} else if (major > 5 || (major == 5 && minor >= 2)) {
-		g_k_type = K_TYPE_VER_5_2_PLUS;
-		snprintf(bpf_load_buffer_name, NAME_LEN,
-			 "socket-trace-bpf-linux-5.2_plus");
-		bpf_bin_buffer = (void *)socket_trace_5_2_plus_ebpf_data;
-		buffer_sz = sizeof(socket_trace_5_2_plus_ebpf_data);
-	} else if (major == 3 && minor == 10) {
-		g_k_type = K_TYPE_VER_3_10;
-		snprintf(bpf_load_buffer_name, NAME_LEN,
-			 "socket-trace-bpf-linux-3.10.0");
-		bpf_bin_buffer = (void *)socket_trace_3_10_0_ebpf_data;
-		buffer_sz = sizeof(socket_trace_3_10_0_ebpf_data);
-	} else {
-		g_k_type = K_TYPE_COMM;
-		snprintf(bpf_load_buffer_name, NAME_LEN,
-			 "socket-trace-bpf-linux-common");
-		bpf_bin_buffer = (void *)socket_trace_common_ebpf_data;
-		buffer_sz = sizeof(socket_trace_common_ebpf_data);
-	}
+	select_bpf_binary(bpf_load_buffer_name, &bpf_bin_buffer, &buffer_sz,
+			  false);
 
 	/*
 	 * Initialize datadump
@@ -2201,8 +2235,19 @@ int running_socket_tracer(tracer_callback_t handle,
 
 	conf_max_trace_entries = max_trace_entries;
 
-	if (tracer_bpf_load(tracer))
+	bool has_attempted = false;
+retry_load:
+	if (tracer_bpf_load(tracer)) {
+		if (!has_attempted && g_k_type == K_TYPE_KFUNC) {
+			has_attempted = true;
+			select_bpf_binary(bpf_load_buffer_name, &bpf_bin_buffer,
+					  &buffer_sz, true);
+			reconfig_load_resources(tracer, bpf_load_buffer_name,
+						bpf_bin_buffer, buffer_sz, tps);
+			goto retry_load;
+		}
 		return -EINVAL;
+	}
 
 	/*
 	 * create reader for read perf buffer data. 

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -523,6 +523,11 @@ int tracer_bpf_load(struct bpf_tracer *tracer)
 	if (ret != 0) {
 		ebpf_warning("bpf load \"%s\" failed, error:%s (%d).\n",
 			     tracer->bpf_load_name, strerror(errno), errno);
+		if (!strcmp(tracer->bpf_load_name, "socket-trace-bpf-linux-kfunc")) {
+			ebpf_info("Try other eBPF bytecode binaries ...\n");
+			return ret;
+		}
+
 		if (errno == EACCES) {
 			ebpf_warning
 			    ("Check the selinux status, if found SELinux"


### PR DESCRIPTION


### This PR is for:


- Agent

#### Affected branches
- main
- v6.5