### PR TITLE
fix: Prometheus data matches the wrong universal tag

### DIFF
--- a/server/ingester/prometheus/decoder/decoder.go
+++ b/server/ingester/prometheus/decoder/decoder.go
@@ -76,6 +76,12 @@ type BuilderCounter struct {
 	Sample            int64 `statsd:"sample-out"`
 }
 
+type UniversalTagKey struct {
+	L3EpcID    int32
+	PodNameID  uint32
+	InstanceID uint32
+}
+
 type PrometheusSamplesBuilder struct {
 	name                string
 	labelTable          *PrometheusLabelTable
@@ -94,9 +100,7 @@ type PrometheusSamplesBuilder struct {
 	appLabelValueIDsBuffer  []uint32
 
 	// universal tag cache
-	podNameIDToUniversalTag  [grpc.MAX_ORG_COUNT]map[uint32]flow_metrics.UniversalTag
-	instanceIPToUniversalTag [grpc.MAX_ORG_COUNT]map[uint32]flow_metrics.UniversalTag
-	vtapIDToUniversalTag     [grpc.MAX_ORG_COUNT]map[uint16]flow_metrics.UniversalTag
+	cacheUniversalTags [grpc.MAX_ORG_COUNT]map[UniversalTagKey]flow_metrics.UniversalTag
 
 	counter *BuilderCounter
 	utils.Closable
@@ -119,9 +123,7 @@ func NewPrometheusSamplesBuilder(name string, index int, platformData *grpc.Plat
 	}
 
 	for i := 0; i < grpc.MAX_ORG_COUNT; i++ {
-		p.podNameIDToUniversalTag[i] = make(map[uint32]flow_metrics.UniversalTag)
-		p.instanceIPToUniversalTag[i] = make(map[uint32]flow_metrics.UniversalTag)
-		p.vtapIDToUniversalTag[i] = make(map[uint16]flow_metrics.UniversalTag)
+		p.cacheUniversalTags[i] = make(map[UniversalTagKey]flow_metrics.UniversalTag)
 	}
 
 	common.RegisterCountableForIngester("decoder", p, stats.OptionStatTags{
@@ -467,7 +469,6 @@ func (b *PrometheusSamplesBuilder) TimeSeriesToStore(vtapID, epcId, podClusterId
 }
 
 func (b *PrometheusSamplesBuilder) fillUniversalTag(m *dbwriter.PrometheusSample, vtapID uint16, podName, instance string, podNameID, instanceID uint32, fillWithVtapId bool) {
-	// fast path
 	platformDataVersion := b.platformData.Version(m.OrgId)
 	if platformDataVersion != b.platformDataVersion[m.OrgId] {
 		if b.platformDataVersion[m.OrgId] != 0 {
@@ -475,39 +476,28 @@ func (b *PrometheusSamplesBuilder) fillUniversalTag(m *dbwriter.PrometheusSample
 				b.platformDataVersion[m.OrgId], platformDataVersion)
 		}
 		b.platformDataVersion[m.OrgId] = platformDataVersion
-		b.podNameIDToUniversalTag[m.OrgId] = make(map[uint32]flow_metrics.UniversalTag)
-		b.instanceIPToUniversalTag[m.OrgId] = make(map[uint32]flow_metrics.UniversalTag)
-		b.vtapIDToUniversalTag[m.OrgId] = make(map[uint16]flow_metrics.UniversalTag)
+		b.cacheUniversalTags[m.OrgId] = make(map[UniversalTagKey]flow_metrics.UniversalTag)
 	} else {
-		if podNameID != 0 {
-			if universalTag, ok := b.podNameIDToUniversalTag[m.OrgId][podNameID]; ok {
-				m.UniversalTag = universalTag
-				return
-			}
-		} else if instanceID != 0 {
-			if universalTag, ok := b.instanceIPToUniversalTag[m.OrgId][instanceID]; ok {
-				m.UniversalTag = universalTag
-				return
-			}
-		} else if fillWithVtapId {
-			if universalTag, ok := b.vtapIDToUniversalTag[m.OrgId][vtapID]; ok {
-				m.UniversalTag = universalTag
-				return
-			}
+		// fast path
+		l3EpcID := b.platformData.QueryVtapEpc0(m.OrgId, vtapID)
+		if universalTag, ok := b.cacheUniversalTags[m.OrgId][UniversalTagKey{
+			L3EpcID:    l3EpcID,
+			PodNameID:  podNameID,
+			InstanceID: instanceID,
+		}]; ok {
+			m.UniversalTag = universalTag
+			return
 		}
 	}
 
 	// slow path
 	b.fillUniversalTagSlow(m, vtapID, podName, instance, fillWithVtapId)
-
 	// update fast path
-	if podName != "" && podNameID != 0 {
-		b.podNameIDToUniversalTag[m.OrgId][podNameID] = m.UniversalTag
-	} else if instanceID != 0 {
-		b.instanceIPToUniversalTag[m.OrgId][instanceID] = m.UniversalTag
-	} else if fillWithVtapId {
-		b.vtapIDToUniversalTag[m.OrgId][vtapID] = m.UniversalTag
-	}
+	b.cacheUniversalTags[m.OrgId][UniversalTagKey{
+		L3EpcID:    m.UniversalTag.L3EpcID,
+		PodNameID:  podNameID,
+		InstanceID: instanceID,
+	}] = m.UniversalTag
 }
 
 func (b *PrometheusSamplesBuilder) fillUniversalTagSlow(m *dbwriter.PrometheusSample, vtapID uint16, podName, instance string, fillWithVtapId bool) {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


