### PR TITLE
fix: agent - eBPF Fix enable_unix_socket configuration not taking effect

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -3287,6 +3287,14 @@ impl ConfigHandler {
             kprobe.disabled = new_kprobe.disabled;
             restart_agent = !first_run;
         }
+        if kprobe.enable_unix_socket != new_kprobe.enable_unix_socket {
+            info!(
+                "Update inputs.ebpf.socket.kprobe.enable_unix_socket from {:?} to {:?}.",
+                kprobe.enable_unix_socket, new_kprobe.enable_unix_socket
+            );
+            kprobe.enable_unix_socket = new_kprobe.enable_unix_socket;
+            restart_agent = !first_run;
+        }
         if kprobe.blacklist.ports != new_kprobe.blacklist.ports {
             info!(
                 "Update inputs.ebpf.socket.kprobe.blacklist.ports from {:?} to {:?}.",


### PR DESCRIPTION

### This PR is for:

- Agent



#### Affected branches
- main
- v7.0
- v6.6
