### PR TITLE
feat: sender add compress flag

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -2366,6 +2366,20 @@ impl Default for Npb {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct OutputCompression {
+    pub application_log: bool,
+}
+
+impl Default for OutputCompression {
+    fn default() -> Self {
+        Self {
+            application_log: true,
+        }
+    }
+}
+
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct Outputs {
@@ -2373,6 +2387,7 @@ pub struct Outputs {
     pub flow_log: OutputsFlowLog,
     pub flow_metrics: FlowMetrics,
     pub npb: Npb,
+    pub compression: OutputCompression,
 }
 
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -1488,6 +1488,7 @@ pub struct MetricServerConfig {
     pub port: u16,
     pub compressed: bool,
     pub profile_compressed: bool,
+    pub application_log_compressed: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -2052,6 +2053,7 @@ impl TryFrom<(Config, UserConfig)> for ModuleConfig {
                 port: conf.inputs.integration.listen_port,
                 compressed: conf.inputs.integration.compression.trace,
                 profile_compressed: conf.inputs.integration.compression.profile,
+                application_log_compressed: conf.outputs.compression.application_log,
             },
             agent_type: conf.global.common.agent_type,
             port_config: PortConfig {
@@ -4121,6 +4123,14 @@ impl ConfigHandler {
                 npb.target_port, new_npb.target_port
             );
             npb.target_port = new_npb.target_port;
+            restart_agent = !first_run;
+        }
+        if outputs.compression != new_outputs.compression {
+            info!(
+                "Update outputs.compression from {:?} to {:?}.",
+                outputs.compression, new_outputs.compression
+            );
+            outputs.compression = new_outputs.compression.clone();
             restart_agent = !first_run;
         }
 

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -17,6 +17,7 @@
 use std::env;
 use std::fmt;
 use std::fs;
+use std::io::Write;
 use std::mem;
 use std::net::SocketAddr;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
@@ -32,12 +33,18 @@ use std::time::Duration;
 use anyhow::{anyhow, Result};
 use arc_swap::access::Access;
 use dns_lookup::lookup_host;
+use flate2::{
+    write::{GzEncoder, ZlibEncoder},
+    Compression,
+};
 use flexi_logger::{
     colored_opt_format, writers::LogWriter, Age, Cleanup, Criterion, FileSpec, Logger, Naming,
 };
 use log::{debug, info, warn};
+use num_enum::{FromPrimitive, IntoPrimitive};
 use tokio::runtime::{Builder, Runtime};
 use tokio::sync::broadcast;
+use zstd::Encoder as ZstdEncoder;
 
 use crate::{
     collector::{
@@ -233,6 +240,47 @@ impl From<&AgentId> for agent::AgentId {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug, FromPrimitive, IntoPrimitive, num_enum::Default)]
+#[repr(u8)]
+pub enum SenderEncoder {
+    #[num_enum(default)]
+    Raw = 0,
+
+    Zlib = 1,
+    Gzip = 2,
+    Zstd = 3,
+}
+
+impl SenderEncoder {
+    pub fn encode(&self, encode_buffer: &[u8]) -> std::io::Result<Option<Vec<u8>>> {
+        let result = match self {
+            Self::Raw => None,
+            Self::Zlib => {
+                let mut encoder = ZlibEncoder::new(
+                    Vec::with_capacity(encode_buffer.len()),
+                    Compression::default(),
+                );
+                encoder.write_all(&encode_buffer)?;
+                Some(encoder.finish()?)
+            }
+            Self::Gzip => {
+                let mut encoder = GzEncoder::new(
+                    Vec::with_capacity(encode_buffer.len()),
+                    Compression::default(),
+                );
+                encoder.write_all(&encode_buffer)?;
+                Some(encoder.finish()?)
+            }
+            Self::Zstd => {
+                let mut encoder = ZstdEncoder::new(Vec::with_capacity(encode_buffer.len()), 0)?;
+                encoder.write_all(&encode_buffer)?;
+                Some(encoder.finish()?)
+            }
+        };
+        Ok(result)
+    }
+}
+
 pub struct Trident {
     state: AgentState,
     handle: Option<JoinHandle<()>>,
@@ -312,6 +360,7 @@ impl Trident {
             stats_collector.clone(),
             exception_handler.clone(),
             Some(log_stats_shared_connection.clone()),
+            SenderEncoder::Raw,
         );
         stats_sender.start();
 
@@ -2162,6 +2211,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            SenderEncoder::Raw,
         );
 
         let metrics_queue_name = "3-doc-to-collector-sender";
@@ -2184,6 +2234,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            SenderEncoder::Raw,
         );
 
         let proto_log_queue_name = "2-protolog-to-collector-sender";
@@ -2206,6 +2257,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            SenderEncoder::Raw,
         );
 
         let analyzer_ip = if candidate_config
@@ -2273,6 +2325,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             Some(pcap_packet_shared_connection.clone()),
+            SenderEncoder::Raw,
         );
         // Enterprise Edition Feature: packet-sequence
         let packet_sequence_queue_name = "2-packet-sequence-block-to-sender";
@@ -2298,6 +2351,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             Some(pcap_packet_shared_connection),
+            SenderEncoder::Raw,
         );
 
         let bpf_builder = bpf::Builder {
@@ -2408,6 +2462,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            SenderEncoder::Raw,
         );
 
         let profile_queue_name = "1-profile-to-sender";
@@ -2430,6 +2485,9 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            // profiler compress is a special one, it requires compressed and directly write into db
+            // so we compress profile data inside and not compress secondly
+            SenderEncoder::Raw,
         );
         let application_log_queue_name = "1-application-log-to-sender";
         let (application_log_sender, application_log_receiver, counter) = queue::bounded_with_debug(
@@ -2455,6 +2513,11 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            if candidate_config.metric_server.application_log_compressed {
+                SenderEncoder::Zlib
+            } else {
+                SenderEncoder::Raw
+            },
         );
 
         let skywalking_queue_name = "1-skywalking-to-sender";
@@ -2481,6 +2544,11 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            if candidate_config.metric_server.compressed {
+                SenderEncoder::Zlib
+            } else {
+                SenderEncoder::Raw
+            },
         );
 
         let datadog_queue_name = "1-datadog-to-sender";
@@ -2507,6 +2575,11 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            if candidate_config.metric_server.compressed {
+                SenderEncoder::Zlib
+            } else {
+                SenderEncoder::Raw
+            },
         );
 
         let ebpf_dispatcher_id = dispatcher_components.len();
@@ -2631,6 +2704,11 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            if candidate_config.metric_server.compressed {
+                SenderEncoder::Zlib
+            } else {
+                SenderEncoder::Raw
+            },
         );
 
         let otel_dispatcher_id = ebpf_dispatcher_id + 1;
@@ -2689,6 +2767,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             Some(prometheus_telegraf_shared_connection.clone()),
+            SenderEncoder::Raw,
         );
 
         let telegraf_queue_name = "1-telegraf-to-sender";
@@ -2715,6 +2794,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             Some(prometheus_telegraf_shared_connection),
+            SenderEncoder::Raw,
         );
 
         let compressed_otel_queue_name = "1-compressed-otel-to-sender";
@@ -2741,6 +2821,7 @@ impl AgentComponents {
             stats_collector.clone(),
             exception_handler.clone(),
             None,
+            SenderEncoder::Raw,
         );
 
         let (external_metrics_server, external_metrics_counter) = MetricServer::new(

--- a/agent/src/utils/logger.rs
+++ b/agent/src/utils/logger.rs
@@ -36,6 +36,7 @@ use crate::{
     config::handler::{LogAccess, LogConfig, SenderAccess},
     exception::ExceptionHandler,
     sender::uniform_sender::{Connection, UniformSenderThread},
+    trident::SenderEncoder,
 };
 
 macro_rules! write_message {
@@ -123,6 +124,7 @@ impl RemoteLogWriter {
             stats_collector,
             exception_handler,
             Some(shared_conn),
+            SenderEncoder::Raw,
         );
         uniform_sender.start();
         Self {

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -5152,6 +5152,7 @@ inputs:
 开启后，deepflow-agent 将对集成的剖析数据进行压缩处理，压缩比例在 5:1~10:1 之间。注意：
 开启此特性将增加 deepflow-agent 的 CPU 消耗。
 
+
 ### Prometheus 额外 Label {#inputs.integration.prometheus_extra_labels}
 
 deepflow-agent 支持从 Prometheus RemoteWrite 的 http header 中获取额外的 label。
@@ -8496,6 +8497,35 @@ outputs:
 **详细描述**:
 
 设置 deepflow-agent 做 NPB 分发的最大吞吐率。
+
+## 压缩 {#outputs.compression}
+
+## 应用日志 {#outputs.compression.application_log}
+
+**标签**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`outputs.compression.application_log`
+
+**默认值**:
+```yaml
+outputs:
+  compression:
+    application_log: true
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**详细描述**:
+
+开启后，deepflow-agent 将对集成的应用日志数据进行压缩处理，压缩比例在 5:1~20:1 之间。注意：
+开启此特性将增加 deepflow-agent 的 CPU 消耗。
 
 # 插件 {#plugins}
 

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -5309,6 +5309,7 @@ Whether to compress the integrated profile data received by deepflow-agent. The 
 ratio is about 5:1~10:1. Turning on this feature will result in higher CPU consumption
 of deepflow-agent.
 
+
 ### Prometheus Extra Labels {#inputs.integration.prometheus_extra_labels}
 
 Support for getting extra labels from headers in http requests from RemoteWrite.
@@ -8793,6 +8794,36 @@ outputs:
 **Description**:
 
 Maximum traffic rate allowed for npb sender.
+
+## Compression {#outputs.compression}
+
+## ApplicationLog {#outputs.compression.application_log}
+
+**Tags**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`outputs.compression.application_log`
+
+**Default value**:
+```yaml
+outputs:
+  compression:
+    application_log: true
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**Description**:
+
+Whether to compress the integrated application log data received by deepflow-agent. The compression
+ratio is about 5:1~20:1. Turning on this feature will result in higher CPU consumption
+of deepflow-agent.
 
 # Plugins {#plugins}
 

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -5676,6 +5676,30 @@ outputs:
     #     设置 deepflow-agent 做 NPB 分发的最大吞吐率。
     # upgrade_from: max_npb_bps
     max_tx_throughput: 1000
+  # type: section
+  # name:
+  #   en: Compression
+  #   ch: 压缩
+  # description:
+  compression:
+    # type: bool
+    # name:
+    #   en: Application_Log
+    #   ch: Application_Log
+    # unit:
+    # range: []
+    # enum_options: []
+    # modification: agent_restart
+    # ee_feature: false
+    # description:
+    #   en: |-
+    #     Whether to compress the integrated application log data received by deepflow-agent. The compression
+    #     ratio is about 5:1~20:1. Turning on this feature will result in higher CPU consumption
+    #     of deepflow-agent.
+    #   ch: |-
+    #     开启后，deepflow-agent 将对集成的应用日志数据进行压缩处理，压缩比例在 5:1~20:1 之间。注意：
+    #     开启此特性将增加 deepflow-agent 的 CPU 消耗。
+    application_log: true
 
 # type: section
 # name:

--- a/server/libs/datatype/droplet-message.go
+++ b/server/libs/datatype/droplet-message.go
@@ -159,6 +159,13 @@ const (
 	FLOW_HEADER_LEN     = FLOW_VTAPID_OFFSET + 2
 )
 
+const (
+	MESSAGE_ENCODER_RAW = iota
+	MESSAGE_ENCODER_ZLIB
+	MESSAGE_ENCODER_GZIP
+	MESSAGE_ENCODER_ZSTD
+)
+
 type BaseHeader struct {
 	FrameSize uint32      // tcp发送时，需要按此长度收齐数据后，再decode (FrameSize总长度，包含了 BaseHeader的长度)
 	Type      MessageType // 消息类型


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### add default encode compression functions for agent sender
#### Backport to branches
- main

--- 

test for application_log compression with config:

```yaml
inputs:
  integration:
    compression:
      application_log: true
```
---
conclusion:
- after compression, cpu cost about 3% upper, no changes in memory, compression ratio: 1:20

- 压缩后 cpu 消耗大概多 3% 左右，内存消耗无明显变化，发送数据减少为 1/20，压缩比 1:20左右

---
test results:

agent cpu compare:

before:
![image](https://github.com/user-attachments/assets/47679235-3911-4f61-a58e-dd7a60791085)
after:
![image](https://github.com/user-attachments/assets/01e6843a-c612-4b57-8fa8-7b7a00bd0f37)

agent mem compare:

before:
![image](https://github.com/user-attachments/assets/57d8f575-49a2-415b-9b0d-aebf008e03c0)
after:
![image](https://github.com/user-attachments/assets/60a56880-163a-4f92-9896-6795a9af65d6)


send tx-bytes compare:

before:
![image](https://github.com/user-attachments/assets/71e208be-58d6-4bdd-a0b7-156e7a863576)
after:
![image](https://github.com/user-attachments/assets/2d876bcc-cd7b-4276-a41b-289709f050e9)

