### PR TITLE
fix: adding an existing native tag should result in a failure

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -1351,7 +1351,7 @@ func (i *Issu) Start() error {
 			if nativeTag == nil {
 				continue
 			}
-			if e := nativetag.CKAddNativeTag(i.cfg.CKDB.Type == ckdb.CKDBTypeByconity, connect, ckdb.DEFAULT_ORG_ID, nativeTag); e != nil {
+			if e := nativetag.CKAddNativeTag(i.cfg.CKDB.Type == ckdb.CKDBTypeByconity, true, connect, ckdb.DEFAULT_ORG_ID, nativeTag); e != nil {
 				log.Error(err)
 			}
 		}
@@ -1405,7 +1405,7 @@ func (i *Issu) Start() error {
 						if nativeTag == nil {
 							continue
 						}
-						if e := nativetag.CKAddNativeTag(i.cfg.CKDB.Type == ckdb.CKDBTypeByconity, connect, orgId, nativeTag); e != nil {
+						if e := nativetag.CKAddNativeTag(i.cfg.CKDB.Type == ckdb.CKDBTypeByconity, true, connect, orgId, nativeTag); e != nil {
 							log.Error(err)
 						}
 					}

--- a/server/ingester/ingester/org_handler.go
+++ b/server/ingester/ingester/org_handler.go
@@ -122,7 +122,7 @@ func (o *OrgHandler) addNativeTag(orgId uint16, nativeTag *nativetag.NativeTag) 
 	}
 	defer conns.Close()
 	for _, conn := range conns {
-		err := nativetag.CKAddNativeTag(o.cfg.CKDB.Type == ckdb.CKDBTypeByconity, conn, orgId, nativeTag)
+		err := nativetag.CKAddNativeTag(o.cfg.CKDB.Type == ckdb.CKDBTypeByconity, false, conn, orgId, nativeTag)
 		if err != nil {
 			log.Error(err)
 			return err

--- a/server/libs/nativetag/nativetag.go
+++ b/server/libs/nativetag/nativetag.go
@@ -226,7 +226,7 @@ func UpdateNativeTag(op NativeTagOP, orgId uint16, nativeTag *NativeTag) {
 	log.Infof("after %s orgid %d, table %s, native tag: %+v", op, orgId, tableId.Table(), oldNativeTag)
 }
 
-func CKAddNativeTag(isByConity bool, conn *sql.DB, orgId uint16, nativeTag *NativeTag) error {
+func CKAddNativeTag(isByConity, ignoreColumnExisted bool, conn *sql.DB, orgId uint16, nativeTag *NativeTag) error {
 	tableId, err := ToNativeTagTable(nativeTag.Db, nativeTag.Table)
 	if err != nil {
 		log.Error(err)
@@ -256,7 +256,7 @@ func CKAddNativeTag(isByConity bool, conn *sql.DB, orgId uint16, nativeTag *Nati
 			_, err := conn.Exec(sql)
 			if err != nil {
 				// if it has already been added, you need to skip the error
-				if strings.Contains(err.Error(), "column with this name already exists") {
+				if strings.Contains(err.Error(), "column with this name already exists") && ignoreColumnExisted {
 					log.Infof("db: %s, table: %s error: %s", tableId.Database(), tableId.Table(), err)
 					continue
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


