### PR TITLE
fix: ignore process config

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -570,6 +570,13 @@ impl Default for Proc {
             tag_extraction: TagExtraction::default(),
             process_matcher: vec![
                 ProcessMatcher {
+                    match_regex: Regex::new(r"^(sleep|sh|bash|pause|runc)$").unwrap(),
+                    only_in_container: false,
+                    ignore: true,
+                    enabled_features: vec!["proc.gprocess_info".to_string()],
+                    ..Default::default()
+                },
+                ProcessMatcher {
                     match_regex: Regex::new(r"\bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)").unwrap(),
                     only_in_container: false,
                     match_type: ProcessMatchType::CmdWithArgs,

--- a/agent/src/utils/process/linux.rs
+++ b/agent/src/utils/process/linux.rs
@@ -426,12 +426,20 @@ impl ProcessListener {
 
             let mut pids = vec![];
             let mut process_datas = vec![];
+            let mut ignore_pids = HashSet::new();
 
             for matcher in &value.process_matcher {
                 for pdata in process_data_cache.values() {
                     if let Some(process_data) = matcher.get_process_data(pdata, &tags_map) {
-                        pids.push(pdata.pid as u32);
-                        process_datas.push(process_data);
+                        if matcher.ignore {
+                            ignore_pids.insert(pdata.pid);
+                            continue;
+                        }
+
+                        if !ignore_pids.contains(&pdata.pid) {
+                            pids.push(pdata.pid as u32);
+                            process_datas.push(process_data);
+                        }
                     }
                 }
             }

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -1654,6 +1654,11 @@ inputs:
   proc:
     process_matcher:
     - enabled_features:
+      - proc.gprocess_info
+      ignore: true
+      match_regex: ^(sleep|sh|bash|pause|runc)$
+      only_in_container: false
+    - enabled_features:
       - ebpf.profile.on_cpu
       - proc.gprocess_info
       match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
@@ -1695,7 +1700,7 @@ rewrite_name 可定义为正则表达式捕获组索引，或 windows 风格的�
 - match_regex: 用于匹配进程的表达式，缺省值为 `""`。
 - match_type: 被用于正则表达式匹配的对象，缺省值为 `process_name`，可选项为：
   [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
-- ignore: 是否要忽略正则匹配，缺省值为 `false`
+- ignore: 是否要忽略匹配到的进程，缺省值为 `false`
 - rewrite_name: 使用正则替换匹配到的进程名或命令行，缺省值为 `""` 表示不做替换。
 - enabled_features: 为匹配到的进程开启的特性列表，可选项如下
   - proc.gprocess_info（注意确认 `inputs.proc.enabled` 已配置为 **true**）
@@ -1948,7 +1953,7 @@ inputs:
 
 **详细描述**:
 
-Whether to ingore matched processes..
+Whether to ignore matched processes..
 
 #### 重命名 {#inputs.proc.process_matcher.rewrite_name}
 

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -1674,6 +1674,11 @@ inputs:
   proc:
     process_matcher:
     - enabled_features:
+      - proc.gprocess_info
+      ignore: true
+      match_regex: ^(sleep|sh|bash|pause|runc)$
+      only_in_container: false
+    - enabled_features:
       - ebpf.profile.on_cpu
       - proc.gprocess_info
       match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
@@ -1716,7 +1721,7 @@ Configuration Item:
 - match_regex: The regexp use for match the process, default value is `""`
 - match_type: regexp match field, default value is `process_name`, options are
   [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
-- ignore: Whether to ignore when regex match, default value is `false`
+- ignore: Whether to ignore matched processes, default value is `false`
 - rewrite_name: The name will replace the process name or cmd use regexp replace.
   Default value `""` means no replacement.
 - enabled_features: List of features enabled for matched processes. Available options:
@@ -1970,7 +1975,7 @@ inputs:
 
 **Description**:
 
-Whether to ingore matched processes..
+Whether to ignore matched processes..
 
 #### Rewrite Name {#inputs.proc.process_matcher.rewrite_name}
 

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -1183,7 +1183,7 @@ inputs:
     #     - match_regex: 用于匹配进程的表达式，缺省值为 `""`。
     #     - match_type: 被用于正则表达式匹配的对象，缺省值为 `process_name`，可选项为：
     #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
-    #     - ignore: 是否要忽略正则匹配，缺省值为 `false`
+    #     - ignore: 是否要忽略匹配到的进程，缺省值为 `false`
     #     - rewrite_name: 使用正则替换匹配到的进程名或命令行，缺省值为 `""` 表示不做替换。
     #     - enabled_features: 为匹配到的进程开启的特性列表，可选项如下
     #       - proc.gprocess_info（注意确认 `inputs.proc.enabled` 已配置为 **true**）
@@ -1235,7 +1235,7 @@ inputs:
     #     - match_regex: The regexp use for match the process, default value is `""`
     #     - match_type: regexp match field, default value is `process_name`, options are
     #       [process_name, cmdline, cmdline_with_args, parent_process_name, tag]
-    #     - ignore: Whether to ignore when regex match, default value is `false`
+    #     - ignore: Whether to ignore matched processes, default value is `false`
     #     - rewrite_name: The name will replace the process name or cmd use regexp replace.
     #       Default value `""` means no replacement.
     #     - enabled_features: List of features enabled for matched processes. Available options:
@@ -1381,7 +1381,7 @@ inputs:
     # ee_feature: false
     # description:
     #   en: |-
-    #     Whether to ingore matched processes..
+    #     Whether to ignore matched processes..
     # upgrade_from: static_config.os-proc-regex.action
     # ---
     # ignore: false
@@ -1450,6 +1450,10 @@ inputs:
     # ---
     # enabled_features: []
     process_matcher:
+      - match_regex: ^(sleep|sh|bash|pause|runc)$
+        only_in_container: false
+        ignore: true
+        enabled_features: [proc.gprocess_info]
       - match_regex: \bjava( +\S+)* +-jar +(\S*/)*([^ /]+\.jar)
         match_type: cmdline_with_args
         only_in_container: false


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
- Documents
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes process matcher ignore process not effected
#### Steps to reproduce the bug
- use process_matcher for ignore process
#### Changes to fix the bug
- add ignore process code
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

