### PR TITLE
feat: agent - eBPF Retry CPU Binding on KICK Thread Failure

### DIFF
--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -540,6 +540,13 @@ struct reader_forward_info {
 	struct bpf_tracer *tracer;
 };
 
+// Structure to store kick CPU thread info
+typedef struct {
+	pid_t tid;     // Linux thread ID (TID) of the kernel thread
+	int cpu_id;    // CPU core number the thread is bound to
+	bool can_bind_cpu;
+} kick_thread_info_t;
+
 extern volatile uint32_t *tracers_lock;
 
 /*


### PR DESCRIPTION
Add a conditional trigger when the KICK kernel thread fails to bind to a CPU, allowing it to attempt CPU binding again.


### This PR is for:


- Agent


#### Affected branches
- main
- v7.0
- v6.6