### PR TITLE
fix: agent - eBPF recvmmsg() tracing switched to tracepoint type

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1908,18 +1908,15 @@ TPPROG(sys_exit_recvmsg) (struct syscall_comm_exit_ctx * ctx) {
 	return 0;
 }
 
-// int __sys_recvmmsg(int fd, struct mmsghdr __user *mmsg, unsigned int vlen,
-//                 unsigned int flags, struct timespec *timeout)
-KPROG(__sys_recvmmsg) (struct pt_regs * ctx) {
-	int flags = (int)PT_REGS_PARM4(ctx);
+// /sys/kernel/debug/tracing/events/syscalls/sys_enter_recvmmsg/format
+TPPROG(sys_enter_recvmmsg) (struct syscall_comm_enter_ctx * ctx) {
+	int flags = ctx->flags;
 	if (flags & MSG_PEEK)
 		return 0;
-
+	int sockfd = (int)ctx->fd;
+	struct mmsghdr *msgvec = (struct mmsghdr *)ctx->buf;
+	unsigned int vlen = (unsigned int)ctx->count;
 	__u64 id = bpf_get_current_pid_tgid();
-	int sockfd = (int)PT_REGS_PARM1(ctx);
-	struct mmsghdr *msgvec = (struct mmsghdr *)PT_REGS_PARM2(ctx);
-	unsigned int vlen = (unsigned int)PT_REGS_PARM3(ctx);
-
 	if (msgvec != NULL && vlen >= 1) {
 		int offset;
 		// Stash arguments.

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -130,7 +130,6 @@ static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 	probes_set_enter_symbol(tps, "__sys_sendmsg");
 	probes_set_enter_symbol(tps, "__sys_sendmmsg");
 	probes_set_enter_symbol(tps, "__sys_recvmsg");
-	probes_set_enter_symbol(tps, "__sys_recvmmsg");
 
 	if (k_version == KERNEL_VERSION(3, 10, 0)) {
 		/*
@@ -158,6 +157,7 @@ static void socket_tracer_set_probes(struct tracer_probes_conf *tps)
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_sendto");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvfrom");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_connect");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
 
 	// exit tracepoints
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_socket");


### PR DESCRIPTION
On certain kernels, such as 5.15.0-127-generic and 5.10.134-18.al8.x86_64, `recvmmsg()` probes of type `kprobe`/`kfunc` may not work properly. To address this, we use the more stable `tracepoint`-based probe instead



### This PR is for:

- Agent


#### Affected branches
- main
- v6.6
- v6.5
- v6.4