### PR TITLE
fix: agent - eBPF Fix unrecognized HTTP/2 magic

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -454,21 +454,6 @@ static __inline enum message_type parse_http2_headers_frame(const char
 	if (count < HTTPV2_FRAME_PROTO_SZ)
 		return MSG_UNKNOWN;
 
-	/*
-	 * The frame payload length (excluding the initial 9 bytes) must not
-	 * exceed the actual length of the system call.
-	 */
-	if ((__bpf_ntohl(*(__u32 *) buf_kern) >> 8) > syscall_len - HTTPV2_FRAME_PROTO_SZ)
-		return MSG_UNKNOWN;
-
-	/*
-	 * The highest bit of the 5th byte (i.e., the first byte of the Stream
-	 * Identifier) must be 0, indicating that the reserved bit (R) is 0;
-	 * otherwise, it violates the HTTP/2 specification.
-	 */
-	if (buf_kern[5] >> 7 != 0)
-		return MSG_UNKNOWN;
-	
 	__u32 offset = 0;
 	__u8 flags_unset = 0, flags_padding = 0, flags_priority = 0;
 	__u8 type = 0, reserve = 0, static_table_idx, i, block_fragment_offset;
@@ -481,6 +466,21 @@ static __inline enum message_type parse_http2_headers_frame(const char
 	if (is_first && is_http2_magic(buf_src, count)) {
 		static const int HTTP2_MAGIC_SIZE = 24;
 		offset = HTTP2_MAGIC_SIZE;
+	} else {
+		/*
+	 	* The frame payload length (excluding the initial 9 bytes) must not
+		* exceed the actual length of the system call.
+	 	*/
+		if ((__bpf_ntohl(*(__u32 *) buf_kern) >> 8) > syscall_len - HTTPV2_FRAME_PROTO_SZ)
+			return MSG_UNKNOWN;
+
+		/*
+		 * The highest bit of the 5th byte (i.e., the first byte of the Stream
+		 * Identifier) must be 0, indicating that the reserved bit (R) is 0;
+		 * otherwise, it violates the HTTP/2 specification.
+		 */
+		if (buf_kern[5] >> 7 != 0)
+			return MSG_UNKNOWN;
 	}
 
 	/*


### PR DESCRIPTION
Due to commit 0b26d5d skipping the detection of the HTTP/2 MAGIC segment, the MAGIC segment could not be recognized. This PR fixes the issue.

### This PR is for:

- Agent

#### Affected branches
- main
- v7.0
- v6.6
- v6.5
- v6.4
