### PR TITLE
fix: refine condition logic for  in the

### DIFF
--- a/server/ingester/exporters/exporters.go
+++ b/server/ingester/exporters/exporters.go
@@ -189,7 +189,12 @@ func IsExportField(tag *config.StructTags, exportFieldCategoryBits uint64, expor
 		return false
 	}
 
-	if tag.CategoryBit&exportFieldCategoryBits != 0 || tag.SubCategoryBit&exportFieldCategoryBits != 0 {
+	// for category_k8s_label
+	if config.K8S_LABEL&exportFieldCategoryBits != 0 {
+		return true
+	}
+	// for category_tag, category_metrics
+	if tag.CategoryBit&exportFieldCategoryBits != 0 && tag.SubCategoryBit&exportFieldCategoryBits != 0 {
 		return true
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes <refine condition logic for `exportFieldCategoryBits ` in the `IsExportField `>
#### Steps to reproduce the bug
- config a promethues exporter
- config some export field_names, like `observation_point`, `auto_instance_id_0`, `auto_instance_id_1` ...
- also config a export category, like `$tag.network_layer`
- run server, and you will find that the exported data were all of the `category_tag`
#### Changes to fix the bug
- In the isExportField method, the current logic for checking exportFieldCategoryBits has issues and should be modified based on different scenarios;
- For category_tag and category_metrics cases:
`CategoryBit` includes `SubCategoryBit`, so the condition `tag.CategoryBit&exportFieldCategoryBits != 0 || tag.SubCategoryBit&exportFieldCategoryBits != 0` only partially works. This leads to the export of extra subcategory field contents. The condition should be changed to `tag.CategoryBit&exportFieldCategoryBits != 0 && tag.SubCategoryBit&exportFieldCategoryBits != 0`;
- For category_k8s_label cases:
`CategoryBit` can only be equal to `config.K8S_LABEL`. The condition should be modified to `config.K8S_LABEL&exportFieldCategoryBits != 0`.
 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [x] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


