### PR TITLE
fix: query skywalking data update resource info

### DIFF
--- a/server/querier/app/tracing-adapter/model/tracing.go
+++ b/server/querier/app/tracing-adapter/model/tracing.go
@@ -27,6 +27,7 @@ type ExSpan struct {
 	TapSide         string `json:"tap_side"` // spankind=server: s-app/ spankind=client: c-app/ spankind=internal: app
 	L7Protocol      int    `json:"l7_protocol"`
 	L7ProtocolStr   string `json:"l7_protocol_str"`
+	L7ProtocolEnum  string `json:"Enum(l7_protocol)"` // required, will show in span bar name in flamegraph
 	TraceID         string `json:"trace_id"`
 	SpanID          string `json:"span_id"`
 	ParentSpanID    string `json:"parent_span_id"`
@@ -34,6 +35,7 @@ type ExSpan struct {
 	Endpoint        string `json:"endpoint"`
 	RequestType     string `json:"request_type"`     // method
 	RequestResource string `json:"request_resource"` // path
+	ResponseCode    int    `json:"response_code"`
 	ResponseStatus  int    `json:"response_status"`
 	AppService      string `json:"app_service"`   // service name
 	AppInstance     string `json:"app_instance"`  // service instance name

--- a/server/querier/app/tracing-adapter/service/base.go
+++ b/server/querier/app/tracing-adapter/service/base.go
@@ -17,6 +17,10 @@
 package service
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/deepflowio/deepflow/server/libs/datatype"
 	"github.com/deepflowio/deepflow/server/querier/app/tracing-adapter/model"
 	"github.com/deepflowio/deepflow/server/querier/app/tracing-adapter/service/packet_service"
 	"github.com/op/go-logging"
@@ -40,4 +44,27 @@ func Register() error {
 		log_base.Debugf("external apm %s register success")
 	}
 	return nil
+}
+
+func ParseUrlPath(rawURL string) (string, error) {
+	parts := strings.SplitN(rawURL, "://", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("invalid URL format")
+	}
+	pathStart := strings.Index(parts[1], "/")
+	if pathStart == -1 {
+		return "/", nil
+	}
+
+	return parts[1][pathStart:], nil
+}
+
+func HttpCodeToResponseStatus(code int) datatype.LogMessageStatus {
+	if code >= 400 && code <= 499 {
+		return datatype.STATUS_CLIENT_ERROR
+	} else if code >= 500 && code <= 600 {
+		return datatype.STATUS_SERVER_ERROR
+	} else {
+		return datatype.STATUS_OK
+	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes skywalking query get full data to show
#### Steps to reproduce the bug
- use skywalking query in distributed tracing
#### Changes to fix the bug
- try to get l7protocol from other tags
- when layer can not get l7protocol, try to find from tag infos
#### Affected branches
- main
- v6.6
- v6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

