### PR TITLE
fix: agnet - eBPF Bypass kernel bug in fentry/fexit

### DIFF
--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -1312,7 +1312,7 @@ u64 kallsyms_lookup_name(const char *name)
 	void *addr;
 
 	if (!f)
-		return -ENOENT;
+		return 0;
 
 	while (!feof(f)) {
 		if (!fgets(buf, sizeof(buf), f))


### PR DESCRIPTION
There is a known bug in the `fentry/fexit` mechanism, with details and a fix provided in the following commit:
[https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=e21d2b92354b3cd25dd774ebb0f0e52ff04a7861](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=e21d2b92354b3cd25dd774ebb0f0e52ff04a7861)

This bug may cause system crashes when attaching or detaching hooks. To ensure the current kernel includes the fix, we check for the presence of the `__bpf_tramp_image_put_rcu` function, which was introduced as part of the bug fix. If this function is not present, we assume the kernel is unpatched and will avoid using the `fentry/fexit` approach. Instead, we will fall back to using `tracepoint`-based hooks.
### This PR is for:
- Agent


#### Affected branches
- main
- 7.0
- 6.6
- 6.5