### PR TITLE
fix: the initial connection CK failed, causing panic all the time

### DIFF
--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -323,7 +323,14 @@ func InitTable(addr, user, password, timeZone string, t *ckdb.Table, orgID uint1
 }
 
 func (w *CKWriter) InitTable(queueID int, orgID uint16) error {
-	for _, conn := range w.queueContexts[queueID].conns {
+	queueContext := w.queueContexts[queueID]
+	for i, conn := range queueContext.conns {
+		if conn == nil || conn.IsClosed() {
+			if err := queueContext.initConn(i); err != nil {
+				return err
+			}
+			conn = queueContext.conns[i]
+		}
 		if err := initTable(conn, w.timeZone, w.table, orgID); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


