### PR TITLE
perf: modify materialized view local table without group by

### DIFF
--- a/server/ingester/datasource/handle.go
+++ b/server/ingester/datasource/handle.go
@@ -175,8 +175,8 @@ func getColumnString(column *ckdb.Column, aggrSummable, aggrUnsummable string, t
 				strings.ReplaceAll(column.Name, "count", "sum"), strings.ReplaceAll(column.Name, "sum", "count"), // 总是取 xxx_sum/xxx_count 的值
 				column.Name, AGG.String())
 		case LOCAL:
-			// 例如： argMaxMerge(rtt_count__agg) as rtt_count,
-			return fmt.Sprintf("%sMerge(%s__%s) AS %s", aggrFunc, column.Name, AGG.String(), column.Name)
+			// 例如： finalizeAggregation(rtt_count__agg) as rtt_count,
+			return fmt.Sprintf("finalizeAggregation(%s__%s) AS %s", column.Name, AGG.String(), column.Name)
 		}
 	} else {
 		var aggr string
@@ -197,7 +197,7 @@ func getColumnString(column *ckdb.Column, aggrSummable, aggrUnsummable string, t
 		case MV:
 			return fmt.Sprintf("%sState(%s) AS %s__%s", aggr, column.Name, column.Name, AGG.String())
 		case LOCAL:
-			return fmt.Sprintf("%sMerge(%s__%s) AS %s", aggr, column.Name, AGG.String(), column.Name)
+			return fmt.Sprintf("finalizeAggregation(%s__%s) AS %s", column.Name, AGG.String(), column.Name)
 		}
 	}
 
@@ -441,12 +441,10 @@ func MakeCreateTableLocal(t *ckdb.Table, db, dstTable, aggrSummable, aggrUnsumma
 CREATE VIEW IF NOT EXISTS %s
 AS SELECT
 %s
-FROM %s
-GROUP BY %s`,
+FROM %s`,
 		tableLocal,
 		strings.Join(columns, ",\n"),
-		tableAgg,
-		strings.Join(groupKeys, ","))
+		tableAgg)
 }
 
 func MakeGlobalTableCreateSQL(t *ckdb.Table, db, dstTable string) string {

--- a/server/libs/ckdb/table.go
+++ b/server/libs/ckdb/table.go
@@ -497,7 +497,7 @@ func (t *Table) MakeAggrLocalTableCreateSQL(orgID uint16, aggrInterval Aggregati
 				groupKeys = append(groupKeys, c.Name)
 			}
 		} else {
-			columns = append(columns, fmt.Sprintf("%sMerge(%s__agg) AS %s", getAggr(c), c.Name, c.Name))
+			columns = append(columns, fmt.Sprintf("finalizeAggregation(%s__agg) AS %s", c.Name, c.Name))
 		}
 	}
 
@@ -505,12 +505,10 @@ func (t *Table) MakeAggrLocalTableCreateSQL(orgID uint16, aggrInterval Aggregati
 CREATE VIEW IF NOT EXISTS %s
 AS SELECT
 %s
-FROM %s
-GROUP BY %s`,
+FROM %s`,
 		tableLocal,
 		strings.Join(columns, ",\n"),
-		tableAgg,
-		strings.Join(groupKeys, ","))
+		tableAgg)
 }
 
 func (t *Table) MakeAggrGlobalTableCreateSQL(orgID uint16, aggrInterval AggregationInterval) string {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


