### PR TITLE
fix: failed to create 1h/1d data source, do not cause startup failure

### DIFF
--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -186,29 +186,29 @@ func initTable(conn clickhouse.Conn, timeZone string, t *ckdb.Table, orgID uint1
 
 	if t.Aggr1H1D {
 		if err := ExecSQL(conn, t.MakeAggrTableCreateSQL1H(orgID)); err != nil {
-			return err
+			log.Warningf("create 1h agg table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrMVTableCreateSQL1H(orgID)); err != nil {
-			return err
+			log.Warningf("create 1h mv table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrLocalTableCreateSQL1H(orgID)); err != nil {
-			return err
+			log.Warningf("create 1h local table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrGlobalTableCreateSQL1H(orgID)); err != nil {
-			return err
+			log.Warningf("create 1h global table failed: %s", err)
 		}
 
 		if err := ExecSQL(conn, t.MakeAggrTableCreateSQL1D(orgID)); err != nil {
-			return err
+			log.Warningf("create 1d agg table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrMVTableCreateSQL1D(orgID)); err != nil {
-			return err
+			log.Warningf("create 1d mv table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrLocalTableCreateSQL1D(orgID)); err != nil {
-			return err
+			log.Warningf("create 1d local table failed: %s", err)
 		}
 		if err := ExecSQL(conn, t.MakeAggrGlobalTableCreateSQL1D(orgID)); err != nil {
-			return err
+			log.Warningf("create 1d global table failed: %s", err)
 		}
 	}
 


### PR DESCRIPTION
The old version has different aggregation methods for some fields than the new version, such as direction_score, which will cause the automatic creation of the 1h/1d data source to fail, but it will not affect it.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


