### PR TITLE
fix: Bad use of lock in socket synchronizer blocks agent exit

### DIFF
--- a/agent/src/platform/synchronizer.rs
+++ b/agent/src/platform/synchronizer.rs
@@ -143,6 +143,8 @@ impl Synchronizer {
     }
 
     pub fn stop(&self) {
+        debug!("PlatformSynchronizer stopping");
+
         let mut running_lock = self.running.lock().unwrap();
         if !*running_lock {
             let config_guard = self.config.load();
@@ -331,15 +333,11 @@ impl Synchronizer {
         }
     }
 
-    fn wait_timeout(running: &Arc<Mutex<bool>>, timer: &Arc<Condvar>, interval: Duration) -> bool {
+    fn wait_timeout(running: &Mutex<bool>, timer: &Condvar, interval: Duration) -> bool {
         let guard = running.lock().unwrap();
         if !*guard {
             return true;
         }
-        let (guard, _) = timer.wait_timeout(guard, interval).unwrap();
-        if !*guard {
-            return true;
-        }
-        false
+        !*timer.wait_timeout(guard, interval).unwrap().0
     }
 }

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -2978,7 +2978,7 @@ impl AgentComponents {
         if self.running.swap(true, Ordering::Relaxed) {
             return;
         }
-        info!("Staring agent components.");
+        info!("Starting agent components.");
         self.stats_collector.start();
 
         #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


