### PR TITLE
fix: adapt pprof u64 params

### DIFF
--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -937,10 +937,20 @@ fn parse_profile_query(query: &str, profile: &mut metric::Profile) {
         profile.sample_rate = sample_rate.parse::<u32>().unwrap_or_default();
     };
     if let Some(from) = query_hash.get("from") {
-        profile.from = from.parse::<u32>().unwrap_or_default();
+        let from = from.parse::<u64>().unwrap_or_default();
+        if from > u32::MAX as u64 {
+            profile.from = (from / 1_000_000_000) as u32;
+        } else {
+            profile.from = from as u32;
+        }
     };
     if let Some(until) = query_hash.get("until") {
-        profile.until = until.parse::<u32>().unwrap_or_default();
+        let until = until.parse::<u64>().unwrap_or_default();
+        if until > u32::MAX as u64 {
+            profile.until = (until / 1_000_000_000) as u32;
+        } else {
+            profile.until = until as u32;
+        }
     };
     if let Some(spy_name) = query_hash.get("spyName") {
         profile.spy_name = spy_name.to_string();


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes profile upload u64 timestamps
#### Steps to reproduce the bug
- use golang profile with pyroscope
#### Changes to fix the bug
- update `from` and `until` params
#### Affected branches
- main


