### PR TITLE
refactor: replace deprecated `io/ioutil` functions

### DIFF
--- a/cli/ctl/agent.go
+++ b/cli/ctl/agent.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -300,7 +299,7 @@ func deleteAgent(cmd *cobra.Command, args []string) {
 }
 
 func updateAgent(cmd *cobra.Command, args []string, updateFilename string) {
-	yamlFile, err := ioutil.ReadFile(updateFilename)
+	yamlFile, err := os.ReadFile(updateFilename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return

--- a/cli/ctl/common/http_util.go
+++ b/cli/ctl/common/http_util.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	_ "net"
 	"net/http"
 	"os"
@@ -107,7 +107,7 @@ func parseResponse(req *http.Request, cfg *HTTPConf) (*simplejson.Json, error) {
 	}
 
 	defer resp.Body.Close()
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errResponse, errors.New(fmt.Sprintf("read (%s) body failed, (%v)", req.URL, err))
 	}
@@ -180,7 +180,7 @@ func CURLResponseRawJson(method string, url string, opts ...HTTPOption) (*simple
 	}
 
 	defer resp.Body.Close()
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errResponse, errors.New(fmt.Sprintf("read (%s) body failed, (%v)", url, err))
 	}

--- a/cli/ctl/domain.go
+++ b/cli/ctl/domain.go
@@ -19,7 +19,6 @@ package ctl
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -335,7 +334,7 @@ func formatBody(filename string) (map[string]interface{}, error) {
 			return upperBody, err
 		}
 	} else {
-		yamlFile, err := ioutil.ReadFile(filename)
+		yamlFile, err := os.ReadFile(filename)
 		if err != nil {
 			return upperBody, err
 		}

--- a/cli/ctl/domain_additional_resource.go
+++ b/cli/ctl/domain_additional_resource.go
@@ -19,7 +19,6 @@ package ctl
 import (
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -262,7 +261,7 @@ func exampleDomainAdditionalResourceConfig(cmd *cobra.Command) {
 
 func loadBodyFromFile(filename string) (map[string]interface{}, error) {
 	var body map[string]interface{}
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/server/config.go
+++ b/server/cmd/server/config.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -69,7 +68,7 @@ func loadConfig(path string) *Config {
 		MonitorPaths:        []string{"/", "/mnt", "/var/log"},
 		FreeOSMemoryManager: FreeOSMemoryManager{false, DEFAULT_FREE_INTERVAL_SECOND},
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Printf("Read config file path: %s, error: %s", err, path)
 		os.Exit(1)

--- a/server/common/module_shared.go
+++ b/server/common/module_shared.go
@@ -18,7 +18,7 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/deepflowio/deepflow/server/libs/eventapi"
@@ -64,7 +64,7 @@ type ExportersConfig struct {
 }
 
 func ExportersEnabled(configPath string) bool {
-	configBytes, err := ioutil.ReadFile(configPath)
+	configBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		log.Error("Read config file error:", err)
 		return false

--- a/server/controller/cloud/common/http.go
+++ b/server/controller/cloud/common/http.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -70,7 +70,7 @@ func RequestGet(url, token string, timeout time.Duration) (jsonResp *simplejson.
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = newErr(url, fmt.Sprintf("read failed: %s", err.Error()))
 		log.Errorf(err.Error())
@@ -111,7 +111,7 @@ func RequestPost(url string, timeout time.Duration, body map[string]interface{})
 		return
 	}
 	defer resp.Body.Close()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = newErr(url, fmt.Sprintf("read failed: %s", err.Error()))
 		log.Errorf(err.Error())

--- a/server/controller/cloud/huawei/curl.go
+++ b/server/controller/cloud/huawei/curl.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -72,7 +72,7 @@ func RequestGet(url, token string, timeout time.Duration, header map[string]stri
 	}
 	defer resp.Body.Close()
 
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = newErr(url, fmt.Sprintf("read failed: %s", err.Error()))
 		log.Errorf(err.Error())
@@ -112,7 +112,7 @@ func RequestPost(url string, timeout time.Duration, body map[string]interface{})
 		return
 	}
 	defer resp.Body.Close()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		err = newErr(url, fmt.Sprintf("read failed: %s", err.Error()))
 		log.Errorf(err.Error())

--- a/server/controller/common/aes.go
+++ b/server/controller/common/aes.go
@@ -25,8 +25,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 
@@ -114,7 +114,7 @@ func GetEncryptKey(controllerIP, grpcServerPort, key string) (string, error) {
 }
 
 func EncryptSecretKey(secretKey string) (string, error) {
-	caData, err := ioutil.ReadFile(K8S_CA_CRT_PATH)
+	caData, err := os.ReadFile(K8S_CA_CRT_PATH)
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -129,7 +129,7 @@ func EncryptSecretKey(secretKey string) (string, error) {
 }
 
 func DecryptSecretKey(secretKey string) (string, error) {
-	caData, err := ioutil.ReadFile(K8S_CA_CRT_PATH)
+	caData, err := os.ReadFile(K8S_CA_CRT_PATH)
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -144,7 +144,7 @@ func DecryptSecretKey(secretKey string) (string, error) {
 }
 
 func GetLocalClusterID() (string, error) {
-	caData, err := ioutil.ReadFile(K8S_CA_CRT_PATH)
+	caData, err := os.ReadFile(K8S_CA_CRT_PATH)
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -153,7 +153,7 @@ func GetLocalClusterID() (string, error) {
 }
 
 func getCAMD5() string {
-	caData, err := ioutil.ReadFile(K8S_CA_CRT_PATH)
+	caData, err := os.ReadFile(K8S_CA_CRT_PATH)
 	if err != nil {
 		log.Error(err)
 		return ""

--- a/server/controller/config/config.go
+++ b/server/controller/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -121,7 +120,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Load(path string) {
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Error("Read config file error:", err, path)
 		os.Exit(1)

--- a/server/ingester/app_log/config/config.go
+++ b/server/ingester/app_log/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -71,7 +70,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.ApplicationLog
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.ApplicationLog.Validate()

--- a/server/ingester/config/config.go
+++ b/server/ingester/config/config.go
@@ -19,7 +19,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -484,7 +483,7 @@ func (c *Config) GetCKDBColdStorages() map[string]*ckdb.ColdStorage {
 }
 
 func Load(path string) *Config {
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	config := BaseConfig{
 		LogFile:  "/var/log/deepflow/server.log",
 		LogLevel: "info",

--- a/server/ingester/datasource/datasource.go
+++ b/server/ingester/datasource/datasource.go
@@ -19,7 +19,7 @@ package datasource
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -138,7 +138,7 @@ type DelBody struct {
 }
 
 func (m *DatasourceManager) rpAdd(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("read body err, %v", err)
 		respFailed(w, err.Error())
@@ -161,7 +161,7 @@ func (m *DatasourceManager) rpAdd(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *DatasourceManager) rpMod(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("read body err, %v", err)
 		respFailed(w, err.Error())
@@ -189,7 +189,7 @@ func (m *DatasourceManager) rpMod(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *DatasourceManager) rpDel(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Errorf("read body err, %v", err)
 		respFailed(w, err.Error())

--- a/server/ingester/event/config/config.go
+++ b/server/ingester/event/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -113,7 +112,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.Event
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.Event.Validate()

--- a/server/ingester/exporters/config/config.go
+++ b/server/ingester/exporters/config/config.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -742,7 +741,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.Exporters
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.Exporters.Validate()

--- a/server/ingester/exporters/config/config_test.go
+++ b/server/ingester/exporters/config/config_test.go
@@ -17,7 +17,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -34,7 +34,7 @@ type ingesterConfig struct {
 
 func TestConfig(t *testing.T) {
 	ingesterCfg := baseConfig{}
-	configBytes, _ := ioutil.ReadFile("./config_test.yaml")
+	configBytes, _ := os.ReadFile("./config_test.yaml")
 	err := yaml.Unmarshal(configBytes, &ingesterCfg)
 	if err != nil {
 		t.Fatalf("yaml unmarshal failed: %v", err)

--- a/server/ingester/ext_metrics/config/config.go
+++ b/server/ingester/ext_metrics/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -71,7 +70,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.ExtMetrics
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.ExtMetrics.Validate()

--- a/server/ingester/flow_log/config/config.go
+++ b/server/ingester/flow_log/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	logging "github.com/op/go-logging"
@@ -103,7 +102,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.FlowLog
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.FlowLog.Validate()

--- a/server/ingester/flow_log/decoder/decoder.go
+++ b/server/ingester/flow_log/decoder/decoder.go
@@ -19,7 +19,7 @@ package decoder
 import (
 	"bytes"
 	"compress/zlib"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"time"
 
@@ -238,7 +238,7 @@ func decompressOpenTelemetry(compressed []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }
 
 func (d *Decoder) handleOpenTelemetry(decoder *codec.SimpleDecoder, pbTracesData *v1.TracesData, compressed bool) {

--- a/server/ingester/flow_metrics/config/config.go
+++ b/server/ingester/flow_metrics/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -107,7 +106,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.FlowMetrics
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warningf("Read config file error:", err)
 		config.FlowMetrics.Validate()

--- a/server/ingester/pcap/config/config.go
+++ b/server/ingester/pcap/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -74,7 +73,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.Pcap
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.Pcap.Validate()

--- a/server/ingester/profile/config/config.go
+++ b/server/ingester/profile/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -86,7 +85,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.Profile
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.Profile.Validate()

--- a/server/ingester/prometheus/config/config.go
+++ b/server/ingester/prometheus/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/deepflowio/deepflow/server/ingester/config"
@@ -102,7 +101,7 @@ func Load(base *config.Config, path string) *Config {
 		log.Info("no config file, use defaults")
 		return &config.Prometheus
 	}
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Warning("Read config file error:", err)
 		config.Prometheus.Validate()

--- a/server/querier/app/distributed_tracing/config/config.go
+++ b/server/querier/app/distributed_tracing/config/config.go
@@ -17,11 +17,9 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
-
 	"strings"
 
 	"github.com/op/go-logging"
@@ -75,7 +73,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Load(path string) {
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Error("Read config file error:", err, path)
 		os.Exit(1)

--- a/server/querier/common/utils.go
+++ b/server/querier/common/utils.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"slices"
 	"strings"
@@ -43,7 +42,7 @@ func LoadDbDescriptions(dir string) (map[string]interface{}, error) {
 }
 
 func readDir(dir string, desMap map[string]interface{}) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		// TODO
 		return err

--- a/server/querier/config/config.go
+++ b/server/querier/config/config.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -136,7 +135,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Load(path string) {
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Error("Read config file error:", err, path)
 		os.Exit(1)

--- a/server/querier/engine/clickhouse/common/utils.go
+++ b/server/querier/engine/clickhouse/common/utils.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"slices"
@@ -100,7 +100,7 @@ func IPFilterStringToHex(ip string) string {
 
 func ParseResponse(response *http.Response) (map[string]interface{}, error) {
 	var result map[string]interface{}
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err == nil {
 		err = json.Unmarshal(body, &result)
 	}

--- a/server/querier/profile/config/config.go
+++ b/server/querier/profile/config/config.go
@@ -17,14 +17,13 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/op/go-logging"
 	"gopkg.in/yaml.v2"
-	"strings"
 )
 
 var log = logging.MustGetLogger("profile")
@@ -71,7 +70,7 @@ func (c *Config) Validate() error {
 }
 
 func (c *Config) Load(path string) {
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.Error("Read config file error:", err, path)
 		os.Exit(1)

--- a/server/querier/tempo/tempo.go
+++ b/server/querier/tempo/tempo.go
@@ -21,6 +21,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/config"
@@ -37,12 +43,6 @@ import (
 	"github.com/google/uuid"
 
 	//"github.com/k0kubun/pp"
-	"io/ioutil"
-	"math/rand"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 
 	logging "github.com/op/go-logging"
 )
@@ -275,7 +275,7 @@ func FindTraceByTraceID(args *common.TempoParams) (req *tempopb.Trace, err error
 
 func ParseResponse(response *http.Response) (map[string]interface{}, error) {
 	var result map[string]interface{}
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err == nil {
 		err = json.Unmarshal(body, &result)
 	}


### PR DESCRIPTION
### This PR is for:

- CLI
- Server

The `io/ioutil` package has been deprecated as of Go 1.16. This commit replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

Reference: https://golang.org/doc/go1.16#ioutil

![2025-03-13_00-44](https://github.com/user-attachments/assets/5ebb380e-2e40-4d55-8a52-397068704e5f)
