### PR TITLE
refactor: replace `golang.org/x/exp/slices` with stdlib `slices`

### DIFF
--- a/server/agent_config/migrator.go
+++ b/server/agent_config/migrator.go
@@ -18,10 +18,10 @@ package agent_config
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/baidubce/bce-sdk-go/util/log"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/server/agent_config/migrator_conv.go
+++ b/server/agent_config/migrator_conv.go
@@ -19,10 +19,9 @@ package agent_config
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/baidubce/bce-sdk-go/util/log"
 	"gopkg.in/yaml.v3"

--- a/server/controller/http/service/vtap/vtap_interface.go
+++ b/server/controller/http/service/vtap/vtap_interface.go
@@ -19,11 +19,11 @@ package vtap
 import (
 	"fmt"
 	"net"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/bitly/go-simplejson"
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"

--- a/server/controller/prometheus/cache/org.go
+++ b/server/controller/prometheus/cache/org.go
@@ -19,11 +19,11 @@ package cache
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
 	cmap "github.com/orcaman/concurrent-map/v2"
-	"golang.org/x/exp/slices"
 
 	ctrlrcommon "github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"

--- a/server/controller/prometheus/encoder/org.go
+++ b/server/controller/prometheus/encoder/org.go
@@ -19,10 +19,9 @@ package encoder
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"
 	prometheuscfg "github.com/deepflowio/deepflow/server/controller/prometheus/config"

--- a/server/controller/recorder/cleaner/cleaner.go
+++ b/server/controller/recorder/cleaner/cleaner.go
@@ -18,11 +18,10 @@ package cleaner
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	ctrlrcommon "github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"

--- a/server/controller/recorder/common/slice.go
+++ b/server/controller/recorder/common/slice.go
@@ -17,11 +17,10 @@
 package common
 
 import (
+	"cmp"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 )
 
 func IntSliceToString(s []int) string {
@@ -49,7 +48,7 @@ func StringToIntSlice(str string) []int {
 	return s
 }
 
-func ElementsSame[T constraints.Ordered](s1, s2 []T) bool {
+func ElementsSame[T cmp.Ordered](s1, s2 []T) bool {
 	slices.Sort(s1)
 	slices.Sort(s2)
 	return slices.Equal(s1, s2)

--- a/server/controller/recorder/db/idmng/org.go
+++ b/server/controller/recorder/db/idmng/org.go
@@ -19,10 +19,9 @@ package idmng
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"

--- a/server/controller/recorder/event/process.go
+++ b/server/controller/recorder/event/process.go
@@ -18,10 +18,10 @@ package event
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/controller/common"
 	metadbmodel "github.com/deepflowio/deepflow/server/controller/db/metadb/model"

--- a/server/controller/recorder/updater/logger.go
+++ b/server/controller/recorder/updater/logger.go
@@ -19,8 +19,7 @@ package updater
 import (
 	"fmt"
 	"reflect"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/deepflowio/deepflow/server/controller/recorder/config"
 	"github.com/deepflowio/deepflow/server/controller/recorder/constraint"

--- a/server/controller/tagrecorder/ch_app_label.go
+++ b/server/controller/tagrecorder/ch_app_label.go
@@ -17,7 +17,7 @@
 package tagrecorder
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"
 	metadbmodel "github.com/deepflowio/deepflow/server/controller/db/metadb/model"

--- a/server/controller/tagrecorder/check/ch_app_label.go
+++ b/server/controller/tagrecorder/check/ch_app_label.go
@@ -17,7 +17,7 @@
 package tagrecorder
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"
 	metadbmodel "github.com/deepflowio/deepflow/server/controller/db/metadb/model"

--- a/server/controller/tagrecorder/dictionary.go
+++ b/server/controller/tagrecorder/dictionary.go
@@ -20,12 +20,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	mapset "github.com/deckarep/golang-set"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/server/controller/tagrecorder/subscriber.go
+++ b/server/controller/tagrecorder/subscriber.go
@@ -17,9 +17,8 @@
 package tagrecorder
 
 import (
+	"slices"
 	"sync"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/controller/config"
 	"github.com/deepflowio/deepflow/server/controller/db/metadb"

--- a/server/go.mod
+++ b/server/go.mod
@@ -29,20 +29,26 @@ replace (
 )
 
 require (
+	bou.ke/monkey v1.0.2
+	github.com/ClickHouse/ch-go v0.63.2-0.20241227130939-07604935a3cf
 	github.com/ClickHouse/clickhouse-go/v2 v2.1.0
+	github.com/IBM/sarama v1.43.0
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/agiledragon/gomonkey/v2 v2.8.0
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.1633
+	github.com/aws/aws-sdk-go-v2 v1.17.3
 	github.com/aws/aws-sdk-go-v2/config v1.17.8
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.21
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.63.1
+	github.com/aws/aws-sdk-go-v2/service/eks v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancing v1.14.18
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.18.20
 	github.com/baidubce/bce-sdk-go v0.9.141
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bxcodec/faker/v3 v3.8.0
+	github.com/bytedance/sonic v1.12.5
 	github.com/cornelk/hashmap v1.0.8
 	github.com/deckarep/golang-set v1.8.0
 	github.com/deckarep/golang-set/v2 v2.1.0
@@ -52,66 +58,11 @@ require (
 	github.com/deepflowio/deepflow/server/controller/cloud/tencent/expand v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/controller/db/metadb/migrator/edition v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/controller/genesis/store/sync v0.0.0-00010101000000-000000000000
-	github.com/deepflowio/deepflow/server/controller/monitor/license v0.0.0-00010101000000-000000000000
-	github.com/deepflowio/deepflow/server/ingester/config/configdefaults v0.0.0-00010101000000-000000000000
-	github.com/deepflowio/deepflow/server/querier/engine/clickhouse/packet_batch v0.0.0-00010101000000-000000000000
-	github.com/deepflowio/tempopb v0.0.0-20230215110519-15853baf3a79
-	github.com/docker/go-units v0.4.0
-	github.com/gin-gonic/gin v1.9.1
-	github.com/gogo/protobuf v1.3.2
-	github.com/golang/protobuf v1.5.4
-	github.com/google/gopacket v1.1.19
-	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.0
-	github.com/influxdata/influxdb v1.9.7
-	github.com/jmoiron/sqlx v1.3.5
-	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
-	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
-	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c // indirect
-	github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535
-	github.com/pebbe/zmq4 v1.2.9
-	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.35.0
-	github.com/prometheus/prometheus v0.36.2
-	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
-	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/shirou/gopsutil/v3 v3.22.5
-	github.com/smartystreets/goconvey v1.7.2
-	github.com/spf13/cobra v1.4.0
-	github.com/stretchr/testify v1.10.0
-	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.726
-	github.com/textnode/fencer v0.0.0-20121219195347-6baed0e5ef9a
-	github.com/vishvananda/netlink v1.1.0
-	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
-	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.49.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
-	go.opentelemetry.io/otel/sdk v1.33.0
-	go.opentelemetry.io/proto/otlp v1.1.0
-	golang.org/x/net v0.26.0
-	golang.org/x/sys v0.28.0
-	google.golang.org/grpc v1.62.1
-	gopkg.in/alexcesaro/statsd.v2 v2.0.0
-	gopkg.in/yaml.v2 v2.4.0
-	gorm.io/driver/mysql v1.3.4
-	gorm.io/driver/sqlite v1.3.4
-	gorm.io/gorm v1.25.10
-	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
-	k8s.io/api v0.24.0
-	k8s.io/apimachinery v0.24.0
-	k8s.io/client-go v0.24.0
-)
-
-require (
-	bou.ke/monkey v1.0.2
-	github.com/ClickHouse/ch-go v0.63.2-0.20241227130939-07604935a3cf
-	github.com/IBM/sarama v1.43.0
-	github.com/aws/aws-sdk-go-v2/service/eks v1.26.0
-	github.com/bytedance/sonic v1.12.5
 	github.com/deepflowio/deepflow/server/controller/http/appender v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/controller/http/service/agentlicense v0.0.0-00010101000000-000000000000
+	github.com/deepflowio/deepflow/server/controller/monitor/license v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/controller/native_field v0.0.0-00010101000000-000000000000
+	github.com/deepflowio/deepflow/server/ingester/config/configdefaults v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/ingester/flow_log/log_data/dd_import v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/ingester/flow_log/log_data/sw_import v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/libs/logger/blocker v0.0.0-20240822020041-cdaf0f82ce6f
@@ -119,24 +70,80 @@ require (
 	github.com/deepflowio/deepflow/server/querier/app/prometheus/router/packet_adapter v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/querier/app/prometheus/service/packet_wrapper v0.0.0-00010101000000-000000000000
 	github.com/deepflowio/deepflow/server/querier/app/tracing-adapter/service/packet_service v0.0.0-00010101000000-000000000000
+	github.com/deepflowio/deepflow/server/querier/engine/clickhouse/packet_batch v0.0.0-00010101000000-000000000000
+	github.com/deepflowio/tempopb v0.0.0-20230215110519-15853baf3a79
+	github.com/docker/go-units v0.4.0
+	github.com/gin-gonic/gin v1.9.1
 	github.com/go-redis/redis/v9 v9.0.0-rc.2
+	github.com/go-sql-driver/mysql v1.8.1
+	github.com/goccy/go-json v0.10.2
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
+	github.com/golang/protobuf v1.5.4
+	github.com/golang/snappy v0.0.4
+	github.com/google/gopacket v1.1.19
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/mux v1.8.0
 	github.com/grafana/pyroscope-go v1.2.0
+	github.com/influxdata/influxdb v1.9.7
+	github.com/jarcoal/httpmock v1.3.1
+	github.com/jmoiron/sqlx v1.3.5
 	github.com/klauspost/compress v1.17.11
 	github.com/knadh/koanf/parsers/yaml v0.1.0
 	github.com/knadh/koanf/providers/rawbytes v0.1.0
 	github.com/knadh/koanf/v2 v2.1.2
+	github.com/lestrrat-go/file-rotatelogs v2.4.0+incompatible
 	github.com/lib/pq v1.10.2
+	github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
+	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
+	github.com/openshift/client-go v0.0.0-20210422153130-25c8450d1535
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/pebbe/zmq4 v1.2.9
+	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.35.0
+	github.com/prometheus/prometheus v0.36.2
 	github.com/pyroscope-io/pyroscope v0.37.1
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
+	github.com/shirou/gopsutil v3.21.11+incompatible
+	github.com/shirou/gopsutil/v3 v3.22.5
+	github.com/smartystreets/goconvey v1.7.2
+	github.com/spf13/cobra v1.4.0
+	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
+	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.726
+	github.com/textnode/fencer v0.0.0-20121219195347-6baed0e5ef9a
+	github.com/vishvananda/netlink v1.1.0
 	github.com/volcengine/volcengine-go-sdk v1.0.141
+	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
+	github.com/yuin/gopher-lua v1.1.1
 	go.opentelemetry.io/collector/pdata v1.0.0
+	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.49.0
+	go.opentelemetry.io/otel v1.33.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.24.0
+	go.opentelemetry.io/otel/sdk v1.33.0
+	go.opentelemetry.io/otel/trace v1.33.0
+	go.opentelemetry.io/proto/otlp v1.1.0
+	golang.org/x/net v0.26.0
+	golang.org/x/sync v0.10.0
+	golang.org/x/sys v0.28.0
+	google.golang.org/grpc v1.62.1
+	google.golang.org/protobuf v1.33.0
+	gopkg.in/alexcesaro/statsd.v2 v2.0.0
+	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/mysql v1.3.4
 	gorm.io/driver/postgres v1.5.11
+	gorm.io/driver/sqlite v1.3.4
+	gorm.io/gorm v1.25.10
+	inet.af/netaddr v0.0.0-20211027220019-c74959edd3b6
+	k8s.io/api v0.24.0
+	k8s.io/apimachinery v0.24.0
+	k8s.io/client-go v0.24.0
 	skywalking.apache.org/repo/goapi v0.0.0-20230712035303-201c1fb2d6ec
 )
 
@@ -145,76 +152,10 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
-	github.com/bytedance/sonic/loader v0.2.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/cloudwego/base64x v0.1.4 // indirect
-	github.com/cloudwego/iasm v0.2.0 // indirect
-	github.com/dgraph-io/badger/v2 v2.2007.2 // indirect
-	github.com/dgraph-io/ristretto v0.1.0 // indirect
-	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/dmarkham/enumer v1.5.10 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/eapache/go-resiliency v1.6.0 // indirect
-	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
-	github.com/eapache/queue v1.1.0 // indirect
-	github.com/edsrzf/mmap-go v1.1.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
-	github.com/go-faster/city v1.0.1 // indirect
-	github.com/go-faster/errors v0.7.1 // indirect
-	github.com/go-openapi/spec v0.20.4 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
-	github.com/golang/glog v1.2.0 // indirect
-	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
-	github.com/hashicorp/consul/api v1.28.2 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/ionos-cloud/sdk-go/v6 v6.1.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.5.5 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
-	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
-	github.com/jcmturner/gofork v1.7.6 // indirect
-	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
-	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
-	github.com/knadh/koanf/maps v0.1.1 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/oklog/ulid v1.3.1 // indirect
-	github.com/pascaldekloe/name v1.0.1 // indirect
-	github.com/pyroscope-io/jfr-parser v0.5.2 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/swaggo/swag v1.8.12 // indirect
-	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/volcengine/volc-sdk-golang v1.0.23 // indirect
-	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
-	golang.org/x/arch v0.7.0 // indirect
-	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
-	golang.org/x/mod v0.18.0 // indirect
-	golang.org/x/tools v0.22.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c // indirect
-)
-
-require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/aws/aws-sdk-go v1.44.37 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.17.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.21 // indirect
@@ -226,12 +167,31 @@ require (
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/bytedance/sonic/loader v0.2.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cloudwego/base64x v0.1.4 // indirect
+	github.com/cloudwego/iasm v0.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect
+	github.com/dgraph-io/badger/v2 v2.2007.2 // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
+	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dmarkham/enumer v1.5.10 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/eapache/go-resiliency v1.6.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-faster/city v1.0.1 // indirect
+	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
@@ -239,20 +199,36 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
+	github.com/go-openapi/spec v0.20.4 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.19.0 // indirect
-	github.com/go-sql-driver/mysql v1.8.1
-	github.com/goccy/go-json v0.10.2
-	github.com/golang/snappy v0.0.4
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/golang/glog v1.2.0 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.8 // indirect
 	github.com/grafana/regexp v0.0.0-20220304095617-2e8d9baf4ac2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
+	github.com/hashicorp/consul/api v1.28.2 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-uuid v1.0.3 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/jarcoal/httpmock v1.3.1
+	github.com/ionos-cloud/sdk-go/v6 v6.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
+	github.com/jackc/pgx/v5 v5.5.5 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
+	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect
+	github.com/jcmturner/gofork v1.7.6 // indirect
+	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
+	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
@@ -261,6 +237,8 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
+	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/strftime v1.0.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
@@ -268,10 +246,15 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/openshift/api v0.0.0-20210422150128-d8a48168c81c // indirect
+	github.com/pascaldekloe/name v1.0.1 // indirect
 	github.com/paulmach/orb v0.7.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
@@ -281,33 +264,44 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/pyroscope-io/jfr-parser v0.5.2 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/swaggo/swag v1.8.12 // indirect
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
-	github.com/yuin/gopher-lua v1.1.1
+	github.com/volcengine/volc-sdk-golang v1.0.23 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.33.0
 	go.opentelemetry.io/otel/metric v1.33.0 // indirect
-	go.opentelemetry.io/otel/trace v1.33.0
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	go4.org/intern v0.0.0-20211027215823-ae77deb06f29 // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
+	golang.org/x/arch v0.7.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
+	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/oauth2 v0.19.0 // indirect
-	golang.org/x/sync v0.10.0
 	golang.org/x/term v0.27.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
-	google.golang.org/protobuf v1.33.0
+	golang.org/x/tools v0.22.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240314234333-6e1732d8331c // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.70.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/server/go.mod
+++ b/server/go.mod
@@ -136,7 +136,6 @@ require (
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/volcengine/volcengine-go-sdk v1.0.141
 	go.opentelemetry.io/collector/pdata v1.0.0
-	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	gorm.io/driver/postgres v1.5.11
 	skywalking.apache.org/repo/goapi v0.0.0-20230712035303-201c1fb2d6ec
 )
@@ -203,6 +202,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.7.0 // indirect
+	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect

--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"reflect"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -33,7 +33,6 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/xwb1989/sqlparser"
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/app/prometheus/model"
 	"github.com/deepflowio/deepflow/server/querier/common"
@@ -732,7 +731,7 @@ func (p *prometheusReader) respTransToProm(ctx context.Context, metricsName stri
 			}
 			promJsonMap[promTagJson] = filterTagMap
 			// IMPORTANT: tags needed to be sorted, it will be compare both in cache and seriesIndexMap
-			sort.Strings(promTagStrList)
+			slices.Sort(promTagStrList)
 			for i := 0; i < len(promTagStrList); i++ {
 				promTagWriter.WriteString(promTagStrList[i])
 				promTagWriter.WriteByte(':')

--- a/server/querier/common/utils.go
+++ b/server/querier/common/utils.go
@@ -20,9 +20,8 @@ import (
 	"bufio"
 	"io/ioutil"
 	"os"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 )
 
 func IsValueInSliceString(value string, list []string) bool {

--- a/server/querier/engine/clickhouse/callback.go
+++ b/server/querier/engine/clickhouse/callback.go
@@ -19,10 +19,9 @@ package clickhouse
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/libs/utils"
 	"github.com/deepflowio/deepflow/server/querier/common"

--- a/server/querier/engine/clickhouse/clickhouse.go
+++ b/server/querier/engine/clickhouse/clickhouse.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,7 +30,6 @@ import (
 	//"github.com/k0kubun/pp"
 	logging "github.com/op/go-logging"
 	"github.com/xwb1989/sqlparser"
-	"golang.org/x/exp/slices"
 
 	ctlcommon "github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/querier/common"
@@ -692,7 +691,7 @@ func (e *CHEngine) ParseSlimitSql(sql string, args *common.QuerierParams) (strin
 								for autoTagKey, _ := range autoTagMap {
 									autoTagSlice = append(autoTagSlice, autoTagKey)
 								}
-								sort.Strings(autoTagSlice)
+								slices.Sort(autoTagSlice)
 								for _, autoTagKey := range autoTagSlice {
 									outerWhereLeftSlice = append(outerWhereLeftSlice, "`"+autoTagKey+"`")
 								}
@@ -710,7 +709,7 @@ func (e *CHEngine) ParseSlimitSql(sql string, args *common.QuerierParams) (strin
 								for autoTagKey, _ := range autoTagMap {
 									autoTagSlice = append(autoTagSlice, autoTagKey)
 								}
-								sort.Strings(autoTagSlice)
+								slices.Sort(autoTagSlice)
 								for _, autoTagKey := range autoTagSlice {
 									outerWhereLeftSlice = append(outerWhereLeftSlice, "`"+autoTagKey+"`")
 								}

--- a/server/querier/engine/clickhouse/common/utils.go
+++ b/server/querier/engine/clickhouse/common/utils.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/deepflowio/deepflow/server/querier/engine/clickhouse/client"
 	logging "github.com/op/go-logging"
 	"github.com/xwb1989/sqlparser"
-	"golang.org/x/exp/slices"
 )
 
 var log = logging.MustGetLogger("common")

--- a/server/querier/engine/clickhouse/filter.go
+++ b/server/querier/engine/clickhouse/filter.go
@@ -21,11 +21,10 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/Knetic/govaluate"
 	"github.com/deepflowio/deepflow/server/libs/utils"

--- a/server/querier/engine/clickhouse/from.go
+++ b/server/querier/engine/clickhouse/from.go
@@ -18,8 +18,7 @@ package clickhouse
 
 import (
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"

--- a/server/querier/engine/clickhouse/function.go
+++ b/server/querier/engine/clickhouse/function.go
@@ -21,10 +21,9 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/config"

--- a/server/querier/engine/clickhouse/group.go
+++ b/server/querier/engine/clickhouse/group.go
@@ -18,10 +18,8 @@ package clickhouse
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
@@ -145,7 +143,7 @@ func GetGroup(name string, e *CHEngine) ([]Statement, error) {
 				for autoTagKey, _ := range autoTagMap {
 					autoTagSlice = append(autoTagSlice, autoTagKey)
 				}
-				sort.Strings(autoTagSlice)
+				slices.Sort(autoTagSlice)
 				for _, autoTagKey := range autoTagSlice {
 					stmts = append(stmts, &GroupTag{Value: "`" + autoTagKey + "`", AsTagMap: asTagMap})
 				}

--- a/server/querier/engine/clickhouse/metrics/ext_common.go
+++ b/server/querier/engine/clickhouse/metrics/ext_common.go
@@ -19,9 +19,8 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	ctlcommon "github.com/deepflowio/deepflow/server/controller/common"
 	"github.com/deepflowio/deepflow/server/querier/config"

--- a/server/querier/engine/clickhouse/metrics/metrics.go
+++ b/server/querier/engine/clickhouse/metrics/metrics.go
@@ -21,9 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/config"

--- a/server/querier/engine/clickhouse/table.go
+++ b/server/querier/engine/clickhouse/table.go
@@ -18,8 +18,7 @@ package clickhouse
 
 import (
 	"context"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	"github.com/deepflowio/deepflow/server/querier/engine/clickhouse/client"

--- a/server/querier/engine/clickhouse/tag.go
+++ b/server/querier/engine/clickhouse/tag.go
@@ -19,10 +19,8 @@ package clickhouse
 import (
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 	chCommon "github.com/deepflowio/deepflow/server/querier/engine/clickhouse/common"
@@ -95,7 +93,7 @@ func GetTagTranslator(name, alias string, e *CHEngine) ([]Statement, string, err
 			for autoTagKey, _ := range autoTagMap {
 				autoTagSlice = append(autoTagSlice, autoTagKey)
 			}
-			sort.Strings(autoTagSlice)
+			slices.Sort(autoTagSlice)
 			for _, autoTagKey := range autoTagSlice {
 				stmts = append(stmts, &SelectTag{Value: autoTagMap[autoTagKey], Alias: "`" + autoTagKey + "`"})
 			}
@@ -126,7 +124,7 @@ func GetTagTranslator(name, alias string, e *CHEngine) ([]Statement, string, err
 			for autoTagKey, _ := range autoTagMap {
 				autoTagSlice = append(autoTagSlice, autoTagKey)
 			}
-			sort.Strings(autoTagSlice)
+			slices.Sort(autoTagSlice)
 			for _, autoTagKey := range autoTagSlice {
 				if autoTagMap[autoTagKey] != "" {
 					stmts = append(stmts, &SelectTag{Value: autoTagMap[autoTagKey], Alias: "`" + autoTagKey + "`"})
@@ -179,7 +177,7 @@ func GetTagTranslator(name, alias string, e *CHEngine) ([]Statement, string, err
 			for autoTagKey, _ := range autoTagMap {
 				autoTagSlice = append(autoTagSlice, autoTagKey)
 			}
-			sort.Strings(autoTagSlice)
+			slices.Sort(autoTagSlice)
 			for _, autoTagKey := range autoTagSlice {
 				if autoTagMap[autoTagKey] != "" {
 					stmts = append(stmts, &SelectTag{Value: autoTagMap[autoTagKey], Alias: "`" + autoTagKey + "`"})

--- a/server/querier/engine/clickhouse/tag/description.go
+++ b/server/querier/engine/clickhouse/tag/description.go
@@ -21,10 +21,9 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	logging "github.com/op/go-logging"
 

--- a/server/querier/engine/clickhouse/tag/translation.go
+++ b/server/querier/engine/clickhouse/tag/translation.go
@@ -18,10 +18,9 @@ package tag
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/deepflowio/deepflow/server/querier/common"
 )

--- a/server/querier/profile/service/profile.go
+++ b/server/querier/profile/service/profile.go
@@ -19,11 +19,10 @@ package service
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	logging "github.com/op/go-logging"
 


### PR DESCRIPTION
### This PR is for:

- Server

The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#slices