### PR TITLE
fix: query percentile to min/max time

### DIFF
--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -535,7 +535,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(toUnixTimestamp(time),1) as _last_timestamp,Percentile(toUnixTimestamp(time),0) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Max(time) as _last_timestamp,Min(time) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
 			err:    nil,
 		},
 
@@ -727,7 +727,7 @@ func TestParseQueryRequestToSQL(t *testing.T) {
 					{Name: "job", Type: labels.MatchEqual, Value: "prometheus"},
 				},
 			},
-			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Percentile(toUnixTimestamp(time),1) as _last_timestamp,Percentile(toUnixTimestamp(time),0) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
+			output: fmt.Sprintf("SELECT time(time, 14, 1,'', %d) AS timestamp,FastTrans(tag) as __labels_index__,Max(time) as _last_timestamp,Min(time) as _first_timestamp,Percentile(value, 0) as _first_value,Max(value) as value,`tag.cpu` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = 'localhost' AND `tag.job` = 'prometheus' GROUP BY __labels_index__,`tag.cpu`,timestamp ORDER BY timestamp desc LIMIT 1000000", rateInterval, start, end),
 			err:    nil,
 		},
 

--- a/server/querier/app/prometheus/service/functions.go
+++ b/server/querier/app/prometheus/service/functions.go
@@ -285,11 +285,9 @@ func offloadRate(fun string) QueryFunc {
 		 SO:
 		 assume metrics are `COUNTER` (only COUNTER with `rate`/`increase` is meaningful)
 		 we use MIN/MAX instead of first/last
-		 why not min(): min() will do `fill 0` in the time window, so we use Percentile(0) instead of it
-		 why not max(time): MAX(time) is not supported
 		*/
-		*query = append(*query, fmt.Sprintf("Percentile(toUnixTimestamp(time),1) as %s", PROMETHEUS_WINDOW_LAST_TIME))  // last time
-		*query = append(*query, fmt.Sprintf("Percentile(toUnixTimestamp(time),0) as %s", PROMETHEUS_WINDOW_FIRST_TIME)) // first time
+		*query = append(*query, fmt.Sprintf("Max(time) as %s", PROMETHEUS_WINDOW_LAST_TIME))  // last time
+		*query = append(*query, fmt.Sprintf("Min(time) as %s", PROMETHEUS_WINDOW_FIRST_TIME)) // first time
 
 		*query = append(*query, fmt.Sprintf("Percentile(%s, 0) as %s", metric, PROMETHEUS_WINDOW_FIRST_VALUE)) // first
 		*query = append(*query, fmt.Sprintf("Max(%s)", metric))


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes support min/max time for rate/irate
#### Steps to reproduce the bug
- use prom query offloading with rate/irate
#### Changes to fix the bug
- fixes query min/max time
#### Affected branches
- main


