### PR TITLE
fix: add process_id in profile data query

### DIFF
--- a/server/querier/db_descriptions/clickhouse/tag/profile/in_process
+++ b/server/querier/db_descriptions/clickhouse/tag/profile/in_process
@@ -45,6 +45,7 @@ is_ipv4                    , is_ipv4                   , is_ipv4                
 
 app_service                , app_service               , app_service               , string_enum   ,                       , Service Info    , 111            , 0
 app_instance               , app_instance              , app_instance              , string_enum   ,                       , Service Info    , 111            , 0
+process_id                 , process_id                , process_id                , int           ,                       , Service Info    , 111            , 0
 
 trace_id                   , trace_id                  , trace_id                  , string        ,                       , Tracing Info    , 111            , 0
 span_name                  , span_name                 , span_name                 , string        ,                       , Tracing Info    , 111            , 0

--- a/server/querier/db_descriptions/clickhouse/tag/profile/in_process.ch
+++ b/server/querier/db_descriptions/clickhouse/tag/profile/in_process.ch
@@ -45,6 +45,7 @@ is_ipv4                    , IPv4 标志                  ,
 
 app_service                , 应用服务                    ,
 app_instance               , 应用实例                    ,
+process_id                 , 进程 ID                     ,
 
 trace_id                   , TraceID                    ,
 span_name                  , Span名称                    ,

--- a/server/querier/db_descriptions/clickhouse/tag/profile/in_process.en
+++ b/server/querier/db_descriptions/clickhouse/tag/profile/in_process.en
@@ -45,6 +45,7 @@ is_ipv4                    , IPv4 Flag                     ,
 
 app_service                , Application Service           ,
 app_instance               , Application Instance          ,
+process_id                 , Process ID                    ,
 
 trace_id                   , TraceID                       ,
 span_name                  , Span Name                     ,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes lack of process_id in profile tags
#### Changes to fix the bug
- add process_id in tags


