### PR TITLE
fix: agent - eBPF Some kernels cannot hook file r/w interfaces

### DIFF
--- a/agent/src/ebpf/kernel/files_rw.bpf.c
+++ b/agent/src/ebpf/kernel/files_rw.bpf.c
@@ -218,7 +218,6 @@ KPROG(do_preadv) (struct pt_regs *ctx) {
 	return do_sys_enter_pread(fd, SYSCALL_FUNC_PREADV);
 }
 #else
-#ifndef LINUX_VER_KFUNC
 // /sys/kernel/debug/tracing/events/syscalls/sys_enter_pread64/format
 TP_SYSCALL_PROG(enter_pread64) (struct syscall_comm_enter_ctx *ctx) {
 	int fd = ctx->fd;
@@ -236,19 +235,6 @@ TP_SYSCALL_PROG(enter_preadv2) (struct syscall_comm_enter_ctx *ctx) {
 	int fd = ctx->fd;
 	return do_sys_enter_pread(fd, SYSCALL_FUNC_PREADV2);
 }
-#else
-KFUNC_PROG(ksys_pread64, unsigned int fd, char __user *buf, size_t count,
-	   loff_t pos)
-{
-	return do_sys_enter_pread(fd, SYSCALL_FUNC_PREAD64);
-}
-
-KFUNC_PROG(do_preadv, unsigned long fd, const struct iovec __user *vec,
-	   unsigned long vlen, loff_t pos, rwf_t flags)
-{
-	return do_sys_enter_pread(fd, SYSCALL_FUNC_PREADV);
-}
-#endif /* LINUX_VER_KFUNC */
 #endif /* SUPPORTS_KPROBE_ONLY */
 
 static __inline int do_sys_exit_pread(void *ctx, ssize_t bytes_count)
@@ -281,7 +267,6 @@ KRETPROG(do_preadv) (struct pt_regs *ctx) {
 	return do_sys_exit_pread((void *)ctx, bytes_count);
 }
 #else
-#ifndef LINUX_VER_KFUNC
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_pwrite64/format
 TP_SYSCALL_PROG(exit_pread64) (struct syscall_comm_exit_ctx *ctx) {
 	return do_sys_exit_pread((void *)ctx, (ssize_t) ctx->ret);
@@ -296,19 +281,6 @@ TP_SYSCALL_PROG(exit_preadv) (struct syscall_comm_exit_ctx *ctx) {
 TP_SYSCALL_PROG(exit_preadv2) (struct syscall_comm_exit_ctx *ctx) {
 	return do_sys_exit_pread((void *)ctx, (ssize_t) ctx->ret);
 }
-#else
-KRETFUNC_PROG(ksys_pread64, unsigned int fd, char __user *buf, size_t count,
-	      loff_t pos, ssize_t bytes_count)
-{
-	return do_sys_exit_pread((void *)ctx, bytes_count);
-}
-
-KRETFUNC_PROG(do_preadv, unsigned long fd, const struct iovec __user *vec,
-	      unsigned long vlen, loff_t pos, rwf_t flags, ssize_t bytes_count)
-{
-	return do_sys_exit_pread((void *)ctx, bytes_count);
-}
-#endif /* LINUX_VER_KFUNC */
 #endif /* SUPPORTS_KPROBE_ONLY */
 
 // File Write Event Tracing
@@ -346,7 +318,6 @@ KPROG(do_pwritev) (struct pt_regs *ctx) {
 	return do_sys_enter_pwrite(fd, SYSCALL_FUNC_PWRITEV);
 }
 #else
-#ifndef LINUX_VER_KFUNC
 // /sys/kernel/debug/tracing/events/syscalls/sys_enter_pwrite64/format
 TP_SYSCALL_PROG(enter_pwrite64) (struct syscall_comm_enter_ctx *ctx) {
 	int fd = ctx->fd;
@@ -364,20 +335,6 @@ TP_SYSCALL_PROG(enter_pwritev2) (struct syscall_comm_enter_ctx *ctx) {
 	int fd = ctx->fd;
 	return do_sys_enter_pwrite(fd, SYSCALL_FUNC_PWRITEV2);
 }
-
-#else
-KFUNC_PROG(ksys_pwrite64, unsigned int fd, const char __user *buf,
-	   size_t count, loff_t pos)
-{
-	return do_sys_enter_pwrite(fd, SYSCALL_FUNC_PWRITE64);
-}
-
-KFUNC_PROG(do_pwritev, unsigned long fd, const struct iovec __user *vec,
-	   unsigned long vlen, loff_t pos, rwf_t flags)
-{
-	return do_sys_enter_pwrite(fd, SYSCALL_FUNC_PWRITEV);
-}
-#endif /* LINUX_VER_KFUNC */
 #endif /* SUPPORTS_KPROBE_ONLY */
 
 // pwrite64()/pwritev()/pwritev2() exit
@@ -411,7 +368,6 @@ KRETPROG(do_pwritev) (struct pt_regs *ctx) {
 	return do_sys_exit_pwrite((void *)ctx, bytes_count);
 }
 #else
-#ifndef LINUX_VER_KFUNC
 // /sys/kernel/debug/tracing/events/syscalls/sys_exit_pwrite64/format
 TP_SYSCALL_PROG(exit_pwrite64) (struct syscall_comm_exit_ctx *ctx) {
 	return do_sys_exit_pwrite((void *)ctx, (ssize_t) ctx->ret);
@@ -426,20 +382,6 @@ TP_SYSCALL_PROG(exit_pwritev) (struct syscall_comm_exit_ctx *ctx) {
 TP_SYSCALL_PROG(exit_pwritev2) (struct syscall_comm_exit_ctx *ctx) {
 	return do_sys_exit_pwrite((void *)ctx, (ssize_t) ctx->ret);
 }
-
-#else
-KRETFUNC_PROG(ksys_pwrite64, unsigned int fd, const char __user *buf,
-	      size_t count, loff_t pos, ssize_t bytes_count)
-{
-	return do_sys_exit_pwrite((void *)ctx, bytes_count);
-}
-
-KRETFUNC_PROG(do_pwritev, unsigned long fd, const struct iovec __user *vec,
-	      unsigned long vlen, loff_t pos, rwf_t flags, ssize_t bytes_count)
-{
-	return do_sys_exit_pwrite((void *)ctx, bytes_count);
-}
-#endif /* LINUX_VER_KFUNC */
 #endif /* SUPPORTS_KPROBE_ONLY */
 
 PROGTP(io_event) (void *ctx) {

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -208,12 +208,6 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	kfunc_set_sym_for_entry_and_exit(tps, "do_writev");
 	kfunc_set_sym_for_entry_and_exit(tps, "do_readv");
 
-	// Probe points for file read/write operations
-	kfunc_set_sym_for_entry_and_exit(tps, "ksys_pwrite64");
-	kfunc_set_sym_for_entry_and_exit(tps, "ksys_pread64");
-	kfunc_set_sym_for_entry_and_exit(tps, "do_preadv");
-	kfunc_set_sym_for_entry_and_exit(tps, "do_pwritev");
-
 #if defined(__x86_64__)
 	kfunc_set_symbol(tps, "__x64_sys_close", false);
 #else
@@ -255,6 +249,22 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 
 	// Periodic trigger for timeout checks on cached data
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");
+
+        // file R/W probes
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pread64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwrite64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pread64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_preadv");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwrite64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwritev");
+	if (!access(SYSCALL_PRWV2_TP_PATH, F_OK)) {
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_preadv2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwritev2");
+	}
 }
 
 static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
@@ -304,14 +314,6 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_connect");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_recvmmsg");
 
-	// file R/W probes
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pread64");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv2");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwrite64");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev2");
-
 	// exit tracepoints
 	/*
 	 * `tracepoint/syscalls/sys_exit_socket` This is currently added only to
@@ -351,13 +353,21 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 	// Periodic trigger for timeout checks on cached data
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");
 	
-	// file R/W probes
+        // file R/W probes
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pread64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwrite64");
+	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pread64");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_preadv");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_preadv2");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwrite64");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwritev");
-	tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwritev2");
+	if (!access(SYSCALL_PRWV2_TP_PATH, F_OK)) {
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_preadv2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pwritev2");
+		tps_set_symbol(tps, "tracepoint/syscalls/sys_exit_pwritev2");
+	}
 }
 
 

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -24,7 +24,9 @@
 
 #define SYSCALL_FORK_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_fork"
 #define SYSCALL_CLONE_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_clone"
+#define SYSCALL_PRWV2_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_enter_preadv2"
 #define FTRACE_SYSCALLS_PATH "/sys/kernel/debug/tracing/events/syscalls"
+
 /*
  * The `__sys_recvmmsg` interface underwent a change in its parameter list starting
  * from Linux kernel version 5.0. If earlier kernel versions support the `fentry/fexit`


### PR DESCRIPTION
We found that certain kernel versions (e.g., 5.10.134-18.al8.x86_64) cannot hook into ksys_pwrite64() using fentry/fexit. This is likely due to kernel optimization during compilation, where the hook address does not match the actual function entry point. This issue can be observed with bpftrace, where the hook appears to succeed but no data is collected.
```
sudo bpftrace -e '
kprobe:ksys_pwrite64
{
    printf("PID %d called ksys_pwrite64(fd=%d, buf=0x%x, count=%d, pos=%d)\n",
           pid, arg0, arg1, arg2, arg3);
}
'
Attaching 1 probe...
```

To work around this, we use tracepoint-based interfaces instead.


### This PR is for:

- Agent



#### Affected branches
- main
- v6.6