### PR TITLE
feat: Support rewrite http x_request_id

### DIFF
--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -6,7 +6,7 @@
 !src/integration/mod.rs
 src/proto/*.rs
 src/proto/integration/*.rs
-src/plugin/wasm/wasm_plugin.rs
+# src/plugin/wasm/wasm_plugin.rs
 src/flow_generator/protocol_logs/mq/pulsar.proto.rs
 
 src/ebpf/data

--- a/agent/build.rs
+++ b/agent/build.rs
@@ -219,6 +219,7 @@ fn set_linkage() -> Result<()> {
     Ok(())
 }
 
+#[allow(dead_code)]
 fn compile_wasm_plugin_proto() -> Result<()> {
     tonic_build::configure()
         .build_server(false)
@@ -276,7 +277,15 @@ fn make_brpc_proto() -> Result<()> {
 
 fn main() -> Result<()> {
     set_build_info()?;
+    /*
+     * The protoc binary is too old (3.12) in rust-build image, which cannot handle optional fields in protobuf v3 correctly.
+     * And it's not easy to upgrade because of the EOL issue of Centos7.
+     * We are pushing the generated protobuf code to repo as a workaround.
+     *
+     * TODO: Fix this issue in the rust-build image.
+     *
     compile_wasm_plugin_proto()?;
+     */
     make_pulsar_proto()?;
     make_brpc_proto()?;
     let target_os = env::var("CARGO_CFG_TARGET_OS")?;

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -66,6 +66,19 @@ impl Version {
     }
 }
 
+impl TryFrom<&str> for Version {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "1.0" => Ok(Self::V1_0),
+            "1.1" => Ok(Self::V1_1),
+            "2" => Ok(Self::V2),
+            _ => Err(Error::HttpHeaderParseFailed),
+        }
+    }
+}
+
 impl Serialize for Version {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -272,47 +285,66 @@ pub struct HttpInfo {
 }
 
 impl HttpInfo {
-    pub fn merge_custom_to_http(&mut self, custom: CustomInfo) {
-        // req rewrite
-        if !custom.req.domain.is_empty() {
-            self.host = custom.req.domain;
+    pub fn merge_custom_to_http(&mut self, custom: CustomInfo, dir: PacketDirection) {
+        if dir == PacketDirection::ClientToServer {
+            if let Ok(v) = Version::try_from(custom.req.version.as_str()) {
+                self.version = v;
+            }
+
+            if let Ok(m) = Method::try_from(custom.req.req_type.as_str()) {
+                self.method = m;
+            }
+
+            if !custom.req.domain.is_empty() {
+                self.host = custom.req.domain;
+            }
+
+            if !custom.req.resource.is_empty() {
+                self.path = custom.req.resource;
+            }
+
+            if let Some(id) = custom.request_id {
+                self.stream_id = Some(id);
+            }
+
+            if !custom.req.endpoint.is_empty() {
+                self.endpoint = Some(custom.req.endpoint)
+            }
         }
 
-        if !custom.req.req_type.is_empty() {
-            self.method = Method::try_from(custom.req.req_type.as_str()).unwrap_or_default();
-        }
+        if dir == PacketDirection::ServerToClient {
+            if let Some(code) = custom.resp.code {
+                self.status_code = code as u16;
+            }
 
-        if !custom.req.resource.is_empty() {
-            self.path = custom.req.resource;
-        }
+            if custom.resp.status != self.status {
+                self.status = custom.resp.status;
+            }
 
-        if !custom.req.endpoint.is_empty() {
-            self.endpoint = Some(custom.req.endpoint)
-        }
+            if !custom.resp.result.is_empty() {
+                self.custom_result = Some(custom.resp.result)
+            }
 
-        //req write
-        if let Some(code) = custom.resp.code {
-            self.status_code = code as u16;
-        }
-
-        if custom.resp.status != self.status {
-            self.status = custom.resp.status;
-        }
-
-        if !custom.resp.result.is_empty() {
-            self.custom_result = Some(custom.resp.result)
-        }
-
-        if !custom.resp.exception.is_empty() {
-            self.custom_exception = Some(custom.resp.exception)
+            if !custom.resp.exception.is_empty() {
+                self.custom_exception = Some(custom.resp.exception)
+            }
         }
 
         //trace info rewrite
-        if custom.trace.trace_id.is_some() {
-            self.trace_id = custom.trace.trace_id.unwrap();
+        if let Some(trace_id) = custom.trace.trace_id {
+            self.trace_id = trace_id;
         }
-        if custom.trace.span_id.is_some() {
-            self.span_id = custom.trace.span_id.unwrap();
+        if let Some(span_id) = custom.trace.span_id {
+            self.span_id = span_id;
+        }
+        if let Some(x_request_id_0) = custom.trace.x_request_id_0 {
+            self.x_request_id_0 = x_request_id_0;
+        }
+        if let Some(x_request_id_1) = custom.trace.x_request_id_1 {
+            self.x_request_id_1 = x_request_id_1;
+        }
+        if let Some(http_proxy_client) = custom.trace.http_proxy_client {
+            self.client_ip = Some(http_proxy_client);
         }
 
         // extend attribute
@@ -1446,7 +1478,7 @@ impl HttpLog {
             PacketDirection::ServerToClient => vm.on_http_resp(payload, param, info),
         }
         .map(|custom| {
-            info.merge_custom_to_http(custom);
+            info.merge_custom_to_http(custom, param.direction);
         });
     }
 }

--- a/agent/src/plugin/WasmPluginApi.proto
+++ b/agent/src/plugin/WasmPluginApi.proto
@@ -1,6 +1,64 @@
 syntax = "proto3";
 
 package wasm_plugin;
+option go_package = ".;pb";
+
+message AppRequest {
+    optional string version = 1;
+    optional string type = 2;
+    optional string domain = 3;
+    optional string resource = 4;
+    optional string endpoint = 5;
+}
+
+enum AppRespStatus {
+    RESP_OK = 0;
+    RESP_TIMEOUT = 2;
+    RESP_SERVER_ERROR = 3;
+    RESP_CLIENT_ERROR = 4;
+    RESP_UNKNOWN = 5;
+}
+
+message AppResponse {
+    optional AppRespStatus status = 1;
+    optional int32 code = 2;
+    optional string exception = 3;
+    optional string result = 4;
+}
+
+message AppTrace {
+    optional string trace_id = 1;
+    optional string span_id = 2;
+    optional string parent_span_id = 3;
+    optional string x_request_id = 4;
+    optional string http_proxy_client = 5;
+}
+
+message KeyVal {
+    string key = 1;
+    string val = 2;
+}
+
+message AppInfo {
+    optional uint32 req_len = 1;
+    optional uint32 resp_len = 2;
+
+    optional uint32 request_id = 3;
+
+    oneof info {
+        AppRequest req = 10;
+        AppResponse resp = 11;
+    }
+    AppTrace trace = 12;
+    optional string protocol_str = 13;
+
+    // a null `is_end` means no need for protocol merge
+    optional bool is_end = 21;
+
+    repeated KeyVal attributes = 31;
+
+    optional uint32 biz_type = 32;
+}
 
 message NatsMessage {
     string subject = 1;

--- a/agent/src/plugin/c_ffi.rs
+++ b/agent/src/plugin/c_ffi.rs
@@ -261,6 +261,7 @@ impl TryFrom<ParseInfo> for CustomInfo {
                         domain: c_str_to_string(&req.domain).unwrap_or_default(),
                         resource: c_str_to_string(&req.resource).unwrap_or_default(),
                         endpoint: c_str_to_string(&req.endpoint).unwrap_or_default(),
+                        ..Default::default()
                     },
                     CustomInfoResp::default(),
                 )
@@ -315,6 +316,7 @@ impl TryFrom<ParseInfo> for CustomInfo {
                 trace_id: c_str_to_string(&v.trace.trace_id),
                 span_id: c_str_to_string(&v.trace.span_id),
                 parent_span_id: c_str_to_string(&v.trace.parent_span_id),
+                ..Default::default()
             },
             attributes: read_attr(&v.attributes, v.attr_len),
             ..Default::default()

--- a/agent/src/plugin/wasm/wasm_plugin.rs
+++ b/agent/src/plugin/wasm/wasm_plugin.rs
@@ -1,0 +1,144 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppRequest {
+    #[prost(string, optional, tag = "1")]
+    pub version: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "2")]
+    pub r#type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "3")]
+    pub domain: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "4")]
+    pub resource: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "5")]
+    pub endpoint: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppResponse {
+    #[prost(enumeration = "AppRespStatus", optional, tag = "1")]
+    pub status: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag = "2")]
+    pub code: ::core::option::Option<i32>,
+    #[prost(string, optional, tag = "3")]
+    pub exception: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "4")]
+    pub result: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppTrace {
+    #[prost(string, optional, tag = "1")]
+    pub trace_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "2")]
+    pub span_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "3")]
+    pub parent_span_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "4")]
+    pub x_request_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "5")]
+    pub http_proxy_client: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct KeyVal {
+    #[prost(string, tag = "1")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub val: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AppInfo {
+    #[prost(uint32, optional, tag = "1")]
+    pub req_len: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "2")]
+    pub resp_len: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "3")]
+    pub request_id: ::core::option::Option<u32>,
+    #[prost(message, optional, tag = "12")]
+    pub trace: ::core::option::Option<AppTrace>,
+    #[prost(string, optional, tag = "13")]
+    pub protocol_str: ::core::option::Option<::prost::alloc::string::String>,
+    /// a null `is_end` means no need for protocol merge
+    #[prost(bool, optional, tag = "21")]
+    pub is_end: ::core::option::Option<bool>,
+    #[prost(message, repeated, tag = "31")]
+    pub attributes: ::prost::alloc::vec::Vec<KeyVal>,
+    #[prost(uint32, optional, tag = "32")]
+    pub biz_type: ::core::option::Option<u32>,
+    #[prost(oneof = "app_info::Info", tags = "10, 11")]
+    pub info: ::core::option::Option<app_info::Info>,
+}
+/// Nested message and enum types in `AppInfo`.
+pub mod app_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Info {
+        #[prost(message, tag = "10")]
+        Req(super::AppRequest),
+        #[prost(message, tag = "11")]
+        Resp(super::AppResponse),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NatsMessage {
+    #[prost(string, tag = "1")]
+    pub subject: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub reply_to: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "3")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ZmtpMessage {
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+    #[prost(oneof = "zmtp_message::Subscription", tags = "1")]
+    pub subscription: ::core::option::Option<zmtp_message::Subscription>,
+}
+/// Nested message and enum types in `ZmtpMessage`.
+pub mod zmtp_message {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Subscription {
+        #[prost(string, tag = "1")]
+        MatchPattern(::prost::alloc::string::String),
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum AppRespStatus {
+    RespOk = 0,
+    RespTimeout = 2,
+    RespServerError = 3,
+    RespClientError = 4,
+    RespUnknown = 5,
+}
+impl AppRespStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            AppRespStatus::RespOk => "RESP_OK",
+            AppRespStatus::RespTimeout => "RESP_TIMEOUT",
+            AppRespStatus::RespServerError => "RESP_SERVER_ERROR",
+            AppRespStatus::RespClientError => "RESP_CLIENT_ERROR",
+            AppRespStatus::RespUnknown => "RESP_UNKNOWN",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "RESP_OK" => Some(Self::RespOk),
+            "RESP_TIMEOUT" => Some(Self::RespTimeout),
+            "RESP_SERVER_ERROR" => Some(Self::RespServerError),
+            "RESP_CLIENT_ERROR" => Some(Self::RespClientError),
+            "RESP_UNKNOWN" => Some(Self::RespUnknown),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

### Branches
- main
- 6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


