### PR TITLE
perf: Avoid loading config every packet

### DIFF
--- a/agent/src/common/l7_protocol_log.rs
+++ b/agent/src/common/l7_protocol_log.rs
@@ -605,7 +605,7 @@ impl<'a> ParseParam<'a> {
         self.rrt_timeout = t;
     }
 
-    pub fn set_log_parse_config(&mut self, conf: &'a LogParserConfig) {
+    pub fn set_log_parser_config(&mut self, conf: &'a LogParserConfig) {
         self.parse_config = Some(conf);
     }
 

--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -290,6 +290,7 @@ impl<'a> MetaPacket<'a> {
     #[inline]
     pub fn empty() -> MetaPacket<'a> {
         MetaPacket {
+            sub_packets: Vec::with_capacity(1),
             ..Default::default()
         }
     }

--- a/agent/src/dispatcher/analyzer_mode_dispatcher.rs
+++ b/agent/src/dispatcher/analyzer_mode_dispatcher.rs
@@ -74,7 +74,7 @@ const HANDLER_BATCH_SIZE: usize = 64;
 pub struct AnalyzerModeDispatcherListener {
     vm_mac_addrs: Arc<RwLock<HashMap<u32, MacAddr>>>,
     gateway_vmac_addrs: Arc<RwLock<Vec<MacAddr>>>,
-    base: BaseDispatcherListener,
+    pub(super) base: BaseDispatcherListener,
 }
 
 impl AnalyzerModeDispatcherListener {
@@ -266,7 +266,7 @@ impl AnalyzerModeDispatcher {
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
-        let log_parse_config = base.log_parse_config.clone();
+        let log_parser_config = base.log_parser_config.clone();
         let collector_config = base.collector_config.clone();
         let packet_sequence_output_queue = base.packet_sequence_output_queue.clone(); // Enterprise Edition Feature: packet-sequence
         let stats = base.stats.clone();
@@ -302,7 +302,7 @@ impl AnalyzerModeDispatcher {
                     while !terminated.load(Ordering::Relaxed) {
                         let config = Config {
                             flow: &flow_map_config.load(),
-                            log_parser: &log_parse_config.load(),
+                            log_parser: &log_parser_config.load(),
                             collector: &collector_config.load(),
                             #[cfg(any(target_os = "linux", target_os = "android"))]
                             ebpf: None,

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -90,7 +90,7 @@ pub(super) struct InternalState {
     pub(super) pipelines: Arc<Mutex<HashMap<u64, Arc<Mutex<Pipeline>>>>>,
     pub(super) tap_interfaces: Arc<Mutex<Vec<Link>>>,
     pub(super) flow_map_config: FlowAccess,
-    pub(super) log_parse_config: LogParserAccess,
+    pub(super) log_parser_config: LogParserAccess,
     pub(super) collector_config: CollectorAccess,
     pub(super) dispatcher_config: DispatcherAccess,
 
@@ -100,6 +100,7 @@ pub(super) struct InternalState {
 
     pub(super) tap_type_handler: CaptureNetworkTypeHandler,
 
+    pub(super) need_reload_config: Arc<AtomicBool>,
     pub(super) need_update_bpf: Arc<AtomicBool>,
     // 该表中的tap接口采集包长不截断
     pub(super) reset_whitelist: Arc<AtomicBool>,
@@ -171,6 +172,7 @@ impl BaseDispatcher {
             bpf_options: is.bpf_options.clone(),
             pipelines: is.pipelines.clone(),
             tap_interfaces: is.tap_interfaces.clone(),
+            need_reload_config: is.need_reload_config.clone(),
             need_update_bpf: is.need_update_bpf.clone(),
             #[cfg(target_os = "linux")]
             platform_poller: is.platform_poller.clone(),
@@ -749,6 +751,7 @@ pub struct BaseDispatcherListener {
     pub handler_builders: Arc<RwLock<Vec<PacketHandlerBuilder>>>,
     pub pipelines: Arc<Mutex<HashMap<u64, Arc<Mutex<Pipeline>>>>>,
     pub tap_interfaces: Arc<Mutex<Vec<Link>>>,
+    pub need_reload_config: Arc<AtomicBool>,
     pub need_update_bpf: Arc<AtomicBool>,
     #[cfg(target_os = "linux")]
     pub platform_poller: Arc<crate::platform::GenericPoller>,

--- a/agent/src/dispatcher/local_multins_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_multins_mode_dispatcher.rs
@@ -113,7 +113,7 @@ impl LocalMultinsModeDispatcher {
         while !base.terminated.load(Ordering::Relaxed) {
             let config = Config {
                 flow: &base.flow_map_config.load(),
-                log_parser: &base.log_parse_config.load(),
+                log_parser: &base.log_parser_config.load(),
                 collector: &base.collector_config.load(),
                 ebpf: None,
             };

--- a/agent/src/dispatcher/local_plus_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_plus_mode_dispatcher.rs
@@ -102,7 +102,7 @@ impl LocalPlusModeDispatcher {
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
-        let log_parse_config = base.log_parse_config.clone();
+        let log_parser_config = base.log_parser_config.clone();
         let collector_config = base.collector_config.clone();
         let packet_sequence_output_queue = base.packet_sequence_output_queue.clone(); // Enterprise Edition Feature: packet-sequence
         let stats = base.stats.clone();
@@ -144,7 +144,7 @@ impl LocalPlusModeDispatcher {
                     while !terminated.load(Ordering::Relaxed) {
                         let config = Config {
                             flow: &flow_map_config.load(),
-                            log_parser: &log_parse_config.load(),
+                            log_parser: &log_parser_config.load(),
                             collector: &collector_config.load(),
                             #[cfg(any(target_os = "linux", target_os = "android"))]
                             ebpf: None,
@@ -471,7 +471,7 @@ impl LocalPlusModeDispatcher {
 
 #[derive(Clone)]
 pub struct LocalPlusModeDispatcherListener {
-    base: BaseDispatcherListener,
+    pub(super) base: BaseDispatcherListener,
     #[cfg(target_os = "linux")]
     extractor: Arc<LibvirtXmlExtractor>,
     rewriter: MacRewriter,

--- a/agent/src/dispatcher/mirror_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_mode_dispatcher.rs
@@ -72,7 +72,7 @@ pub struct MirrorModeDispatcherListener {
     #[cfg(target_os = "linux")]
     poller: Option<Arc<GenericPoller>>,
     agent_type: Arc<RwLock<AgentType>>,
-    base: BaseDispatcherListener,
+    pub(super) base: BaseDispatcherListener,
 }
 
 impl MirrorModeDispatcherListener {
@@ -572,7 +572,7 @@ impl MirrorModeDispatcher {
         while !base.terminated.load(Ordering::Relaxed) {
             let config = Config {
                 flow: &base.flow_map_config.load(),
-                log_parser: &base.log_parse_config.load(),
+                log_parser: &base.log_parser_config.load(),
                 collector: &base.collector_config.load(),
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 ebpf: None,

--- a/agent/src/dispatcher/mirror_plus_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_plus_mode_dispatcher.rs
@@ -69,7 +69,7 @@ pub struct MirrorPlusModeDispatcherListener {
     #[cfg(target_os = "linux")]
     poller: Option<Arc<GenericPoller>>,
     agent_type: Arc<RwLock<AgentType>>,
-    base: BaseDispatcherListener,
+    pub(super) base: BaseDispatcherListener,
 }
 
 impl MirrorPlusModeDispatcherListener {
@@ -276,7 +276,7 @@ impl MirrorPlusModeDispatcher {
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
-        let log_parse_config = base.log_parse_config.clone();
+        let log_parser_config = base.log_parser_config.clone();
         let collector_config = base.collector_config.clone();
         let packet_sequence_output_queue = base.packet_sequence_output_queue.clone(); // Enterprise Edition Feature: packet-sequence
         let stats = base.stats.clone();
@@ -323,7 +323,7 @@ impl MirrorPlusModeDispatcher {
                     while !terminated.load(Ordering::Relaxed) {
                         let config = Config {
                             flow: &flow_map_config.load(),
-                            log_parser: &log_parse_config.load(),
+                            log_parser: &log_parser_config.load(),
                             collector: &collector_config.load(),
                             #[cfg(any(target_os = "linux", target_os = "android"))]
                             ebpf: None,

--- a/agent/src/flow_generator/perf/mod.rs
+++ b/agent/src/flow_generator/perf/mod.rs
@@ -262,7 +262,7 @@ impl FlowLog {
                 is_parse_perf,
                 is_parse_log,
             );
-            parse_param.set_log_parse_config(log_parser_config);
+            parse_param.set_log_parser_config(log_parser_config);
             #[cfg(any(target_os = "linux", target_os = "android"))]
             parse_param.set_counter(self.stats_counter.clone());
             parse_param.set_rrt_timeout(self.rrt_timeout);
@@ -357,7 +357,7 @@ impl FlowLog {
                 is_parse_perf,
                 is_parse_log,
             );
-            param.set_log_parse_config(log_parser_config);
+            param.set_log_parser_config(log_parser_config);
             #[cfg(any(target_os = "linux", target_os = "android"))]
             param.set_counter(self.stats_counter.clone());
             param.set_rrt_timeout(self.rrt_timeout);

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -1891,7 +1891,7 @@ mod tests {
                 true,
             );
             param.set_captured_byte(payload.len());
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             let get_http_info = |i: L7ProtocolInfo| match i {
                 L7ProtocolInfo::HttpInfo(mut h) => {
@@ -2248,7 +2248,7 @@ mod tests {
                     true,
                     true,
                 );
-                param.set_log_parse_config(&config);
+                param.set_log_parser_config(&config);
                 let _ = http.parse_payload(packet.get_l4_payload().unwrap(), param);
             }
         }

--- a/agent/src/flow_generator/protocol_logs/mq/nats.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/nats.rs
@@ -1025,7 +1025,7 @@ mod tests {
                 ..Default::default()
             };
 
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             if first_packet {
                 first_packet = false;

--- a/agent/src/flow_generator/protocol_logs/mq/openwire.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/openwire.rs
@@ -2324,7 +2324,7 @@ mod tests {
                 l7_log_dynamic: config.clone(),
                 ..Default::default()
             };
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             let is_openwire = OpenWireLog::check_protocol(payload, param);
             let infos = openwire.parse(payload, param);

--- a/agent/src/flow_generator/protocol_logs/mq/pulsar.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/pulsar.rs
@@ -1007,7 +1007,7 @@ mod tests {
                 ..Default::default()
             };
 
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             if !pulsar.check_payload(payload, param) {
                 output.push_str("not pulsar\n");

--- a/agent/src/flow_generator/protocol_logs/rpc/brpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/brpc.rs
@@ -417,7 +417,7 @@ mod tests {
                 ..Default::default()
             };
 
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             if !brpc.check_payload(payload, param) {
                 output.push_str("not brpc\n");

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -1220,7 +1220,7 @@ mod tests {
                 true,
             );
             param.set_captured_byte(payload.len());
-            param.set_log_parse_config(&config);
+            param.set_log_parser_config(&config);
             let is_dubbo = dubbo.check_payload(payload, param);
 
             let i = dubbo.parse_payload(payload, param);
@@ -1317,7 +1317,7 @@ mod tests {
             true,
         );
         param.set_captured_byte(payload.len());
-        param.set_log_parse_config(&config);
+        param.set_log_parser_config(&config);
         let is_dubbo = dubbo.check_payload(payload, param);
 
         let i = dubbo.parse_payload(payload, param);
@@ -1417,7 +1417,7 @@ mod tests {
             true,
         );
         param.set_captured_byte(payload.len());
-        param.set_log_parse_config(&config);
+        param.set_log_parser_config(&config);
         let is_dubbo = dubbo.check_payload(payload, param);
 
         let i = dubbo.parse_payload(payload, param);
@@ -1523,7 +1523,7 @@ mod tests {
                 true,
                 true,
             );
-            param.set_log_parse_config(&config);
+            param.set_log_parser_config(&config);
             if packet.get_l4_payload().is_some() {
                 let _ = dubbo.parse_payload(packet.get_l4_payload().unwrap(), param);
             }

--- a/agent/src/flow_generator/protocol_logs/rpc/some_ip.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/some_ip.rs
@@ -340,7 +340,7 @@ mod tests {
                 ..Default::default()
             };
 
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             let info = some_ip.parse_payload(payload, param);
             if let Ok(info) = info {

--- a/agent/src/flow_generator/protocol_logs/rpc/tars.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/tars.rs
@@ -628,7 +628,7 @@ mod tests {
                 ..Default::default()
             };
 
-            param.set_log_parse_config(parse_config);
+            param.set_log_parser_config(parse_config);
 
             if !tars.check_payload(payload, param) {
                 output.push_str("not tars\n");

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -3664,7 +3664,7 @@ fn build_dispatchers(
         .packet_sequence_output_queue(packet_sequence_sender) // Enterprise Edition Feature: packet-sequence
         .stats_collector(stats_collector.clone())
         .flow_map_config(config_handler.flow())
-        .log_parse_config(config_handler.log_parser())
+        .log_parser_config(config_handler.log_parser())
         .collector_config(config_handler.collector())
         .dispatcher_config(config_handler.dispatcher())
         .policy_getter(policy_getter)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
### Branch
- main
- 6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


