### PR TITLE
feat: add default process_matcher rules

### DIFF
--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -1612,10 +1612,26 @@ inputs:
     process_matcher:
     - enabled_features:
       - ebpf.profile.on_cpu
-      - ebpf.profile.off_cpu
       - proc.gprocess_info
-      match_regex: deepflow-.*
+      match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
+      match_type: cmdline_with_args
       only_in_container: false
+      rewrite_name: $3
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: \bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)
+      match_type: cmdline_with_args
+      only_in_container: false
+      rewrite_name: $4
+    - enabled_features:
+      - ebpf.profile.on_cpu
+      - proc.gprocess_info
+      match_regex: ^deepflow-
+      only_in_container: false
+    - enabled_features:
+      - proc.gprocess_info
+      match_regex: .*
 ```
 
 **Schema**:
@@ -1629,16 +1645,17 @@ Will traverse over the entire array, so the previous ones will be matched first.
 when match_type is parent_process_name, will recursive to match parent proc name,
 and rewrite_name field will ignore. rewrite_name can replace by regexp capture group
 and windows style environment variable, for example: `$1-py-script-%HOSTNAME%` will
-replace regexp capture group 1 and HOSTNAME env var. If proc not match any regexp
-will be accepted (essentially will auto append `- match_regex: .*` at the end).
+replace regexp capture group 1 and HOSTNAME env var.
 
 Configuration Item:
-- match_regex: The regexp use for match the process, default value is `.*`
+- match_regex: The regexp use for match the process, default value is `""`
 - match_type: regexp match field, default value is `process_name`, options are
   [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
 - ignore: Whether to ignore when regex match, default value is `false`
 - rewrite_name: The name will replace the process name or cmd use regexp replace.
   Default value `""` means no replacement.
+- enabled_features: the features can be used for process matcher, options:
+  [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
 
 Example:
 ```yaml

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -1088,21 +1088,64 @@ inputs:
     # modification: agent_restart
     # ee_feature: false
     # description:
+    #   ch: |-
+    #     匹配器将自上而下地遍历匹配规则，所以较前的规则将会被优先匹配。
+    #     当 match_type 为 parent_process_name 时，匹配器将会递归地查找父进程名且忽略 rewrite_name 选项。
+    #     rewrite_name 可定义为正则表达式捕获组索引，或 windows 风格的环境变量。
+    #     例如：`$1-py-script-%HOSTNAME%` 中的 $1 将会替换正则表达式捕获到的第一组内容，并替换 HOSTNAME 环境变量。
+    #
+    #     配置键：
+    #     - match_regex: 用于匹配进程的表达式，缺省值为 `""`。
+    #     - match_type: 被用于正则表达式匹配的对象，缺省值为 `process_name`，可选项为：
+    #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
+    #     - ignore: 是否要忽略正则匹配，缺省值为 `false`
+    #     - rewrite_name: 使用正则替换匹配到的进程名或命令行，缺省值为 `""` 表示不做替换。
+    #     - enabled_features: 可用于进程匹配器的 feature，可选项为：
+    #       [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
+    #     
+    #     示例:
+    #     ```yaml
+    #     inputs:
+    #       proc:
+    #         process_matcher:
+    #         - match_regex: python3 (.*)\.py
+    #           match_type: cmdline
+    #           match_languages: []
+    #           match_usernames: []
+    #           only_in_container: true
+    #           only_with_tag: false
+    #           ignore: false
+    #           rewrite_name: $1-py-script
+    #           enabled_features: [ebpf.socket.uprobe.golang, ebpf.profile.on_cpu]
+    #         - match_regex: (?P<PROC_NAME>nginx)
+    #           match_type: process_name
+    #           rewrite_name: ${PROC_NAME}-%HOSTNAME%
+    #         - match_regex: "nginx"
+    #           match_type: parent_process_name
+    #           ignore: true
+    #         - match_regex: .*sleep.*
+    #           match_type: process_name
+    #           ignore: true
+    #         - match_regex: .+ # 可使用冒号连接需要匹配的 tag key 与 value
+    #                           # i.e.: `app:.+` 表示匹配所有具有 `app` tag 的进程
+    #           match_type: tag
+    #     ```
     #   en: |-
     #     Will traverse over the entire array, so the previous ones will be matched first.
     #     when match_type is parent_process_name, will recursive to match parent proc name,
     #     and rewrite_name field will ignore. rewrite_name can replace by regexp capture group
     #     and windows style environment variable, for example: `$1-py-script-%HOSTNAME%` will
-    #     replace regexp capture group 1 and HOSTNAME env var. If proc not match any regexp
-    #     will be accepted (essentially will auto append `- match_regex: .*` at the end).
+    #     replace regexp capture group 1 and HOSTNAME env var.
     #
     #     Configuration Item:
-    #     - match_regex: The regexp use for match the process, default value is `.*`
+    #     - match_regex: The regexp use for match the process, default value is `""`
     #     - match_type: regexp match field, default value is `process_name`, options are
     #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
     #     - ignore: Whether to ignore when regex match, default value is `false`
     #     - rewrite_name: The name will replace the process name or cmd use regexp replace.
     #       Default value `""` means no replacement.
+    #     - enabled_features: the features can be used for process matcher, options:
+    #       [proc.gprocess_info, proc.golang_symbol_table, proc.socket_lis, ebpf.socket.uprobe.golang, ebpf.socket.uprobe.tls, ebpf.profile.on_cpu, ebpf.profile.off_cpu, ebpf.profile.memory]
     #
     #     Example:
     #     ```yaml
@@ -1288,9 +1331,21 @@ inputs:
     # ---
     # enabled_features: []
     process_matcher:
-      - match_regex: deepflow-.*
+      - match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
+        match_type: cmdline_with_args
         only_in_container: false
-        enabled_features: [ebpf.profile.on_cpu, ebpf.profile.off_cpu, proc.gprocess_info]
+        rewrite_name: $3
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: \bpython(\S)*( +-\S+)* +(\S*/)*([^ /]+)
+        match_type: cmdline_with_args
+        only_in_container: false
+        rewrite_name: $4
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: ^deepflow-
+        only_in_container: false
+        enabled_features: [ebpf.profile.on_cpu, proc.gprocess_info]
+      - match_regex: .*
+        enabled_features: [proc.gprocess_info]
     # type: section
     # name:
     #   en: Symbol Table


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
- Documents
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### add default process matcher in v6.6
#### Checklist
#### Backport to branches
- v6.6
- cp from #9278

