### PR TITLE
fix: agent - eBPF Handle the scenario where CONFIG_NET_NS is disabled

### DIFF
--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -281,6 +281,7 @@ u64 get_process_starttime_and_comm(pid_t pid,
 				   int len);
 u32 legacy_fetch_log2_page_size(void);
 u64 get_netns_id_from_pid(pid_t pid);
+bool check_netns_enabled(void);
 int get_nspid(int pid);
 int get_target_uid_and_gid(int target_pid, int *uid, int *gid);
 int copy_file(const char *src_file, const char *dest_file);

--- a/agent/src/ebpf/user/proc.c
+++ b/agent/src/ebpf/user/proc.c
@@ -545,8 +545,6 @@ static int config_symbolizer_proc_info(struct symbolizer_proc_info *p, int pid)
 	p->thread_names = NULL;
 	p->thread_names_lock = 0;
 	p->netns_id = get_netns_id_from_pid(pid);
-	if (p->netns_id == 0)
-		return ETR_INVAL;
 
 	fetch_container_id(pid, p->container_id, sizeof(p->container_id));
 

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -1777,6 +1777,11 @@ int bpf_tracer_init(const char *log_file, bool is_stdout)
 	prev_sys_boot_time_ns = sys_boot_time_ns;
 	ebpf_info("sys_boot_time_ns : %llu\n", sys_boot_time_ns);
 
+	if (!check_netns_enabled())
+		ebpf_warning("If the system has not enabled the 'CONFIG_NET_NS'"
+			     " option, the 'netns_id' for continuously profiling"
+			     " data will be 0.\n");
+
 	/*
 	 * Set up the lock now, so we can use it to make the first add
 	 * thread-safe for tracer alloc.


### PR DESCRIPTION
Fix issues in certain custom kernel systems where the lack of the 'CONFIG_NET_NS' compile option causes process information to fail during the agent initialization phase.


### This PR is for:


- Agent


#### Affected branches
- main
- v6.5
- v6.4


