### PR TITLE
feat: agent - eBPF Support unix domain sockets (#9844)

### DIFF
--- a/agent/src/common/ebpf.rs
+++ b/agent/src/common/ebpf.rs
@@ -38,6 +38,8 @@ pub const IO_EVENT: u8 = 4;
 pub const GO_HTTP2_UPROBE_DATA: u8 = 5;
 // socket close event
 pub const SOCKET_CLOSE_EVENT: u8 = 6;
+// unix socket
+pub const UNIX_SOCKET: u8 = 8;
 
 const EBPF_TYPE_TRACEPOINT: u8 = 0;
 const EBPF_TYPE_TLS_UPROBE: u8 = 1;
@@ -45,6 +47,7 @@ const EBPF_TYPE_GO_HTTP2_UPROBE: u8 = 2;
 const EBPF_TYPE_IO_EVENT: u8 = 4;
 const EBPF_TYPE_GO_HTTP2_UPROBE_DATA: u8 = 5;
 const EBPF_TYPE_SOCKET_CLOSE_EVENT: u8 = 6;
+const EBPF_TYPE_UNIX_SOCKET: u8 = 8;
 const EBPF_TYPE_NONE: u8 = 255;
 
 // ebpf的类型,由ebpf程序传入,对应 SK_BPF_DATA 的 source 字段
@@ -78,6 +81,7 @@ pub enum EbpfType {
     GoHttp2UprobeData = EBPF_TYPE_GO_HTTP2_UPROBE_DATA,
     IOEvent = EBPF_TYPE_IO_EVENT,
     SocketCloseEvent = EBPF_TYPE_SOCKET_CLOSE_EVENT,
+    UnixSocket = EBPF_TYPE_UNIX_SOCKET,
     None = EBPF_TYPE_NONE, // 非 ebpf 类型.
 }
 
@@ -92,6 +96,7 @@ impl TryFrom<u8> for EbpfType {
             SYSCALL => Ok(Self::TracePoint),
             IO_EVENT => Ok(Self::IOEvent),
             SOCKET_CLOSE_EVENT => Ok(Self::SocketCloseEvent),
+            UNIX_SOCKET => Ok(Self::UnixSocket),
             _ => Err(format!("unknown ebpf type: {}", value)),
         }
     }

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -950,6 +950,7 @@ impl Default for EbpfSocketKprobePorts {
 #[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct EbpfSocketKprobe {
+    pub enable_unix_socket: bool,
     pub blacklist: EbpfSocketKprobePorts,
     pub whitelist: EbpfSocketKprobePorts,
 }

--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -103,6 +103,7 @@ enum process_data_extra_source {
 	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
 	DATA_SOURCE_CLOSE,
 	DATA_SOURCE_DPDK,
+	DATA_SOURCE_UNIX_SOCKET,
 };
 
 struct protocol_message_t {

--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -110,6 +110,9 @@ __protocol_port_check(enum traffic_protocol proto,
 		return false;
 	}
 
+	if (conn_info->sk_type == SOCK_UNIX)
+		return true;
+
 	__u32 key = proto;
 	ports_bitmap_t *ports = proto_ports_bitmap__lookup(&key);
 	if (ports) {
@@ -3850,10 +3853,6 @@ infer_protocol_1(struct ctx_info_s *ctx,
 	if (conn_info->sk == NULL)
 		goto infer_aborted;
 
-	if (conn_info->tuple.dport == 0 || conn_info->tuple.num == 0) {
-		goto infer_aborted;
-	}
-
 	/*
 	 * The socket that is indeed determined to be a protocol does not
 	 * enter drop_msg_by_comm().
@@ -3932,7 +3931,8 @@ infer_protocol_1(struct ctx_info_s *ctx,
 	 * If the data source comes from kernel system calls, it is discarded
 	 * directly because some kernel probes do not handle TLS data.
 	 */
-	if (protocol_port_check_1(PROTO_TLS, conn_info) &&
+	if (conn_info->sk_type != SOCK_UNIX &&
+	    protocol_port_check_1(PROTO_TLS, conn_info) &&
 	    extra->source == DATA_SOURCE_SYSCALL) {
 		/*
 		 * TLS first performs handshake protocol inference and discards the data

--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -34,6 +34,8 @@
 #define INFER_CONTINUE	1
 #define INFER_TERMINATE	2
 
+#define SOCK_UNIX	11 // Used to identify UNIX domain sockets. 
+
 #define MAX_PUSH_DELAY_TIME_NS 100000000ULL // 100ms
 
 typedef long unsigned int __kernel_size_t;
@@ -85,6 +87,7 @@ struct mmsghdr {
 #define SOCK_CHECK_TYPE_ERROR           0
 #define SOCK_CHECK_TYPE_UDP             1
 #define SOCK_CHECK_TYPE_TCP_ES          2
+#define SOCK_CHECK_TYPE_UNIX		3
 
 #include "socket_trace_common.h"
 

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -332,6 +332,8 @@ struct debug_data {
 
 struct member_fields_offset {
 	__u8 ready;
+	__u8 enable_unix_socket:1;		// Enable flag for Unix socket tracing
+	__u8 reserved:7;
 	__u16 struct_dentry_d_parent_offset;    // offsetof(struct dentry, d_parent)
 	__u32 task__files_offset;
 	__u32 sock__flags_offset;

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -618,10 +618,13 @@ static __inline int is_tcp_udp_data(void *sk,
 	bpf_probe_read_kernel(&conn_info->skc_family,
 			      sizeof(conn_info->skc_family),
 			      sk + offset->struct_sock_family_offset);
-	/*
-	 * Without thinking about PF_UNIX.
-	 */
+
 	switch (conn_info->skc_family) {
+	case PF_UNIX:
+		if (offset->enable_unix_socket)
+			// Handle UNIX domain sockets, tracing local IPC
+			return SOCK_CHECK_TYPE_UNIX;
+		return SOCK_CHECK_TYPE_ERROR;
 	case PF_INET:
 		break;
 	case PF_INET6:
@@ -691,6 +694,11 @@ static __inline void init_conn_info(__u32 tgid, __u32 fd,
 static __inline bool get_socket_info(struct __socket_data *v, void *sk,
 				     struct conn_info_s *conn_info)
 {
+	if (conn_info->sk_type == SOCK_UNIX) {
+		v->tuple.addr_len = 0;
+		return true;
+	}
+
 	if (v == NULL || sk == NULL)
 		return false;
 
@@ -732,6 +740,11 @@ static __inline bool get_socket_info(struct __socket_data *v, void *sk,
 static __inline bool get_socket_info(struct __tuple_t *tuple, void *sk,
 				     struct conn_info_s *conn_info)
 {
+	if (conn_info->sk_type == SOCK_UNIX) {
+		tuple->addr_len = 0;
+		return true;
+	}
+
 	if (sk == NULL)
 		return false;
 
@@ -1651,7 +1664,11 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		v->extra_data_count = 0;
 
 	v->coroutine_id = trace_key.goid;
-	v->source = extra->source;
+
+	if (conn_info->sk_type == SOCK_UNIX)
+		v->source = DATA_SOURCE_UNIX_SOCKET;
+	else
+		v->source = extra->source;
 
 #if defined(LINUX_VER_KFUNC) || defined(LINUX_VER_5_2_PLUS)
 	__u32 cache_key = ((__u32) bpf_get_current_pid_tgid()) >> 16;
@@ -1726,7 +1743,7 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 #endif
 	struct conn_info_s *conn_info, __conn_info = { 0 };
 	conn_info = &__conn_info;
-	__u8 sock_state;
+	__u8 sock_state = 0;
 	if (!(sk != NULL &&
 	      ((sock_state = is_tcp_udp_data(sk, offset, conn_info))
 	       != SOCK_CHECK_TYPE_ERROR))) {
@@ -1736,6 +1753,9 @@ static __inline int process_data(struct pt_regs *ctx, __u64 id,
 		return -2; // This means attempting to handle I/O events.
 #endif
 	}
+
+	if (sock_state == SOCK_CHECK_TYPE_UNIX)
+		conn_info->sk_type = SOCK_UNIX;
 
 	init_conn_info(id >> 32, args->fd, conn_info, sk, direction,
 		       bytes_count, offset);

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -148,6 +148,8 @@ pub const DATA_SOURCE_IO_EVENT: u8 = 4;
 pub const DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE: u8 = 5;
 #[allow(dead_code)]
 pub const DATA_SOURCE_CLOSE: u8 = 6;
+#[allow(dead_code)]
+pub const DATA_SOURCE_UNIX_SOCKET: u8 = 8;
 cfg_if::cfg_if! {
     if #[cfg(feature = "extended_observability")] {
         #[allow(dead_code)]
@@ -723,6 +725,10 @@ extern "C" {
     pub fn get_dwarf_shard_map_size() -> c_int;
     pub fn set_dwarf_shard_map_size(size: c_int) -> c_void;
 
+    // Disables Unix socket tracing.
+    pub fn disable_unix_socket_feature();
+    // Enables Unix socket tracing.
+    pub fn enable_unix_socket_feature();
     cfg_if::cfg_if! {
         if #[cfg(feature = "extended_observability")] {
             pub fn enable_offcpu_profiler() -> c_int;

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -52,6 +52,7 @@
 static enum linux_kernel_type g_k_type;
 static struct list_head events_list;	// Use for extra register events
 static pthread_t proc_events_pthread;	// Process exec/exit thread
+static bool unix_socket_feature_enable; // Whether to enable the kprobe feature.
 /*
  * Control whether to disable the tracing feature.
  * 'true' disables the tracing feature, and 'false' enables it.
@@ -1230,6 +1231,20 @@ static void reader_raw_cb(void *cookie, void *raw, int raw_size)
 		if (sd->source != DATA_SOURCE_DPDK) {
 			submit_data->socket_id = sd->socket_id;
 			submit_data->tuple = sd->tuple;
+			if (sd->source == DATA_SOURCE_UNIX_SOCKET) {
+				submit_data->tuple.l4_protocol = IPPROTO_TCP;
+				submit_data->tuple.dport = submit_data->tuple.num = 0;
+				// 0:unkonwn 1:client(connect) 2:server(accept)
+				if (sd->socket_role == 1) {
+					submit_data->tuple.dport = 1;
+				} else if (sd->socket_role == 2) {
+					submit_data->tuple.num = 1;
+				}
+				submit_data->tuple.addr_len = 4;
+				*(in_addr_t *)submit_data->tuple.rcv_saddr = htonl(0x7F000001); 
+				*(in_addr_t *)submit_data->tuple.daddr = htonl(0x7F000001);
+			}
+
 			submit_data->process_id = sd->tgid;
 			submit_data->thread_id = sd->pid;
 			submit_data->coroutine_id = sd->coroutine_id;
@@ -1606,6 +1621,10 @@ static int update_offset_map_default(struct bpf_tracer *t,
 	bpf_offset_param_t offset;
 	memset(&offset, 0, sizeof(offset));
 
+	if (unix_socket_feature_enable) {
+		offset.enable_unix_socket = 1;
+	}
+
 	switch (kern_type) {
 	case K_TYPE_VER_3_10:
 		offset.struct_files_struct_fdt_offset = 0x8;
@@ -1803,6 +1822,11 @@ static int update_offset_map_from_btf_vmlinux(struct bpf_tracer *t)
 		  struct_sock_common_ipv6only_offset);
 
 	bpf_offset_param_t offset;
+	memset(&offset, 0, sizeof(offset));
+	if (unix_socket_feature_enable) {
+		offset.enable_unix_socket = 1;
+	}
+
 	offset.ready = 1;
 	offset.task__files_offset = files_offs;
 	offset.sock__flags_offset = sk_flags_offs;
@@ -2589,6 +2613,8 @@ retry_load:
 		ebpf_info
 		    ("[eBPF Kernel Adapt] Set offsets map from btf_vmlinux, success.\n");
 	}
+
+	ebpf_info("== Unix domain socket ==\n");
 
 	// Set default maximum amount of data passed to the agent by eBPF.
 	if (socket_data_limit_max == 0)
@@ -3520,6 +3546,18 @@ void uprobe_match_pid_handle(int feat, int pid, enum match_pids_act act)
 		golang_trace_handle(pid, act);
 	else if (feat == FEATURE_UPROBE_OPENSSL)
 		openssl_trace_handle(pid, act);
+}
+
+void disable_unix_socket_feature(void)
+{
+	unix_socket_feature_enable = false;
+	ebpf_info("unix socket feature has been disabled.\n");
+}
+
+void enable_unix_socket_feature(void)
+{
+	unix_socket_feature_enable = true;
+	ebpf_info("unix socket feature has been enabled.\n");
 }
 
 bool is_pure_kprobe_ebpf(void)

--- a/agent/src/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher.rs
@@ -870,6 +870,14 @@ impl EbpfCollector {
             }
         }
 
+        if config.ebpf.socket.kprobe.enable_unix_socket {
+            info!("ebpf unix socket tracing enabled");
+            ebpf::enable_unix_socket_feature();
+        } else {
+            info!("ebpf unix socket tracing disabled");
+            ebpf::disable_unix_socket_feature();
+        }
+
         let white_list = &config.ebpf.socket.kprobe.whitelist;
         if !white_list.ports.is_empty() {
             if let Some(b) = parse_u16_range_list_to_bitmap(&white_list.ports, false) {

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -681,7 +681,9 @@ impl L7ProtocolParserInterface for HttpLog {
                     self.set_header_decoder(config.l7_log_dynamic.expected_headers_set.clone());
                 }
                 match param.ebpf_type {
-                    EbpfType::GoHttp2Uprobe | EbpfType::GoHttp2UprobeData => {
+                    EbpfType::GoHttp2Uprobe
+                    | EbpfType::GoHttp2UprobeData
+                    | EbpfType::UnixSocket => {
                         if param.direction == PacketDirection::ServerToClient {
                             return false;
                         }

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -3713,6 +3713,34 @@ inputs:
 
 #### Kprobe {#inputs.ebpf.socket.kprobe}
 
+##### 禁用 kprobe {#inputs.ebpf.socket.kprobe.enable_unix_socket}
+
+**标签**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`inputs.ebpf.socket.kprobe.enable_unix_socket`
+
+**默认值**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      kprobe:
+        enable_unix_socket: false
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**详细描述**:
+
+当设置为 true 时，启用 Unix Socket 追踪。
+
 ##### 黑名单 {#inputs.ebpf.socket.kprobe.blacklist}
 
 ###### 端口号 {#inputs.ebpf.socket.kprobe.blacklist.ports}

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -3796,6 +3796,34 @@ Example: `tx_hooks: [i40e_xmit_pkts, virtio_xmit_pkts_packed, virtio_xmit_pkts]`
 
 #### Kprobe {#inputs.ebpf.socket.kprobe}
 
+##### Unix Socket Enabled {#inputs.ebpf.socket.kprobe.enable_unix_socket}
+
+**Tags**:
+
+<mark>agent_restart</mark>
+
+**FQCN**:
+
+`inputs.ebpf.socket.kprobe.enable_unix_socket`
+
+**Default value**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      kprobe:
+        enable_unix_socket: false
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**Description**:
+
+When set to true, enable tracing of Unix domain sockets.
+
 ##### Blacklist {#inputs.ebpf.socket.kprobe.blacklist}
 
 ###### Port Numbers {#inputs.ebpf.socket.kprobe.blacklist.ports}

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -2795,6 +2795,21 @@ inputs:
       # name: Kprobe
       # description:
       kprobe:
+        # type: bool
+        # name:
+        #   en: Unix Socket Enabled 
+        #   ch: 启用 Unix Socket 追踪
+        # unit:
+        # range: []
+        # enum_options: []
+        # modification: agent_restart
+        # ee_feature: false
+        # description:
+        #   en: |-
+        #     When set to true, enable tracing of Unix domain sockets.
+        #   ch: |-
+        #     当设置为 true 时，启用 Unix Socket 追踪。
+        enable_unix_socket: false
         # type: section
         # name:
         #   en: Blacklist


### PR DESCRIPTION
* feat: agent - eBPF Support unix domain sockets

Conflicts:
	agent/src/ebpf/kernel/socket_trace.bpf.c

* add tag

* Add tuple info

Conflicts:
	agent/src/ebpf/user/socket.c

* feat: ebpf type add unix socket

* Set proto: TCP port: 1

* Add port distinction

* Add interface to enable or disable Unix socket tracing

* Add Rust code for the Unix socket tracing toggle interface

---------


Conflicts:
	agent/src/config/config.rs
	agent/src/ebpf/kernel/include/socket_trace_common.h
	agent/src/ebpf/kernel/socket_trace.bpf.c
	agent/src/ebpf/mod.rs
	agent/src/ebpf/user/socket.c
	agent/src/ebpf_dispatcher.rs
	server/agent_config/README-CH.md
	server/agent_config/README.md
	server/agent_config/template.yaml



### This PR is for:

- Agent


#### Affected branches
- main
- v6.6
- v7.0