### PR TITLE
feat: flow_metrics add 1h/1d datasource default

### DIFF
--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -184,6 +184,34 @@ func initTable(conn clickhouse.Conn, timeZone string, t *ckdb.Table, orgID uint1
 		return err
 	}
 
+	if t.Aggr1H1D {
+		if err := ExecSQL(conn, t.MakeAggrTableCreateSQL1H(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrMVTableCreateSQL1H(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrLocalTableCreateSQL1H(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrGlobalTableCreateSQL1H(orgID)); err != nil {
+			return err
+		}
+
+		if err := ExecSQL(conn, t.MakeAggrTableCreateSQL1D(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrMVTableCreateSQL1D(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrLocalTableCreateSQL1D(orgID)); err != nil {
+			return err
+		}
+		if err := ExecSQL(conn, t.MakeAggrGlobalTableCreateSQL1D(orgID)); err != nil {
+			return err
+		}
+	}
+
 	// ByConity not support modify timezone
 	if t.DBType == ckdb.CKDBTypeByconity {
 		return nil

--- a/server/libs/ckdb/ckdb.go
+++ b/server/libs/ckdb/ckdb.go
@@ -328,7 +328,7 @@ type Column struct {
 }
 
 func (c *Column) MakeModifyTimeZoneSQL(database, table, timeZone string) string {
-	if timeZone == "" || !c.Type.HasDFTimeZone() {
+	if timeZone == "" || timeZone == DF_TIMEZONE || !c.Type.HasDFTimeZone() {
 		return ""
 	}
 	newTimeZoneType := strings.ReplaceAll(c.Type.String(), DF_TIMEZONE, timeZone)

--- a/server/libs/ckdb/table.go
+++ b/server/libs/ckdb/table.go
@@ -29,7 +29,62 @@ const (
 	ORG_ID_LEN        = 4 // length of 'xxxx'
 	ORG_ID_PREFIX_LEN = 5 // length of 'xxxx_'
 	MAX_ORG_ID        = 1024
+	AGGREGATION_1H    = "1h"
+	AGGREGATION_1D    = "1d"
+	DEFAULT_1H_TTL    = 24 * 30 // 30 day
+	DEFAULT_1D_TTL    = 24 * 30 // 30 day
 )
+
+type AggregationInterval uint8
+
+const (
+	AggregationMinute AggregationInterval = iota
+	AggregationHour
+	AggregationDay
+)
+
+func (a AggregationInterval) String() string {
+	switch a {
+	case AggregationMinute:
+		return "1m"
+	case AggregationHour:
+		return "1h"
+	case AggregationDay:
+		return "1d"
+	default:
+		return "unkunown aggregation interval"
+	}
+}
+
+func (a AggregationInterval) PartitionBy() TimeFuncType {
+	switch a {
+	case AggregationMinute:
+		return TimeFuncTwelveHour
+	case AggregationHour:
+		return TimeFuncWeek
+	case AggregationDay:
+		return TimeFuncYYYYMM
+	default:
+		return TimeFuncWeek
+	}
+}
+
+func (a AggregationInterval) Aggregation() TimeFuncType {
+	switch a {
+	case AggregationMinute:
+		return TimeFuncMinute
+	case AggregationHour:
+		return TimeFuncHour
+	case AggregationDay:
+		return TimeFuncDay
+	default:
+		return TimeFuncHour
+	}
+}
+
+func (a AggregationInterval) AggregationPrevious() AggregationInterval {
+	return a - 1
+}
 
 func IsDefaultOrgID(orgID uint16) bool {
 	if orgID == DEFAULT_ORG_ID || orgID == INVALID_ORG_ID {
@@ -94,6 +149,7 @@ type Table struct {
 	Engine          EngineType   // 表引擎
 	OrderKeys       []string     // 排序的key
 	PrimaryKeyCount int          // 一级索引的key的个数, 从orderKeys中数前n个,
+	Aggr1H1D        bool         // 是否创建 1h/1d 表
 }
 
 func (t *Table) OrgDatabase(orgID uint16) string {
@@ -209,49 +265,6 @@ func (t *Table) MakeOrgGlobalTableCreateSQL(orgID uint16) string {
 	return t.makeGlobalTableCreateSQL(t.OrgDatabase(orgID))
 }
 
-// database 'xxxx_deepflow_system' adds 'deepflow_system' view pointing to the 'deepflow_system_agent' and 'deepflow_system_server' table
-func (t *Table) MakeViewsCreateSQLForDeepflowSystem(orgID uint16) []string {
-	createViewSqls := []string{}
-	orgDatabase := t.OrgDatabase(orgID)
-	if t.Database == "deepflow_system" && t.GlobalName == "deepflow_system_server" {
-		// recreate table view xxxx_deepflow_system.deepflow_system, for upgrade
-		dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s.deepflow_system", orgDatabase)
-		createViewSqls = append(createViewSqls, dropTable)
-
-		deepflowSystemServerView := fmt.Sprintf("CREATE VIEW IF NOT EXISTS %s.`deepflow_system` AS SELECT * FROM %s.`deepflow_system_agent` UNION ALL SELECT * FROM deepflow_system.deepflow_system_server",
-			orgDatabase, orgDatabase)
-		if !IsDefaultOrgID(orgID) {
-			deepflowSystemServerView += fmt.Sprintf(" UNION ALL SELECT * FROM %s.deepflow_system_server", orgDatabase)
-		}
-		createViewSqls = append(createViewSqls, deepflowSystemServerView)
-	}
-	if t.Database == "flow_tag" && t.GlobalName == "deepflow_system_server_custom_field" {
-		// recreate table xxxx_flow_tag.deepflow_system_custom_field, for upgrade
-		dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s.deepflow_system_custom_field", orgDatabase)
-		createViewSqls = append(createViewSqls, dropTable)
-
-		flowTagFieldView := fmt.Sprintf("CREATE VIEW IF NOT EXISTS %s.`deepflow_system_custom_field` AS SELECT * FROM %s.`deepflow_system_agent_custom_field` UNION ALL SELECT * FROM flow_tag.deepflow_system_server_custom_field",
-			orgDatabase, orgDatabase)
-		if !IsDefaultOrgID(orgID) {
-			flowTagFieldView += fmt.Sprintf(" UNION ALL SELECT * FROM %s.deepflow_system_server_custom_field", orgDatabase)
-		}
-		createViewSqls = append(createViewSqls, flowTagFieldView)
-	}
-	if t.Database == "flow_tag" && t.GlobalName == "deepflow_system_server_custom_field_value" {
-		// recreate table xxxx_flow_tag.deepflow_system_custom_field_value, for upgrade
-		dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s.deepflow_system_custom_field_value", orgDatabase)
-		createViewSqls = append(createViewSqls, dropTable)
-
-		flowTagFieldValueView := fmt.Sprintf("CREATE VIEW IF NOT EXISTS %s.`deepflow_system_custom_field_value` AS SELECT * FROM %s.`deepflow_system_agent_custom_field_value` UNION ALL SELECT * FROM flow_tag.deepflow_system_server_custom_field_value",
-			orgDatabase, orgDatabase)
-		if !IsDefaultOrgID(orgID) {
-			flowTagFieldValueView += fmt.Sprintf(" UNION ALL SELECT * FROM %s.deepflow_system_server_custom_field_value", orgDatabase)
-		}
-		createViewSqls = append(createViewSqls, flowTagFieldValueView)
-	}
-	return createViewSqls
-}
-
 func (t *Table) makePrepareTableInsertSQL(database string) string {
 	if t.DBType == CKDBTypeByconity {
 		t.LocalName = t.GlobalName
@@ -277,4 +290,214 @@ func (t *Table) MakePrepareTableInsertSQL() string {
 
 func (t *Table) MakeOrgPrepareTableInsertSQL(orgID uint16) string {
 	return t.makePrepareTableInsertSQL(t.OrgDatabase(orgID))
+}
+
+func stringSliceHas(items []string, item string) bool {
+	for _, s := range items {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *Table) makeTTLString(duration int) string {
+	if t.ColdStorage.Enabled {
+		return fmt.Sprintf("%s + toIntervalHour(%d), %s +  toIntervalHour(%d) TO %s '%s'",
+			t.TimeKey, duration,
+			t.TimeKey, t.ColdStorage.TTLToMove, t.ColdStorage.Type, t.ColdStorage.Name)
+	}
+	return fmt.Sprintf("%s + toIntervalHour(%d)", t.TimeKey, duration)
+}
+
+func isUnsummable(column *Column) bool {
+	if strings.HasSuffix(column.Name, "_max") ||
+		column.Name == "direction_score" {
+		return true
+	}
+	return false
+}
+
+func getAggr(column *Column) string {
+	if isUnsummable(column) {
+		return "avg"
+	}
+	return "sum"
+}
+
+func (t *Table) MakeAggrTableCreateSQL1H(orgID uint16) string {
+	return t.MakeAggrTableCreateSQL(orgID, AggregationHour, DEFAULT_1H_TTL)
+}
+
+func (t *Table) MakeAggrMVTableCreateSQL1H(orgID uint16) string {
+	return t.MakeAggrMVTableCreateSQL(orgID, AggregationHour)
+}
+
+func (t *Table) MakeAggrLocalTableCreateSQL1H(orgID uint16) string {
+	return t.MakeAggrLocalTableCreateSQL(orgID, AggregationHour)
+}
+
+func (t *Table) MakeAggrGlobalTableCreateSQL1H(orgID uint16) string {
+	return t.MakeAggrGlobalTableCreateSQL(orgID, AggregationHour)
+}
+
+func (t *Table) MakeAggrTableCreateSQL1D(orgID uint16) string {
+	return t.MakeAggrTableCreateSQL(orgID, AggregationDay, DEFAULT_1D_TTL)
+}
+
+func (t *Table) MakeAggrMVTableCreateSQL1D(orgID uint16) string {
+	return t.MakeAggrMVTableCreateSQL(orgID, AggregationDay)
+}
+
+func (t *Table) MakeAggrLocalTableCreateSQL1D(orgID uint16) string {
+	return t.MakeAggrLocalTableCreateSQL(orgID, AggregationDay)
+}
+
+func (t *Table) MakeAggrGlobalTableCreateSQL1D(orgID uint16) string {
+	return t.MakeAggrGlobalTableCreateSQL(orgID, AggregationDay)
+}
+
+func (t *Table) tablePrefix() string {
+	return strings.Split(t.GlobalName, ".")[0]
+}
+
+func (t *Table) MakeAggrTableCreateSQL(orgID uint16, aggrInterval AggregationInterval, ttlHour int) string {
+	tableAgg := fmt.Sprintf("%s.`%s.%s_agg`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	columns := []string{}
+	orderKeys := t.OrderKeys
+	for _, c := range t.Columns {
+		// ignore fields starting with '_', such as _tid, _id
+		if strings.HasPrefix(c.Name, "_") {
+			continue
+		}
+		codec := ""
+		if c.Codec != CodecDefault {
+			codec = fmt.Sprintf("codec(%s)", c.Codec.String())
+		}
+
+		if c.Name == t.TimeKey {
+			c.Comment = t.Version
+		}
+
+		if c.GroupBy {
+			comment := ""
+			if c.Comment != "" {
+				comment = fmt.Sprintf("COMMENT '%s'", c.Comment)
+			}
+			columns = append(columns, fmt.Sprintf("%s %s %s %s", c.Name, c.Type.String(), comment, codec))
+		} else {
+			columns = append(columns, fmt.Sprintf("%s__agg AggregateFunction(%s, %s)", c.Name, getAggr(c), c.Type.String()))
+		}
+	}
+
+	engine := AggregatingMergeTree.String()
+	if t.DBType == CKDBTypeByconity {
+		engine = CnchAggregatingMergeTree.String()
+	}
+
+	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s
+				   (%s)
+				   ENGINE=%s
+				   PRIMARY KEY (%s)
+				   ORDER BY (%s)
+				   PARTITION BY %s
+				   TTL %s
+				   SETTINGS storage_policy = '%s'`,
+		tableAgg,
+		strings.Join(columns, ",\n"),
+		engine,
+		strings.Join(t.OrderKeys[:t.PrimaryKeyCount], ","),
+		strings.Join(orderKeys, ","), // 以order by的字段排序, 相同的做聚合
+		aggrInterval.PartitionBy().String(t.TimeKey),
+		t.makeTTLString(ttlHour),
+		t.StoragePolicy)
+}
+
+func (t *Table) MakeAggrMVTableCreateSQL(orgID uint16, aggrInterval AggregationInterval) string {
+	tableMv := fmt.Sprintf("%s.`%s.%s_mv`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	tableAgg := fmt.Sprintf("%s.`%s.%s_agg`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	tableBase := fmt.Sprintf("%s.`%s.1m_local`", t.OrgDatabase(orgID), t.tablePrefix())
+
+	if t.DBType == CKDBTypeByconity {
+		tableBase = fmt.Sprintf("%s.`%s.1m`", t.OrgDatabase(orgID), t.tablePrefix())
+	}
+
+	groupKeys := t.OrderKeys
+	columns := []string{}
+	for _, c := range t.Columns {
+		if strings.HasPrefix(c.Name, "_") {
+			continue
+		}
+		if c.GroupBy {
+			if c.Name == t.TimeKey {
+				columns = append(columns, fmt.Sprintf("%s AS %s", aggrInterval.Aggregation().String(t.TimeKey), t.TimeKey))
+			} else {
+				columns = append(columns, c.Name)
+			}
+			if !stringSliceHas(groupKeys, c.Name) {
+				groupKeys = append(groupKeys, c.Name)
+			}
+		} else {
+			columns = append(columns, fmt.Sprintf("%sState(%s) AS %s__agg", getAggr(c), c.Name, c.Name))
+		}
+	}
+
+	return fmt.Sprintf(`CREATE MATERIALIZED VIEW IF NOT EXISTS %s TO %s
+			AS SELECT %s
+	                FROM %s
+			GROUP BY (%s)
+			ORDER BY (%s)`,
+		tableMv, tableAgg,
+		strings.Join(columns, ",\n"),
+		tableBase,
+		strings.Join(groupKeys, ","),
+		strings.Join(t.OrderKeys, ","))
+}
+
+func (t *Table) MakeAggrLocalTableCreateSQL(orgID uint16, aggrInterval AggregationInterval) string {
+	tableAgg := fmt.Sprintf("%s.`%s.%s_agg`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	tableLocal := fmt.Sprintf("%s.`%s.%s_local`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	if t.DBType == CKDBTypeByconity {
+		tableLocal = fmt.Sprintf("%s.`%s.%s`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+	}
+
+	columns := []string{}
+	groupKeys := t.OrderKeys
+	for _, c := range t.Columns {
+		if strings.HasPrefix(c.Name, "_") {
+			continue
+		}
+		if c.GroupBy {
+			columns = append(columns, c.Name)
+			if !stringSliceHas(groupKeys, c.Name) {
+				groupKeys = append(groupKeys, c.Name)
+			}
+		} else {
+			columns = append(columns, fmt.Sprintf("%sMerge(%s__agg) AS %s", getAggr(c), c.Name, c.Name))
+		}
+	}
+
+	return fmt.Sprintf(`
+CREATE VIEW IF NOT EXISTS %s
+AS SELECT
+%s
+FROM %s
+GROUP BY %s`,
+		tableLocal,
+		strings.Join(columns, ",\n"),
+		tableAgg,
+		strings.Join(groupKeys, ","))
+}
+
+func (t *Table) MakeAggrGlobalTableCreateSQL(orgID uint16, aggrInterval AggregationInterval) string {
+	if t.DBType == CKDBTypeByconity {
+		return "SELECT VERSION()"
+	}
+	tableGlobal := fmt.Sprintf("%s.%s", t.tablePrefix(), aggrInterval.String())
+	tableLocal := fmt.Sprintf("%s.%s_local", t.tablePrefix(), aggrInterval.String())
+
+	engine := fmt.Sprintf(Distributed.String(), t.Cluster, t.OrgDatabase(orgID), tableLocal)
+	createTable := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.`%s` AS %s.`%s` ENGINE = %s",
+		t.OrgDatabase(orgID), tableGlobal, t.OrgDatabase(orgID), tableLocal, engine)
+	return createTable
 }

--- a/server/libs/flow-metrics/tag.go
+++ b/server/libs/flow-metrics/tag.go
@@ -355,6 +355,7 @@ type Field struct {
 func newMetricsMinuteTable(id MetricsTableID, engine ckdb.EngineType, version, cluster, storagePolicy, ckdbType string, ttl int, coldStorage *ckdb.ColdStorage) *ckdb.Table {
 	timeKey := "time"
 
+	aggr1H1DTable := true
 	var orderKeys []string
 	code := metricsTableCodes[id]
 	if code&L3EpcID != 0 {
@@ -363,6 +364,7 @@ func newMetricsMinuteTable(id MetricsTableID, engine ckdb.EngineType, version, c
 		orderKeys = []string{timeKey, "l3_epc_id_1", "ip4_1", "ip6_1", "l3_epc_id_0", "ip4_0", "ip6_0"}
 	} else if code&ACLGID != 0 {
 		orderKeys = []string{timeKey, "acl_gid"}
+		aggr1H1DTable = false
 	}
 	if code&ServerPort != 0 {
 		orderKeys = append(orderKeys, "server_port")
@@ -395,6 +397,7 @@ func newMetricsMinuteTable(id MetricsTableID, engine ckdb.EngineType, version, c
 		ColdStorage:     *coldStorage,
 		OrderKeys:       orderKeys,
 		PrimaryKeyCount: len(orderKeys),
+		Aggr1H1D:        aggr1H1DTable,
 	}
 }
 
@@ -408,6 +411,7 @@ func newMetricsSecondTable(minuteTable *ckdb.Table, ttl int, coldStorages *ckdb.
 	t.ColdStorage = *coldStorages
 	t.PartitionFunc = ckdb.TimeFuncFourHour
 	t.Engine = ckdb.MergeTree // 秒级数据不用支持使用replica
+	t.Aggr1H1D = false
 
 	return &t
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


