### PR TITLE
fix: the issue of duplicate metrics data

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -515,7 +515,7 @@ impl Stash {
                     is_active_host,
                     config,
                     None,
-                    acc_flow.l7_protocol,
+                    L7Protocol::Unknown,
                 );
                 self.fill_single_l4_stats(tagger, flow_meter);
             }
@@ -527,7 +527,7 @@ impl Stash {
                 acc_flow.is_active_host1,
                 config,
                 None,
-                acc_flow.l7_protocol,
+                L7Protocol::Unknown,
             );
             // edge_stats: If the direction of a certain end is known, the statistical data
             // will be recorded with the direction (corresponding tap-side), up to two times
@@ -550,7 +550,7 @@ impl Stash {
                 acc_flow.is_active_host1,
                 config,
                 None,
-                acc_flow.l7_protocol,
+                L7Protocol::Unknown,
             );
             self.fill_edge_l4_stats(tagger, acc_flow.flow_meter);
         }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### Fixes the issue of duplicate metrics data
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 6.6
- 6.5
- 6.4
- 6.3
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


