### PR TITLE
fix: specific prome remote read content-type

### DIFF
--- a/server/querier/app/prometheus/router/prometheus.go
+++ b/server/querier/app/prometheus/router/prometheus.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/prompb"
@@ -143,6 +144,7 @@ func promReader(svc *service.PrometheusService) gin.HandlerFunc {
 			return
 		}
 		compressed = snappy.Encode(nil, data)
+		c.Header("Content-Type", binding.MIMEPROTOBUF)
 		c.Writer.Write([]byte(compressed))
 	})
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- use prometheus remote read query with prometheus version > 3.x
#### Changes to fix the bug
- add content type in response
#### Affected branches
- main
- v6.6
- v6.5
- v6.4


