### PR TITLE
feat: only send user_config & dynamic_config to disabled agent

### DIFF
--- a/server/controller/trisolaris/services/grpc/agentsynchronize/sync_push.go
+++ b/server/controller/trisolaris/services/grpc/agentsynchronize/sync_push.go
@@ -324,6 +324,16 @@ func (e *AgentEvent) Sync(ctx context.Context, in *api.SyncRequest) (*api.SyncRe
 		log.Errorf("agent(%s) has no ingester_ip, "+
 			"Please check whether the agent allocs tsdb IP or If nat-ip is enabled, whether the tsdb is configured with nat-ip", vtapCache.GetCtrlIP())
 	}
+
+	// if agent is disabled, only return user_config and dynamic_config
+	if vtapCache.GetVTapEnabled() == 0 {
+		return &api.SyncResponse{
+			Status:        &STATUS_SUCCESS,
+			UserConfig:    proto.String(e.formateViperConfigToString(userConfig)),
+			DynamicConfig: dynamicConfig,
+		}, nil
+	}
+
 	localSegments := vtapCache.GetAgentLocalSegments()
 	remoteSegments := vtapCache.GetAgentRemoteSegments()
 	upgradeRevision := vtapCache.GetExpectedRevision()
@@ -551,6 +561,16 @@ func (e *AgentEvent) pushResponse(in *api.SyncRequest, all bool) (*api.SyncRespo
 		log.Errorf("agent(%s) has no ingester_ip, "+
 			"Please check whether the agent allocs tsdb IP or If nat-ip is enabled, whether the tsdb is configured with nat-ip", vtapCache.GetCtrlIP())
 	}
+
+	// if agent is disabled, only return user_config and dynamic_config
+	if vtapCache.GetVTapEnabled() == 0 {
+		return &api.SyncResponse{
+			Status:        &STATUS_SUCCESS,
+			UserConfig:    proto.String(e.formateViperConfigToString(userConfig)),
+			DynamicConfig: dynamicConfig,
+		}, nil
+	}
+
 	localSegments := vtapCache.GetAgentLocalSegments()
 	remoteSegments := vtapCache.GetAgentRemoteSegments()
 	skipInterface := gAgentInfo.GetAgentSkipInterface(vtapCache)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


