### PR TITLE
feat: agent - eBPF Support unix domain sockets (#9844)

### DIFF
--- a/agent/src/common/ebpf.rs
+++ b/agent/src/common/ebpf.rs
@@ -38,6 +38,8 @@ pub const IO_EVENT: u8 = 4;
 pub const GO_HTTP2_UPROBE_DATA: u8 = 5;
 // socket close event
 pub const SOCKET_CLOSE_EVENT: u8 = 6;
+// unix socket
+pub const UNIX_SOCKET: u8 = 8;
 
 const EBPF_TYPE_TRACEPOINT: u8 = 0;
 const EBPF_TYPE_TLS_UPROBE: u8 = 1;
@@ -45,6 +47,7 @@ const EBPF_TYPE_GO_HTTP2_UPROBE: u8 = 2;
 const EBPF_TYPE_IO_EVENT: u8 = 4;
 const EBPF_TYPE_GO_HTTP2_UPROBE_DATA: u8 = 5;
 const EBPF_TYPE_SOCKET_CLOSE_EVENT: u8 = 6;
+const EBPF_TYPE_UNIX_SOCKET: u8 = 8;
 const EBPF_TYPE_NONE: u8 = 255;
 
 // ebpf的类型,由ebpf程序传入,对应 SK_BPF_DATA 的 source 字段
@@ -78,6 +81,7 @@ pub enum EbpfType {
     GoHttp2UprobeData = EBPF_TYPE_GO_HTTP2_UPROBE_DATA,
     IOEvent = EBPF_TYPE_IO_EVENT,
     SocketCloseEvent = EBPF_TYPE_SOCKET_CLOSE_EVENT,
+    UnixSocket = EBPF_TYPE_UNIX_SOCKET,
     None = EBPF_TYPE_NONE, // 非 ebpf 类型.
 }
 
@@ -92,6 +96,7 @@ impl TryFrom<u8> for EbpfType {
             SYSCALL => Ok(Self::TracePoint),
             IO_EVENT => Ok(Self::IOEvent),
             SOCKET_CLOSE_EVENT => Ok(Self::SocketCloseEvent),
+            UNIX_SOCKET => Ok(Self::UnixSocket),
             _ => Err(format!("unknown ebpf type: {}", value)),
         }
     }

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -951,6 +951,7 @@ impl Default for EbpfSocketKprobePorts {
 #[serde(default)]
 pub struct EbpfSocketKprobe {
     pub disabled: bool,
+    pub enable_unix_socket: bool,
     pub blacklist: EbpfSocketKprobePorts,
     pub whitelist: EbpfSocketKprobePorts,
 }

--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -104,6 +104,7 @@ enum process_data_extra_source {
 	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
 	DATA_SOURCE_CLOSE,
 	DATA_SOURCE_DPDK,
+	DATA_SOURCE_UNIX_SOCKET,
 };
 
 struct protocol_message_t {

--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -110,6 +110,9 @@ __protocol_port_check(enum traffic_protocol proto,
 		return false;
 	}
 
+	if (conn_info->sk_type == SOCK_UNIX)
+		return true;
+
 	__u32 key = proto;
 	ports_bitmap_t *ports = proto_ports_bitmap__lookup(&key);
 	if (ports) {
@@ -3952,10 +3955,6 @@ infer_protocol_1(struct ctx_info_s *ctx,
 	if (conn_info->sk == NULL)
 		goto infer_aborted;
 
-	if (conn_info->tuple.dport == 0 || conn_info->tuple.num == 0) {
-		goto infer_aborted;
-	}
-
 	/*
 	 * The socket that is indeed determined to be a protocol does not
 	 * enter drop_msg_by_comm().
@@ -4034,7 +4033,8 @@ infer_protocol_1(struct ctx_info_s *ctx,
 	 * If the data source comes from kernel system calls, it is discarded
 	 * directly because some kernel probes do not handle TLS data.
 	 */
-	if (protocol_port_check_1(PROTO_TLS, conn_info) &&
+	if (conn_info->sk_type != SOCK_UNIX &&
+	    protocol_port_check_1(PROTO_TLS, conn_info) &&
 	    extra->source == DATA_SOURCE_SYSCALL) {
 		/*
 		 * TLS first performs handshake protocol inference and discards the data

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -34,6 +34,8 @@
 #define INFER_CONTINUE	1
 #define INFER_TERMINATE	2
 
+#define SOCK_UNIX	11 // Used to identify UNIX domain sockets. 
+
 #define MAX_PUSH_DELAY_TIME_NS 100000000ULL // 100ms
 
 typedef long unsigned int __kernel_size_t;
@@ -85,6 +87,7 @@ struct mmsghdr {
 #define SOCK_CHECK_TYPE_ERROR           0
 #define SOCK_CHECK_TYPE_UDP             1
 #define SOCK_CHECK_TYPE_TCP_ES          2
+#define SOCK_CHECK_TYPE_UNIX		3
 
 #include "socket_trace_common.h"
 

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -332,7 +332,9 @@ struct debug_data {
 
 struct member_fields_offset {
 	__u8 ready;
-	__u8 kprobe_invalid;			// This indicates that the KPROBE feature has been disabled.
+	__u8 kprobe_invalid:1;			// This indicates that the KPROBE feature has been disabled.
+	__u8 enable_unix_socket:1;		// Enable flag for Unix socket tracing
+	__u8 reserved:6;
 	__u16 struct_dentry_d_parent_offset;    // offsetof(struct dentry, d_parent)
 	__u32 task__files_offset;
 	__u32 sock__flags_offset;

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -150,6 +150,8 @@ pub const DATA_SOURCE_IO_EVENT: u8 = 4;
 pub const DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE: u8 = 5;
 #[allow(dead_code)]
 pub const DATA_SOURCE_CLOSE: u8 = 6;
+#[allow(dead_code)]
+pub const DATA_SOURCE_UNIX_SOCKET: u8 = 8;
 cfg_if::cfg_if! {
     if #[cfg(feature = "extended_observability")] {
         #[allow(dead_code)]
@@ -740,6 +742,11 @@ extern "C" {
      * for monitoring and tracing specific points in the kernel.
      */
     pub fn enable_kprobe_feature();
+
+    // Disables Unix socket tracing.
+    pub fn disable_unix_socket_feature();
+    // Enables Unix socket tracing.
+    pub fn enable_unix_socket_feature();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "extended_observability")] {

--- a/agent/src/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher.rs
@@ -878,6 +878,14 @@ impl EbpfCollector {
             ebpf::enable_kprobe_feature();
         }
 
+        if config.ebpf.socket.kprobe.enable_unix_socket {
+            info!("ebpf unix socket tracing enabled");
+            ebpf::enable_unix_socket_feature();
+        } else {
+            info!("ebpf unix socket tracing disabled");
+            ebpf::disable_unix_socket_feature();
+        }
+
         let white_list = &config.ebpf.socket.kprobe.whitelist;
         if !white_list.ports.is_empty() {
             if let Some(b) = parse_u16_range_list_to_bitmap(&white_list.ports, false) {

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -681,7 +681,9 @@ impl L7ProtocolParserInterface for HttpLog {
                     self.set_header_decoder(config.l7_log_dynamic.expected_headers_set.clone());
                 }
                 match param.ebpf_type {
-                    EbpfType::GoHttp2Uprobe | EbpfType::GoHttp2UprobeData => {
+                    EbpfType::GoHttp2Uprobe
+                    | EbpfType::GoHttp2UprobeData
+                    | EbpfType::UnixSocket => {
                         if param.direction == PacketDirection::ServerToClient {
                             return false;
                         }

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -3872,6 +3872,34 @@ inputs:
 
 当设置为 true 时，kprobe 功能将被禁用。
 
+##### 禁用 kprobe {#inputs.ebpf.socket.kprobe.enable_unix_socket}
+
+**标签**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`inputs.ebpf.socket.kprobe.enable_unix_socket`
+
+**默认值**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      kprobe:
+        enable_unix_socket: false
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**详细描述**:
+
+当设置为 true 时，启用 Unix Socket 追踪。
+
 ##### 黑名单 {#inputs.ebpf.socket.kprobe.blacklist}
 
 ###### 端口号 {#inputs.ebpf.socket.kprobe.blacklist.ports}

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -3954,6 +3954,34 @@ inputs:
 
 When set to true, kprobe will be disabled.
 
+##### Unix Socket Enabled {#inputs.ebpf.socket.kprobe.enable_unix_socket}
+
+**Tags**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`inputs.ebpf.socket.kprobe.enable_unix_socket`
+
+**Default value**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      kprobe:
+        enable_unix_socket: false
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**Description**:
+
+When set to true, enable tracing of Unix domain sockets.
+
 ##### Blacklist {#inputs.ebpf.socket.kprobe.blacklist}
 
 ###### Port Numbers {#inputs.ebpf.socket.kprobe.blacklist.ports}

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -2898,6 +2898,21 @@ inputs:
         #   ch: |-
         #     当设置为 true 时，kprobe 功能将被禁用。
         disabled: false
+        # type: bool
+        # name:
+        #   en: Unix Socket Enabled 
+        #   ch: 启用 Unix Socket 追踪
+        # unit:
+        # range: []
+        # enum_options: []
+        # modification: agent_restart
+        # ee_feature: false
+        # description:
+        #   en: |-
+        #     When set to true, enable tracing of Unix domain sockets.
+        #   ch: |-
+        #     当设置为 true 时，启用 Unix Socket 追踪。
+        enable_unix_socket: false
         # type: section
         # name:
         #   en: Blacklist


### PR DESCRIPTION
* feat: agent - eBPF Support unix domain sockets

Conflicts:
	agent/src/ebpf/kernel/socket_trace.bpf.c

* add tag

* Add tuple info

Conflicts:
	agent/src/ebpf/user/socket.c

* feat: ebpf type add unix socket

* Set proto: TCP port: 1

* Add port distinction

* Add interface to enable or disable Unix socket tracing

* Add Rust code for the Unix socket tracing toggle interface

---------

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Agent



#### Affected branches
- main
- v7.0
- v6.6