### PR TITLE
fix: agent - eBPF recvmmsg() tracing switched to tracepoint type

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -2323,29 +2323,13 @@ KRETFUNC_PROG(__sys_recvmsg, int fd, struct user_msghdr __user * msg,
 	return 0;
 }
 
-//int __sys_recvmmsg(int fd, struct mmsghdr __user *mmsg,
-//                   unsigned int vlen, unsigned int flags,
-//                   struct __kernel_timespec __user *timeout,
-//                   struct old_timespec32 __user *timeout32)
-#ifndef LINUX_VER_KFUNC
-KPROG(__sys_recvmmsg) (struct pt_regs * ctx) {
-	int flags = (int)PT_REGS_PARM4(ctx);
+TP_SYSCALL_PROG(enter_recvmmsg) (struct syscall_comm_enter_ctx * ctx) {
+	int flags = ctx->flags;
 	if (flags & MSG_PEEK)
 		return 0;
-	int sockfd = (int)PT_REGS_PARM1(ctx);
-	struct mmsghdr *msgvec = (struct mmsghdr *)PT_REGS_PARM2(ctx);
-	unsigned int vlen = (unsigned int)PT_REGS_PARM3(ctx);
-#else
-KFUNC_PROG(__sys_recvmmsg, int fd, struct mmsghdr __user * mmsg,
-	   unsigned int vlen, unsigned int flags,
-	   struct __kernel_timespec __user * timeout,
-	   struct old_timespec32 __user * timeout32)
-{
-	if (flags & MSG_PEEK)
-		return 0;
-	int sockfd = fd;
-	struct mmsghdr *msgvec = mmsg;
-#endif
+	int sockfd = (int)ctx->fd;
+	struct mmsghdr *msgvec = (struct mmsghdr *)ctx->buf;
+	unsigned int vlen = (unsigned int)ctx->count;
 	__u64 id = bpf_get_current_pid_tgid();
 	if (msgvec != NULL && vlen >= 1) {
 		int offset;
@@ -2381,18 +2365,9 @@ KFUNC_PROG(__sys_recvmmsg, int fd, struct mmsghdr __user * mmsg,
 	return 0;
 }
 
-#ifndef LINUX_VER_KFUNC
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_recvmmsg/format
 TP_SYSCALL_PROG(exit_recvmmsg) (struct syscall_comm_exit_ctx * ctx) {
 	int num_msgs = ctx->ret;
-#else
-KRETFUNC_PROG(__sys_recvmmsg, int fd, struct mmsghdr __user * mmsg,
-	      unsigned int vlen, unsigned int flags,
-	      struct __kernel_timespec __user * timeout,
-	      struct old_timespec32 __user * timeout32, int ret)
-{
-	int num_msgs = ret;
-#endif
 	__u64 id = bpf_get_current_pid_tgid();
 	// Unstash arguments, and process syscall.
 	struct data_args_t *read_args = active_read_args_map__lookup(&id);

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -205,7 +205,6 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_sendmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_sendmmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_recvmsg");
-	kfunc_set_sym_for_entry_and_exit(tps, "__sys_recvmmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "do_writev");
 	kfunc_set_sym_for_entry_and_exit(tps, "do_readv");
 #if defined(__x86_64__)
@@ -236,6 +235,13 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	if (!access(SYSCALL_CLONE_TP_PATH, F_OK))
 		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_clone");
 
+	/*
+	 * On certain kernels, such as 5.15.0-127-generic and 5.10.134-18.al8.x86_64,
+	 * `recvmmsg()` probes of type `kprobe`/`kfunc` may not work properly. To address
+	 * this, we use the more stable `tracepoint`-based probe instead.
+	 */
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_recvmmsg");	
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exec");
 	// process exit
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exit");
@@ -250,7 +256,6 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	probes_set_enter_symbol(tps, "__sys_sendmsg");
 	probes_set_enter_symbol(tps, "__sys_sendmmsg");
 	probes_set_enter_symbol(tps, "__sys_recvmsg");
-	probes_set_enter_symbol(tps, "__sys_recvmmsg");
 
 	if (k_version == KERNEL_VERSION(3, 10, 0)) {
 		/*
@@ -290,6 +295,7 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_sendto");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvfrom");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_connect");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
 
 	// exit tracepoints
 	/*


### PR DESCRIPTION
On certain kernels, such as 5.15.0-127-generic and 5.10.134-18.al8.x86_64, `recvmmsg()` probes of type `kprobe`/`kfunc` may not work properly. To address this, we use the more stable `tracepoint`-based probe instead



### This PR is for:

- Agent


#### Affected branches
- main
- v6.6
- v6.5
- v6.4