### PR TITLE
fix: agent - eBPF Kernels below v5.2 cannot retrieve IO events

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1685,6 +1685,8 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 	       != SOCK_CHECK_TYPE_ERROR))) {
 #if defined(LINUX_VER_KFUNC) || defined(LINUX_VER_5_2_PLUS)
 		return trace_io_event_common(ctx, offset, args, direction, id);
+#else
+		return -1;
 #endif
 	}
 


### PR DESCRIPTION


### This PR is for:


- Agent


#### Affected branches
- v6.5
