### PR TITLE
feat: resource event support fill tags with gprocessid

### DIFF
--- a/server/libs/grpc/grpc_platformdata.go
+++ b/server/libs/grpc/grpc_platformdata.go
@@ -399,6 +399,11 @@ func (t *PlatformInfoTable) QueryResourceInfo(orgId uint16, resourceType uint32,
 		return t.hostInfos[orgId][resourceID]
 	case trident.DeviceType_DEVICE_TYPE_VM:
 		return t.vmInfos[orgId][resourceID]
+	case trident.DeviceType_DEVICE_TYPE_PROCESS:
+		if _, podId := t.QueryGprocessInfo(orgId, resourceID); podId > 0 {
+			return t.QueryPodIdInfo(orgId, podId)
+		}
+		return nil
 	default:
 		return t.resourceInfos[orgId][uint64(resourceType)<<32|uint64(resourceID)]
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


