### PR TITLE
fix: agent - eBPF Fix unrecognized HTTP/2 magic

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -454,21 +454,6 @@ static __inline enum message_type parse_http2_headers_frame(const char
 	if (count < HTTPV2_FRAME_PROTO_SZ)
 		return MSG_UNKNOWN;
 
-	/*
-	 * The frame payload length (excluding the initial 9 bytes) must not
-	 * exceed the actual length of the system call.
-	 */
-	if ((__bpf_ntohl(*(__u32 *) buf_kern) >> 8) > syscall_len - HTTPV2_FRAME_PROTO_SZ)
-		return MSG_UNKNOWN;
-
-	/*
-	 * The highest bit of the 5th byte (i.e., the first byte of the Stream
-	 * Identifier) must be 0, indicating that the reserved bit (R) is 0;
-	 * otherwise, it violates the HTTP/2 specification.
-	 */
-	if (buf_kern[5] >> 7 != 0)
-		return MSG_UNKNOWN;
-	
 	__u32 offset = 0;
 	__u8 flags_unset = 0, flags_padding = 0, flags_priority = 0;
 	__u8 type = 0, reserve = 0, static_table_idx, i, block_fragment_offset;
@@ -481,6 +466,21 @@ static __inline enum message_type parse_http2_headers_frame(const char
 	if (is_first && is_http2_magic(buf_src, count)) {
 		static const int HTTP2_MAGIC_SIZE = 24;
 		offset = HTTP2_MAGIC_SIZE;
+	} else {
+		/*
+	 	* The frame payload length (excluding the initial 9 bytes) must not
+		* exceed the actual length of the system call.
+	 	*/
+		if ((__bpf_ntohl(*(__u32 *) buf_kern) >> 8) > syscall_len - HTTPV2_FRAME_PROTO_SZ)
+			return MSG_UNKNOWN;
+
+		/*
+		 * The highest bit of the 5th byte (i.e., the first byte of the Stream
+		 * Identifier) must be 0, indicating that the reserved bit (R) is 0;
+		 * otherwise, it violates the HTTP/2 specification.
+		 */
+		if (buf_kern[5] >> 7 != 0)
+			return MSG_UNKNOWN;
 	}
 
 	/*


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### Fixes < HTTP2 协议识别问题 >
#### Steps to reproduce the bug
- 编译 agent/src/ebpf/samples/rust/socket-tracer 后，测试 HTTP2 消息，无法输出 HTTP2 数据。

#### Changes to fix the bug
- 0b26d5de12ba9d9fd2f80daa352f317043415ee5 提交的检测跳过 HTTP2 MAGIC 部分

#### Affected branches
- main
- v7.0
- v6.6
- v6.5
- v6.4

#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


