### PR TITLE
feat: support same pron in extra-filters

### DIFF
--- a/server/querier/app/prometheus/router/prometheus.go
+++ b/server/querier/app/prometheus/router/prometheus.go
@@ -89,6 +89,7 @@ func promQueryRange(svc *service.PrometheusService) gin.HandlerFunc {
 		debug := c.Request.FormValue("debug")
 		block_team_id := c.Request.FormValue("block-team-id")
 		offloading := c.Request.FormValue("operator-offloading")
+		args.ExtraFilters = c.Request.FormValue("extra-filters")
 		setRouterArgs(slimit, &args.Slimit, config.Cfg.Prometheus.SeriesLimit, strconv.Atoi)
 		setRouterArgs(debug, &args.Debug, config.Cfg.Prometheus.RequestQueryWithDebug, strconv.ParseBool)
 		setRouterArgs(offloading, &args.Offloading, config.Cfg.Prometheus.OperatorOffloading, strconv.ParseBool)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### support extra filters parser in promql
#### Checklist
- [X] Added unit test.
#### Backport to branches
- main