### PR TITLE
feat: add default process_matcher rules

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -408,7 +408,11 @@ impl ProcessMatcher {
         let mut match_replace_fn = |reg: &Regex, ignored: bool, s: &String, replace: &String| {
             if reg.is_match(s.as_str()) {
                 if !ignored && !replace.is_empty() {
-                    process_data.name = reg.replace_all(s.as_str(), replace).to_string();
+                    // get match sub string for replace
+                    if let Some(m) = reg.find(s.as_str()) {
+                        process_data.name =
+                            reg.replace_all(&s[m.start()..m.end()], replace).to_string();
+                    }
                 }
                 true
             } else {
@@ -559,16 +563,44 @@ impl Default for Proc {
             socket_info_sync_interval: Duration::from_secs(0),
             min_lifetime: Duration::from_secs(3),
             tag_extraction: TagExtraction::default(),
-            process_matcher: vec![ProcessMatcher {
-                match_regex: Regex::new("deepflow-.*").unwrap(),
-                only_in_container: false,
-                enabled_features: vec![
-                    "ebpf.profile.on_cpu".to_string(),
-                    "ebpf.profile.off_cpu".to_string(),
-                    "proc.gprocess_info".to_string(),
-                ],
-                ..Default::default()
-            }],
+            process_matcher: vec![
+                ProcessMatcher {
+                    match_regex: Regex::new(r"\bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)").unwrap(),
+                    only_in_container: false,
+                    match_type: ProcessMatchType::CmdWithArgs,
+                    rewrite_name: "$3".to_string(),
+                    enabled_features: vec![
+                        "ebpf.profile.on_cpu".to_string(),
+                        "proc.gprocess_info".to_string(),
+                    ],
+                    ..Default::default()
+                },
+                ProcessMatcher {
+                    match_regex: Regex::new(r"\bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)").unwrap(),
+                    only_in_container: false,
+                    match_type: ProcessMatchType::CmdWithArgs,
+                    rewrite_name: "$4".to_string(),
+                    enabled_features: vec![
+                        "ebpf.profile.on_cpu".to_string(),
+                        "proc.gprocess_info".to_string(),
+                    ],
+                    ..Default::default()
+                },
+                ProcessMatcher {
+                    match_regex: Regex::new("^deepflow-").unwrap(),
+                    only_in_container: false,
+                    enabled_features: vec![
+                        "ebpf.profile.on_cpu".to_string(),
+                        "proc.gprocess_info".to_string(),
+                    ],
+                    ..Default::default()
+                },
+                ProcessMatcher {
+                    match_regex: Regex::new(".*").unwrap(),
+                    enabled_features: vec!["proc.gprocess_info".to_string()],
+                    ..Default::default()
+                },
+            ],
             symbol_table: SymbolTable::default(),
         }
     }

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -1597,10 +1597,26 @@ inputs:
     process_matcher:
     - enabled_features:
       - ebpf.profile.on_cpu
-      - ebpf.profile.off_cpu
       - proc.gprocess_info
-      match_regex: deepflow-.*
+      match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
+      match_type: cmdline_with_args
       only_in_container: false
+      rewrite_name: $3
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: \bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)
+      match_type: cmdline_with_args
+      only_in_container: false
+      rewrite_name: $4
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: ^deepflow-
+      only_in_container: false
+    - enabled_features:
+      - proc.gprocess_info
+      match_regex: .*
 ```
 
 **模式**:
@@ -1610,22 +1626,21 @@ inputs:
 
 **详细描述**:
 
-Will traverse over the entire array, so the previous ones will be matched first.
-when match_type is parent_process_name, will recursive to match parent proc name,
-and rewrite_name field will ignore. rewrite_name can replace by regexp capture group
-and windows style environment variable, for example: `$1-py-script-%HOSTNAME%` will
-replace regexp capture group 1 and HOSTNAME env var. If proc not match any regexp
-will be accepted (essentially will auto append `- match_regex: .*` at the end).
+匹配器将自上而下地遍历匹配规则，所以较前的规则将会被优先匹配。
+当 match_type 为 parent_process_name 时，匹配器将会递归地查找父进程名且忽略 rewrite_name 选项。
+rewrite_name 可定义为正则表达式捕获组索引，或 windows 风格的环境变量。
+例如：`$1-py-script-%HOSTNAME%` 中的 $1 将会替换正则表达式捕获到的第一组内容，并替换 HOSTNAME 环境变量。
 
-Configuration Item:
-- match_regex: The regexp use for match the process, default value is `.*`
-- match_type: regexp match field, default value is `process_name`, options are
+配置键：
+- match_regex: 用于匹配进程的表达式，缺省值为 `""`。
+- match_type: 被用于正则表达式匹配的对象，缺省值为 `process_name`，可选项为：
   [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
-- ignore: Whether to ignore when regex match, default value is `false`
-- rewrite_name: The name will replace the process name or cmd use regexp replace.
-  Default value `""` means no replacement.
+- ignore: 是否要忽略正则匹配，缺省值为 `false`
+- rewrite_name: 使用正则替换匹配到的进程名或命令行，缺省值为 `""` 表示不做替换。
+- enabled_features: 可用于进程匹配器的 feature，可选项为：
+  [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
 
-Example:
+示例:
 ```yaml
 inputs:
   proc:
@@ -1648,8 +1663,8 @@ inputs:
     - match_regex: .*sleep.*
       match_type: process_name
       ignore: true
-    - match_regex: .+ # match after concatenating a tag key and value pair using colon,
-                      # i.e., an regex `app:.+` can match all processes has a `app` tag
+    - match_regex: .+ # 可使用冒号连接需要匹配的 tag key 与 value
+                      # i.e.: `app:.+` 表示匹配所有具有 `app` tag 的进程
       match_type: tag
 ```
 

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -1613,10 +1613,26 @@ inputs:
     process_matcher:
     - enabled_features:
       - ebpf.profile.on_cpu
-      - ebpf.profile.off_cpu
       - proc.gprocess_info
-      match_regex: deepflow-.*
+      match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
+      match_type: cmdline_with_args
       only_in_container: false
+      rewrite_name: $3
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: \bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)
+      match_type: cmdline_with_args
+      only_in_container: false
+      rewrite_name: $4
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: ^deepflow-
+      only_in_container: false
+    - enabled_features:
+      - proc.gprocess_info
+      match_regex: .*
 ```
 
 **Schema**:
@@ -1630,16 +1646,17 @@ Will traverse over the entire array, so the previous ones will be matched first.
 when match_type is parent_process_name, will recursive to match parent proc name,
 and rewrite_name field will ignore. rewrite_name can replace by regexp capture group
 and windows style environment variable, for example: `$1-py-script-%HOSTNAME%` will
-replace regexp capture group 1 and HOSTNAME env var. If proc not match any regexp
-will be accepted (essentially will auto append `- match_regex: .*` at the end).
+replace regexp capture group 1 and HOSTNAME env var.
 
 Configuration Item:
-- match_regex: The regexp use for match the process, default value is `.*`
+- match_regex: The regexp use for match the process, default value is `""`
 - match_type: regexp match field, default value is `process_name`, options are
   [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
 - ignore: Whether to ignore when regex match, default value is `false`
 - rewrite_name: The name will replace the process name or cmd use regexp replace.
   Default value `""` means no replacement.
+- enabled_features: the features can be used for process matcher, options:
+  [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
 
 Example:
 ```yaml

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -1090,21 +1090,64 @@ inputs:
     # modification: agent_restart
     # ee_feature: false
     # description:
+    #   ch: |-
+    #     匹配器将自上而下地遍历匹配规则，所以较前的规则将会被优先匹配。
+    #     当 match_type 为 parent_process_name 时，匹配器将会递归地查找父进程名且忽略 rewrite_name 选项。
+    #     rewrite_name 可定义为正则表达式捕获组索引，或 windows 风格的环境变量。
+    #     例如：`$1-py-script-%HOSTNAME%` 中的 $1 将会替换正则表达式捕获到的第一组内容，并替换 HOSTNAME 环境变量。
+    #
+    #     配置键：
+    #     - match_regex: 用于匹配进程的表达式，缺省值为 `""`。
+    #     - match_type: 被用于正则表达式匹配的对象，缺省值为 `process_name`，可选项为：
+    #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
+    #     - ignore: 是否要忽略正则匹配，缺省值为 `false`
+    #     - rewrite_name: 使用正则替换匹配到的进程名或命令行，缺省值为 `""` 表示不做替换。
+    #     - enabled_features: 可用于进程匹配器的 feature，可选项为：
+    #       [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
+    #     
+    #     示例:
+    #     ```yaml
+    #     inputs:
+    #       proc:
+    #         process_matcher:
+    #         - match_regex: python3 (.*)\.py
+    #           match_type: cmdline
+    #           match_languages: []
+    #           match_usernames: []
+    #           only_in_container: true
+    #           only_with_tag: false
+    #           ignore: false
+    #           rewrite_name: $1-py-script
+    #           enabled_features: [ebpf.socket.uprobe.golang, ebpf.profile.on_cpu]
+    #         - match_regex: (?P<PROC_NAME>nginx)
+    #           match_type: process_name
+    #           rewrite_name: ${PROC_NAME}-%HOSTNAME%
+    #         - match_regex: "nginx"
+    #           match_type: parent_process_name
+    #           ignore: true
+    #         - match_regex: .*sleep.*
+    #           match_type: process_name
+    #           ignore: true
+    #         - match_regex: .+ # 可使用冒号连接需要匹配的 tag key 与 value
+    #                           # i.e.: `app:.+` 表示匹配所有具有 `app` tag 的进程
+    #           match_type: tag
+    #     ```
     #   en: |-
     #     Will traverse over the entire array, so the previous ones will be matched first.
     #     when match_type is parent_process_name, will recursive to match parent proc name,
     #     and rewrite_name field will ignore. rewrite_name can replace by regexp capture group
     #     and windows style environment variable, for example: `$1-py-script-%HOSTNAME%` will
-    #     replace regexp capture group 1 and HOSTNAME env var. If proc not match any regexp
-    #     will be accepted (essentially will auto append `- match_regex: .*` at the end).
+    #     replace regexp capture group 1 and HOSTNAME env var.
     #
     #     Configuration Item:
-    #     - match_regex: The regexp use for match the process, default value is `.*`
+    #     - match_regex: The regexp use for match the process, default value is `""`
     #     - match_type: regexp match field, default value is `process_name`, options are
     #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
     #     - ignore: Whether to ignore when regex match, default value is `false`
     #     - rewrite_name: The name will replace the process name or cmd use regexp replace.
     #       Default value `""` means no replacement.
+    #     - enabled_features: the features can be used for process matcher, options:
+    #       [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
     #
     #     Example:
     #     ```yaml
@@ -1290,9 +1333,21 @@ inputs:
     # ---
     # enabled_features: []
     process_matcher:
-      - match_regex: deepflow-.*
+      - match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
+        match_type: cmdline_with_args
         only_in_container: false
-        enabled_features: [ebpf.profile.on_cpu, ebpf.profile.off_cpu, proc.gprocess_info]
+        rewrite_name: $3
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: \bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)
+        match_type: cmdline_with_args
+        only_in_container: false
+        rewrite_name: $4
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: ^deepflow-
+        only_in_container: false
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: .*
+        enabled_features: [proc.gprocess_info]
     # type: section
     # name:
     #   en: Symbol Table


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
- Documents
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

### add default process_matcher for gprocess_info & on_cpu profiling
#### Backport to branches
- main
