### PR TITLE
fix: agent - eBPF Correct the maximum data push delay

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -34,6 +34,8 @@
 #define INFER_CONTINUE	1
 #define INFER_TERMINATE	2
 
+#define MAX_PUSH_DELAY_TIME_NS 100000000ULL // 100ms
+
 typedef long unsigned int __kernel_size_t;
 
 enum {

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -192,7 +192,12 @@ enum {
  * the data resident in the eBPF buffer. This value is the periodic time, unit
  * is milliseconds.
  */
-#define KICK_KERN_PERIOD 40000000  // Set default interval to 30 milliseconds
+#define KICK_KERN_PERIOD 40000000  // Set default interval to 40 milliseconds
+/*
+ * A special value should be assigned to indicate the case where no data has
+ * been pushed after exceeding 100 milliseconds.
+ */
+#define PUSH_DELAY_EXCEEDED_MARKER 199000 // 199 ms
 
 /*
  * timer config

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -2614,8 +2614,7 @@ struct socket_trace_stats socket_tracer_stats(void)
 			     stats_total.period_event_count) / NS_IN_USEC;
 
 		if (stats_total.period_event_max_delay > 0) {
-			stats.period_push_max_delay =
-			    stats_total.period_event_max_delay / NS_IN_USEC;
+			stats.period_push_max_delay = PUSH_DELAY_EXCEEDED_MARKER;
 		} else {
 			stats.period_push_max_delay = stats.period_push_avg_delay;
 		}


### PR DESCRIPTION
When a delay occurs in the eBPF data push cycle (i.e., the time difference between the current and previous trigger exceeds 100 milliseconds), we set the maximum data push delay to a special value (`PUSH_DELAY_EXCEEDED_MARKER`: 199000) to indicate that a delay has occurred, instead of providing the specific delay value. The reason is that in a multi-core environment, direct variable assignment in eBPF cannot ensure atomicity. Therefore, we use a special value to signify the occurrence of a delay.

### This PR is for:


- Agent

#### Affected branches
- main
- v6.6
- v6.5