### PR TITLE
fix: all org data is written into the default org

### DIFF
--- a/server/ingester/pkg/ckwriter/ckwriter.go
+++ b/server/ingester/pkg/ckwriter/ckwriter.go
@@ -158,7 +158,7 @@ func (qc *QueueContext) EndpointsChange(addrs []string) {
 	}
 }
 
-func (qc *QueueContext) Init(addrs []string, user, password, insertTable string) error {
+func (qc *QueueContext) Init(addrs []string, user, password string, table *ckdb.Table) error {
 	qc.addrs = addrs
 	qc.connCount = len(addrs)
 	qc.conns = make([]*ch.Client, qc.connCount)
@@ -183,6 +183,7 @@ func (qc *QueueContext) Init(addrs []string, user, password, insertTable string)
 		orgCaches[i] = new(Cache)
 		orgCaches[i].orgID = uint16(i)
 		orgCaches[i].queueContext = qc
+		insertTable := fmt.Sprintf("%s.`%s`", table.OrgDatabase(uint16(i)), table.LocalName)
 		orgCaches[i].prepare = fmt.Sprintf("INSERT INTO %s VALUES", insertTable)
 	}
 	qc.orgCaches = orgCaches
@@ -391,8 +392,7 @@ func NewCKWriter(addrs []string, user, password, counterName, timeZone string, t
 	queueContexts := make([]*QueueContext, queueCount)
 	for i := range queueContexts {
 		queueContexts[i] = &QueueContext{}
-		insertTable := fmt.Sprintf("%s.`%s`", table.OrgDatabase(uint16(i)), table.LocalName)
-		if err := queueContexts[i].Init(addrs, user, password, insertTable); err != nil {
+		if err := queueContexts[i].Init(addrs, user, password, table); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


