### PR TITLE
fix: agent - eBPF Fix find_pid_by_name() missing closedir()

### DIFF
--- a/agent/src/ebpf/user/utils.c
+++ b/agent/src/ebpf/user/utils.c
@@ -1599,8 +1599,10 @@ int find_pid_by_name(const char *process_name, int exclude_pid)
 				snprintf(status_path, sizeof(status_path),
 					 "/proc/%d/status", pid);
 				if (find_proc_form_status_file
-				    (status_path, process_name) == 0)
+				    (status_path, process_name) == 0) {
+					closedir(proc);
 					return pid;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This does not affect memory because it is used to check for the special case of two `deepflow-agent` instances being started. If two agents are started, the newly launched one will exit (releasing memory automatically).

If only one agent is started, it will properly call `closedir()` without causing any impact.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.6
- v6.5

