### PR TITLE
fix: agent - eBPF Fix Event Type Value

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -292,16 +292,16 @@ struct ebpf_proc_info {
 
 enum {
 	/*
-	 * 0 ~ 16 for L7 socket event (struct socket_data_buffer),
+	 * 0 ~ 256 for L7 socket event (struct socket_data_buffer),
 	 * indicates the number of socket data in socket_data_buffer.
 	 */
 
 	/*
 	 * For event registrion
 	 */
-	EVENT_TYPE_MIN = 1 << 5,
-	EVENT_TYPE_PROC_EXEC = 1 << 5,
-	EVENT_TYPE_PROC_EXIT = 1 << 6
+	EVENT_TYPE_MIN = 1 << 9,
+	EVENT_TYPE_PROC_EXEC = 1 << 9,
+	EVENT_TYPE_PROC_EXIT = 1 << 10
 	    // Add new event type here.
 };
 

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -189,9 +189,9 @@ pub const MSG_COMMON: u8 = 7;
 
 //Register event types
 #[allow(dead_code)]
-pub const EVENT_TYPE_PROC_EXEC: u32 = 1 << 5;
+pub const EVENT_TYPE_PROC_EXEC: u32 = 1 << 9;
 #[allow(dead_code)]
-pub const EVENT_TYPE_PROC_EXIT: u32 = 1 << 6;
+pub const EVENT_TYPE_PROC_EXIT: u32 = 1 << 10;
 
 // Profiler types
 #[allow(dead_code)]


### PR DESCRIPTION
If `0 < ev_meta->event_type < EVENT_TYPE_MIN`, it is classified as 'socket data buffer'. If `ev_meta->event_type >= EVENT_TYPE_MIN`, it is classified as register events.

Previously, the value of `EVENT_TYPE_MIN` was set to 32. However, some UPROBE events exceeded or equaled 32, causing data loss in socket data. This patch increases `EVENT_TYPE_MIN` to 512 to fix this issue.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.6
