### PR TITLE
fix: agent - eBPF Fix Crashes Caused by Packet Count Statistics

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1163,7 +1163,7 @@ static void reader_raw_cb(void *cookie, void *raw, int raw_size)
 			return;
 		}
 		int i;
-		for (i = nr; nr < buf->events_num; i++) {
+		for (i = nr; i < buf->events_num; i++) {
 			if (burst_data[i]->source == DATA_SOURCE_DPDK)
 				atomic64_inc(&tracer->dropped_pkts);
 		}


### PR DESCRIPTION

### This PR is for:

- Agent

#### Affected branches
- main
- v6.6