### PR TITLE
fix: avoid server switch caused by mysql exception

### DIFF
--- a/server/controller/monitor/analyzer.go
+++ b/server/controller/monitor/analyzer.go
@@ -247,6 +247,11 @@ func (c *AnalyzerCheck) vtapAnalyzerCheck(orgDB *metadb.DB) {
 	ipMap, err := getIPMap(common.HOST_TYPE_ANALYZER)
 	if err != nil {
 		log.Error(err, orgDB.LogPrefixORGID)
+		return
+	}
+	if len(ipMap) == 0 {
+		log.Info("no analyzer in DB, do nothing", orgDB.LogPrefixORGID)
+		return
 	}
 
 	if err := orgDB.Where("type != ?", common.VTAP_TYPE_TUNNEL_DECAPSULATION).Find(&vtaps).Error; err != nil {

--- a/server/controller/monitor/common.go
+++ b/server/controller/monitor/common.go
@@ -64,14 +64,18 @@ func getIPMap(hostType string) (map[string]bool, error) {
 	switch hostType {
 	case common.HOST_TYPE_CONTROLLER:
 		var controllers []metadbmodel.Controller
-		metadb.DefaultDB.Find(&controllers)
+		if err := metadb.DefaultDB.Find(&controllers).Error; err != nil {
+			return nil, err
+		}
 		res = make(map[string]bool, len(controllers))
 		for _, controller := range controllers {
 			res[controller.IP] = true
 		}
 	case common.HOST_TYPE_ANALYZER:
 		var analyzers []metadbmodel.Analyzer
-		metadb.DefaultDB.Find(&analyzers)
+		if err := metadb.DefaultDB.Find(&analyzers).Error; err != nil {
+			return nil, err
+		}
 		res = make(map[string]bool, len(analyzers))
 		for _, analyzer := range analyzers {
 			res[analyzer.IP] = true

--- a/server/controller/monitor/controller.go
+++ b/server/controller/monitor/controller.go
@@ -255,7 +255,12 @@ func (c *ControllerCheck) vtapControllerCheck(orgDB *metadb.DB) {
 
 	ipMap, err := getIPMap(common.HOST_TYPE_CONTROLLER)
 	if err != nil {
-		log.Error(err)
+		log.Error(err, orgDB.LogPrefixORGID)
+		return
+	}
+	if len(ipMap) == 0 {
+		log.Info("no controller in DB, do nothing", orgDB.LogPrefixORGID)
+		return
 	}
 
 	if err := orgDB.Where("type != ?", common.VTAP_TYPE_TUNNEL_DECAPSULATION).Find(&vtaps).Error; err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


