### PR TITLE
fix: force prometheus version to avoid panic

### DIFF
--- a/server/querier/app/prometheus/service/remote_read.go
+++ b/server/querier/app/prometheus/service/remote_read.go
@@ -51,8 +51,11 @@ type prometheusReader struct {
 
 func (p *prometheusReader) promReaderExecute(ctx context.Context, req *prompb.ReadRequest, debug bool) (resp *prompb.ReadResponse, querierSql, sql string, duration float64, err error) {
 	// promrequest trans to sql
-	if req == nil || len(req.Queries) == 0 {
+	if req == nil || len(req.Queries) == 0 || req.Queries[0] == nil {
 		return nil, "", "", 0, errors.New("len(req.Queries) == 0, this feature is not yet implemented! ")
+	}
+	if req.Queries[0].Hints == nil || req.Queries[0].Matchers == nil {
+		return nil, "", "", 0, errors.New("req.Queries dont have hint or matchers! ")
 	}
 	start, end := cache.GetPromRequestQueryTime(req.Queries[0])
 	metricName := cache.GetMetricFromLabelMatcher(&req.Queries[0].Matchers)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes prometheus remote read error
#### Steps to reproduce the bug
- use prometheus remote read and prometheus version is too lower
#### Changes to fix the bug
-  fixes when read request did not have Hint/Matchers
#### Affected branches
- main


