### PR TITLE
feat: agent - eBPF Get the remote IP and port of the DNS

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -271,7 +271,16 @@ struct data_args_t {
 	};
 	// Scenario for using sendto() with a specified address
 	__u16 port;
-	__u8 addr[16];
+	union {
+		__u8 addr[16];
+
+		/*
+		 * Used to record the parameters of `sendmsg()/recvmsg()`, 
+		 * where `msghdr->msg_name` stores the IP address information
+		 * in UDP communication.
+		 */
+		void *ipaddr_ptr;
+	};
 } __attribute__ ((packed));
 
 struct syscall_comm_enter_ctx {


### PR DESCRIPTION
For the `sendmsg()/recvmsg()` system interfaces, the remote IP address and port may be specified through the parameter `struct user_msghdr __user *msg` and may not be recorded in the kernel `sock` structure (as is common in the UDP protocol). We extract the values from the system call parameters to obtain this data and populate the network tuple.



### This PR is for:

- Agent



#### Affected branches
- main
- v6.6
- v6.5
- v6.4
