### PR TITLE
fix: use sw uri to identify json/grpc request

### DIFF
--- a/agent/plugins/integration_skywalking/src/lib.rs
+++ b/agent/plugins/integration_skywalking/src/lib.rs
@@ -47,3 +47,15 @@ pub async fn handle_skywalking_request(
         .body(Body::empty())
         .unwrap()
 }
+
+pub async fn handle_skywalking_streaming_request(
+    _: SocketAddr,
+    _: Body,
+    _: &str,
+    _: DebugSender<SkyWalkingExtra>,
+) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::empty())
+        .unwrap()
+}

--- a/message/flow_log.proto
+++ b/message/flow_log.proto
@@ -299,4 +299,5 @@ message MqttTopic {
 message SkyWalkingExtra {
     bytes data = 1;
     bytes peer_ip = 2;
+    string uri = 3;
 }

--- a/server/ingester/flow_log/decoder/decoder.go
+++ b/server/ingester/flow_log/decoder/decoder.go
@@ -304,15 +304,16 @@ func (d *Decoder) handleSkyWalking(decoder *codec.SimpleDecoder, pbSkyWalkingDat
 			d.counter.ErrorCount++
 			continue
 		}
-		d.sendSkyWalking(pbSkyWalkingData.Data, pbSkyWalkingData.PeerIp)
+		d.sendSkyWalking(pbSkyWalkingData.Data, pbSkyWalkingData.PeerIp, pbSkyWalkingData.Uri)
 	}
 }
-func (d *Decoder) sendSkyWalking(segmentData, peerIP []byte) {
+
+func (d *Decoder) sendSkyWalking(segmentData, peerIP []byte, uri string) {
 	if d.debugEnabled {
 		log.Debugf("decoder %d vtap %d recv skywalking data length: %d", d.index, d.agentId, len(segmentData))
 	}
 	d.counter.Count++
-	ls := sw_import.SkyWalkingDataToL7FlowLogs(d.agentId, d.orgId, d.teamId, segmentData, peerIP, d.platformData, d.cfg)
+	ls := sw_import.SkyWalkingDataToL7FlowLogs(d.agentId, d.orgId, d.teamId, segmentData, peerIP, uri, d.platformData, d.cfg)
 	for _, l := range ls {
 		l.AddReferenceCount()
 		if !d.throttler.SendWithThrottling(l) {

--- a/server/ingester/flow_log/log_data/sw_import/sw_import.go
+++ b/server/ingester/flow_log/log_data/sw_import/sw_import.go
@@ -22,6 +22,6 @@ import (
 	"github.com/deepflowio/deepflow/server/libs/grpc"
 )
 
-func SkyWalkingDataToL7FlowLogs(vtapID, orgId, teamId uint16, segmentData, peerIP []byte, platformData *grpc.PlatformInfoTable, cfg *flowlogCfg.Config) []*log_data.L7FlowLog {
+func SkyWalkingDataToL7FlowLogs(vtapID, orgId, teamId uint16, segmentData, peerIP []byte, uri string, platformData *grpc.PlatformInfoTable, cfg *flowlogCfg.Config) []*log_data.L7FlowLog {
 	return []*log_data.L7FlowLog{}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Client
- Server
- Message
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes sw integration by js/go agent not working
#### Steps to reproduce the bug
- use js/go agent as skywalking data agent and upload data to deepflow-agent
- expected: uploaded app span
- real: not uploaded
#### Changes to fix the bug
- add uri idenitfy for data deserialization and streaming handling for skywalking grpc-client stream mode
#### Affected branches
- main


