### PR TITLE
fix: 修改误将索引当做agentID使用的编码错误

### DIFF
--- a/server/controller/trisolaris/metadata/agentmetadata/policy.go
+++ b/server/controller/trisolaris/metadata/agentmetadata/policy.go
@@ -644,7 +644,7 @@ func (op *PolicyDataOP) generateProtoActions(acl *models.ACL) (map[int][]*agent.
 							log.Errorf(op.Logf("not found agent in vtap group id(%d)", vtapGroupIDInt))
 							continue
 						}
-						for agentID := range agentIDs {
+						for _, agentID := range agentIDs {
 							agentIDToNpbActions[agentID] = append(agentIDToNpbActions[agentID], npbAction)
 						}
 					}


### PR DESCRIPTION
解决编码错误导致npb策略无法下发给agent的问题


