### PR TITLE
fix: allow universal tags query with priority level

### DIFF
--- a/server/querier/app/prometheus/service/converters_test.go
+++ b/server/querier/app/prometheus/service/converters_test.go
@@ -360,6 +360,15 @@ func TestPromReaderTransToSQL(t *testing.T) {
 			output:   fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,value,`tag` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND `tag.instance` = '''demo'  ORDER BY timestamp desc LIMIT %s", startS, endS, limit),
 			hasError: false,
 		},
+
+		// universal tag
+		{
+
+			hints:    promqlHints{matcher: `node_cpu_seconds_total{df_pod!=""}`},
+			input:    `node_cpu_seconds_total{df_pod!=""}`,
+			output:   fmt.Sprintf("SELECT toUnixTimestamp(time) AS timestamp,value,`tag`,`pod`,`pod_group`,`pod_service`,`pod_node`,`pod_ns`,`pod_cluster` FROM `node_cpu_seconds_total` WHERE (time >= %d AND time <= %d) AND exist(`pod`)  ORDER BY timestamp desc LIMIT %s", startS, endS, limit),
+			hasError: false,
+		},
 	}
 
 	Convey("TestPromReaderTransToSQL_Query_Parse_1", t, func() {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes only query specific tag when in promql filter
#### Steps to reproduce the bug
- use promql with deepflow tag query
#### Changes to fix the bug

- 以前的设计里，promql 查询时如果没有明确指定查某个 deepflow universal tag，则不会尝试去查，导致有些语句试图获得 universsal_tag 需要加上一个类似 `df_pod != ""` 的过滤条件
- 但在部分查询中，存在一个需求：主要分组不为空，次要分组允许为空（即，按工作负载允许查询出服务、命名空间、集群等），导致这一类 `df_xx!=""` 的条件需要去掉。这里加了个按层级找 unviversal tag 的设计，即查询 pod 时把 pod_group / pod_ns / pod_service 一类层级高的 tag 也查出来

- before: promql query needs to specific an universal tag when we do query, which forces the user add some filters like  `df_pod!=""` for query;
- but in some senarios, we need to query basic grouping with data and allow a null data from secondary grouping, which means query pod service / pod namespace by pod workloads.
- in this commit, add a level priority query by basic grouping tags, like when query pod, we can get pod_group / pod_service/ pod_ns as extra query selector

#### Affected branches
- main