### PR TITLE
fix: agent - eBPF recvmmsg() tracing switched to tracepoint type

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -195,7 +195,6 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_sendmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_sendmmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "__sys_recvmsg");
-	kfunc_set_sym_for_entry_and_exit(tps, "__sys_recvmmsg");
 	kfunc_set_sym_for_entry_and_exit(tps, "do_writev");
 	kfunc_set_sym_for_entry_and_exit(tps, "do_readv");
 #if defined(__x86_64__)
@@ -226,6 +225,13 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	if (!access(SYSCALL_CLONE_TP_PATH, F_OK))
 		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_clone");
 
+	/*
+	 * On certain kernels, such as 5.15.0-127-generic and 5.10.134-18.al8.x86_64,
+	 * `recvmmsg()` probes of type `kprobe`/`kfunc` may not work properly. To address
+	 * this, we use the more stable `tracepoint`-based probe instead.
+	 */
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_recvmmsg");	
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exec");
 	// process exit
 	tps_set_symbol(tps, "tracepoint/sched/sched_process_exit");
@@ -240,7 +246,6 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	probes_set_enter_symbol(tps, "__sys_sendmsg");
 	probes_set_enter_symbol(tps, "__sys_sendmmsg");
 	probes_set_enter_symbol(tps, "__sys_recvmsg");
-	probes_set_enter_symbol(tps, "__sys_recvmmsg");
 
 	if (k_version == KERNEL_VERSION(3, 10, 0)) {
 		/*
@@ -280,6 +285,7 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_sendto");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvfrom");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_connect");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
 
 	// exit tracepoints
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_socket");


### PR DESCRIPTION
On certain kernels, such as 5.15.0-127-generic and 5.10.134-18.al8.x86_64, `recvmmsg()` probes of type `kprobe`/`kfunc` may not work properly. To address this, we use the more stable `tracepoint`-based probe instead



### This PR is for:

- Agent


#### Affected branches
- main
- v6.6
- v6.5
- v6.4