### PR TITLE
fix: agnet - eBPF Fix the kernel kick on CPU0 was not triggered

### DIFF
--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -1574,7 +1574,7 @@ static int boot_time_update(void)
  */
 static void *kick_kern_push_data(void *arg)
 {
-	int cpu_id = *((int *)arg);	// Extract CPU ID from the argument
+	int cpu_id = (int)((uintptr_t)arg);	// Extract CPU ID from the argument
 	char thread_name[NAME_LEN];
 
 	// Set a descriptive thread name
@@ -1680,7 +1680,7 @@ static void period_process_main(__unused void *arg)
 	for (i = 0; i < sys_cpus_count; i++) {
 		if (cpu_online[i])
 			if (pthread_create
-			    (&threads[i], NULL, kick_kern_push_data, &i) != 0) {
+			    (&threads[i], NULL, kick_kern_push_data, (void *)(uintptr_t)i) != 0) {
 				ebpf_warning("pthread_create failed");
 			}
 	}


### PR DESCRIPTION


### This PR is for:

- Agent



#### Affected branches
- main
- v6.6