### PR TITLE
fix: Socket info incomplete

### DIFF
--- a/agent/crates/public/src/netns.rs
+++ b/agent/crates/public/src/netns.rs
@@ -188,6 +188,11 @@ impl NsFile {
         }
         r
     }
+
+    pub fn from_pid_with_root(root: &str, pid: u32) -> Result<Self> {
+        let path: PathBuf = [root, &pid.to_string(), "ns", "net"].iter().collect();
+        Ok(Self::Proc(fs::metadata(path)?.ino()))
+    }
 }
 
 impl fmt::Display for NsFile {

--- a/agent/src/platform/platform_synchronizer/linux_process.rs
+++ b/agent/src/platform/platform_synchronizer/linux_process.rs
@@ -35,7 +35,6 @@ use public::pwd::PasswordInfo;
 use ring::digest;
 use serde::Deserialize;
 
-use super::linux_socket::get_proc_netns;
 use super::proc_scan_hook::proc_scan_hook;
 
 use crate::config::handler::OsProcScanConfig;
@@ -144,6 +143,17 @@ pub fn calc_process_datas_sha1(data: &Vec<ProcessData>) -> [u8; SHA1_DIGEST_LEN]
     let mut ret = [0u8; SHA1_DIGEST_LEN];
     ret.copy_from_slice(h.finish().as_ref().as_bytes());
     ret
+}
+
+fn get_proc_netns(proc: &Process) -> Result<u64, ProcError> {
+    // works with linux 3.0+ kernel only
+    // refer to this [commit](https://github.com/torvalds/linux/commit/6b4e306aa3dc94a0545eb9279475b1ab6209a31f)
+    // use 0 as default ns for old kernel
+    proc.namespaces()
+        .map_or(Ok(0), |m| match m.get(&std::ffi::OsString::from("net")) {
+            Some(netns) => Ok(netns.identifier),
+            _ => Ok(0),
+        })
 }
 
 impl TryFrom<&Process> for ProcessData {

--- a/agent/src/platform/platform_synchronizer/linux_socket.rs
+++ b/agent/src/platform/platform_synchronizer/linux_socket.rs
@@ -21,15 +21,15 @@ use std::os::linux::fs::MetadataExt;
 
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsString,
+    fmt, fs,
     net::{IpAddr, SocketAddr},
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use log::{error, warn};
+use log::{debug, trace};
 use procfs::{
-    net::{TcpNetEntry, TcpState, UdpNetEntry},
+    net::TcpState,
     process::{FDTarget, Process},
     ProcError,
 };
@@ -41,6 +41,7 @@ use crate::{
 
 use public::{
     bytes::read_u32_be,
+    netns::NsFile,
     proto::agent::{GpidSyncEntry, RoleType, ServiceProtocol},
 };
 
@@ -74,6 +75,21 @@ pub(super) struct SockEntry {
     pub(super) real_client: Option<SockAddrData>,
     // netns idx is the unique number of netns, not equal to netns inode.
     pub(super) netns_idx: u16,
+    pub(super) netns: NsFile,
+}
+
+impl fmt::Display for SockEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (c, s) = match self.role {
+            Role::Client => (&self.local, &self.remote),
+            Role::Server => (&self.remote, &self.local),
+        };
+        write!(
+            f,
+            "{:?} {}:{} -> {}:{} in {}, pid: {}",
+            self.proto, c.ip, c.port, s.ip, s.port, self.netns, self.pid
+        )
+    }
 }
 
 impl TryFrom<SockEntry> for GpidSyncEntry {
@@ -156,295 +172,6 @@ impl TryFrom<SockEntry> for GpidSyncEntry {
     }
 }
 
-// return server local addr, client remote addr
-pub(super) fn get_all_socket(
-    conf: &OsProcScanConfig,
-    policy_getter: &mut PolicyGetter,
-    epc_id: u32,
-    pids: Vec<u32>,
-) -> Result<Vec<SockEntry>, ProcError> {
-    // Hashmap<inode, (pid,fd)>
-    let mut inode_pid_fd_map = HashMap::new();
-
-    // Hashmap<netns_id, netns_idx>, use for map the netns id to u16 and skip the netns which info had been fetched
-    let mut netns_id_idx_map = HashMap::new();
-
-    // HashSet<(port, proto, NetnsInode)>, the listenning port when socket listening in `0.0.0.0` or `::`
-    let mut all_iface_listen_sock = HashSet::new();
-    // HashSet<(SocketAddr)>, the listenning addr when socket listening specific addr
-    let mut spec_addr_listen_sock = HashSet::new();
-
-    let (
-        _tagged_only,
-        proc_root,
-        min_sock_lifetime,
-        now_sec,
-        mut tcp_entries,
-        mut udp_entries,
-        mut sock_entries,
-    ) = (
-        conf.os_proc_sync_tagged_only,
-        conf.os_proc_root.as_str(),
-        conf.os_proc_socket_min_lifetime as u64,
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        vec![],
-        vec![],
-        vec![],
-    );
-    // netns idx increase every time get the new netns id
-    let mut netns_idx = 0u16;
-
-    for pid in pids {
-        let process = Process::new(pid as i32);
-        if let Err(ref e) = process {
-            warn!("get process(pid: {}) failed: {:?}", pid, e);
-            continue;
-        }
-        let process = process.unwrap();
-        let Ok(process_data) = ProcessData::try_from(&process) else {
-            continue;
-        };
-
-        let (fds, netns, pid) = match (process.fd(), get_proc_netns(&process)) {
-            (Ok(fds), Ok(netns)) => (fds, netns, process.pid),
-            _ => {
-                continue;
-            }
-        };
-
-        let Ok(up_sec) = process_data.up_sec(now_sec) else {
-            continue;
-        };
-
-        // filter the short live proc
-        if up_sec < u64::from(conf.os_proc_socket_min_lifetime) {
-            continue;
-        }
-
-        // when match proc, will record the inode and (pid, fd) map, use for get the connection pid and fd in later.
-        for fd in fds {
-            let Ok(f) = fd else {
-                continue;
-            };
-            if let FDTarget::Socket(fd_inode) = f.target {
-                inode_pid_fd_map.insert(fd_inode, (pid, f.fd));
-            }
-        }
-
-        // break if the netns had been fetched
-        if netns_id_idx_map.contains_key(&netns) {
-            break;
-        };
-
-        netns_id_idx_map.insert(netns, {
-            if netns_idx == u16::MAX {
-                warn!("netns_idx reach u16::Max, set to 0");
-                0
-            } else {
-                netns_idx += 1;
-                netns_idx
-            }
-        });
-
-        // also recoed the listining socket info, use for determine client or server connection.
-        // note that proc.{tcp(), tcp6(), udp(), udp6()} include all connection in the proc netns
-        if let Err(err) = record_tcp_listening_ip_port(
-            &process,
-            Some(netns),
-            &mut all_iface_listen_sock,
-            &mut spec_addr_listen_sock,
-        ) {
-            error!("pid {} record_tcp_listening_ip_port fail: {}", pid, err);
-            break;
-        }
-
-        // record the tcp and udp connection in current netns
-        // only support ipv4 now, ipv6 dual stack will extra ipv4 addr
-        match (process.tcp(), process.udp()) {
-            (Ok(tcp), Ok(udp)) => {
-                tcp_entries.push((tcp, netns));
-                udp_entries.push((udp, netns));
-            }
-            _ => error!("pid {} get connection info fail", pid),
-        }
-
-        // old kernel have no tcp6/udp6
-        match (process.tcp6(), process.udp6()) {
-            (Ok(tcp6), Ok(udp6)) => {
-                tcp_entries.push((tcp6, netns));
-                udp_entries.push((udp6, netns));
-            }
-            _ => {}
-        }
-    }
-
-    // let mut pid_proc_map = get_all_pid_process_map(conf.os_proc_root.as_str());
-
-    // // get all process, and record the open fd and fetch listining socket info
-    // // note that the /proc/pid/net/{tcp,tcp6,udp,udp6} include all the connection in the proc netns, not the process created connection.
-    // for p in procfs::process::all_processes_with_root(proc_root)? {
-    //     for i in conf.os_proc_regex.as_slice() {
-    //         if i.match_and_rewrite_proc(&mut proc_data, &pid_proc_map, &tags_map, true) {
-    //             if i.action() == RegExpAction::Drop {
-    //                 break;
-    //             }
-
-    //             if tags_map.get(&(proc.pid as u64)).is_none() && tagged_only {
-    //                 break;
-    //             }
-
-    //             // when match proc, will record the inode and (pid, fd) map, use for get the connection pid and fd in later.
-    //             for fd in fds {
-    //                 let Ok(f) = fd else {
-    //                     continue;
-    //                 };
-    //                 if let FDTarget::Socket(fd_inode) = f.target {
-    //                     inode_pid_fd_map.insert(fd_inode, (pid, f.fd));
-    //                 }
-    //             }
-
-    //             // break if the netns had been fetched
-    //             if netns_id_idx_map.contains_key(&netns) {
-    //                 break;
-    //             };
-
-    //             netns_id_idx_map.insert(netns, {
-    //                 if netns_idx == u16::MAX {
-    //                     warn!("netns_idx reach u16::Max, set to 0");
-    //                     0
-    //                 } else {
-    //                     netns_idx += 1;
-    //                     netns_idx
-    //                 }
-    //             });
-
-    //             // also recoed the listining socket info, use for determine client or server connection.
-    //             // note that proc.{tcp(), tcp6(), udp(), udp6()} include all connection in the proc netns
-    //             if let Err(err) = record_tcp_listening_ip_port(
-    //                 &proc,
-    //                 Some(netns),
-    //                 &mut all_iface_listen_sock,
-    //                 &mut spec_addr_listen_sock,
-    //             ) {
-    //                 error!("pid {} record_tcp_listening_ip_port fail: {}", pid, err);
-    //                 break;
-    //             }
-
-    //             // record the tcp and udp connection in current netns
-    //             // only support ipv4 now, ipv6 dual stack will extra ipv4 addr
-    //             match (proc.tcp(), proc.udp()) {
-    //                 (Ok(tcp), Ok(udp)) => {
-    //                     tcp_entries.push((tcp, netns));
-    //                     udp_entries.push((udp, netns));
-    //                 }
-    //                 _ => error!("pid {} get connection info fail", pid),
-    //             }
-
-    //             // old kernel have no tcp6/udp6
-    //             match (proc.tcp6(), proc.udp6()) {
-    //                 (Ok(tcp6), Ok(udp6)) => {
-    //                     tcp_entries.push((tcp6, netns));
-    //                     udp_entries.push((udp6, netns));
-    //                 }
-    //                 _ => {}
-    //             }
-
-    //             break;
-    //         }
-    //     }
-    // }
-
-    divide_tcp_entry(
-        epc_id,
-        proc_root,
-        policy_getter,
-        min_sock_lifetime,
-        &all_iface_listen_sock,
-        &spec_addr_listen_sock,
-        &inode_pid_fd_map,
-        &netns_id_idx_map,
-        tcp_entries,
-        &mut sock_entries,
-    );
-    divide_udp_entry(
-        epc_id,
-        proc_root,
-        policy_getter,
-        min_sock_lifetime,
-        &inode_pid_fd_map,
-        &netns_id_idx_map,
-        udp_entries,
-        &mut sock_entries,
-    );
-
-    Ok(sock_entries)
-}
-
-fn is_zero_addr(addr: &SocketAddr) -> bool {
-    addr.ip().is_unspecified()
-}
-
-pub(super) fn get_proc_netns(proc: &Process) -> Result<u64, ProcError> {
-    // works with linux 3.0+ kernel only
-    // refer to this [commit](https://github.com/torvalds/linux/commit/6b4e306aa3dc94a0545eb9279475b1ab6209a31f)
-    // use 0 as default ns for old kernel
-    proc.namespaces()
-        .map_or(Ok(0), |m| match m.get(&OsString::from("net")) {
-            Some(netns) => Ok(netns.identifier),
-            _ => Ok(0),
-        })
-}
-
-/*
-    record the listenning sock from proc netns
-
-    note that the Process.tcp() and Process.udp() correspond the /proc/pid/net/{tcp, udp}, it include all the connection info
-    in the proc netns, not only the connection which the proc create.
-
-    param:
-
-        all_iface_listen_sock: HashSet<(port, proto, NetnsInode)>
-
-        spec_addr_listen_sock: HashSet<(SocketAddr)>,
-*/
-fn record_tcp_listening_ip_port(
-    proc: &Process,
-    netns: Option<u64>,
-    all_iface_listen_sock: &mut HashSet<(u16, Protocol, u64)>,
-    spec_addr_listen_sock: &mut HashSet<SocketAddr>,
-) -> Result<(), ProcError> {
-    let netns = netns.unwrap_or(get_proc_netns(&proc)?);
-
-    let mut handle_entry = |enties: Vec<TcpNetEntry>| {
-        for t in enties {
-            if t.state == TcpState::Listen {
-                // when listening in zero addr, indicate listen in all interface
-                if is_zero_addr(&t.local_address) {
-                    all_iface_listen_sock.insert((t.local_address.port(), Protocol::Tcp, netns));
-                } else {
-                    // now only support ipv4
-                    let Some(local_address) = convert_addr_to_v4(t.local_address) else {
-                        continue;
-                    };
-                    spec_addr_listen_sock.insert(local_address);
-                }
-            }
-        }
-    };
-
-    if let Ok(tcp) = proc.tcp() {
-        handle_entry(tcp);
-    }
-    if let Ok(tcp) = proc.tcp6() {
-        handle_entry(tcp);
-    }
-
-    Ok(())
-}
-
 /*
     divide all socket info to server or client side
 
@@ -492,184 +219,255 @@ fn record_tcp_listening_ip_port(
 
     note that the /proc/pid/net/{tcp,tcp6,udp,udp6} consist of all the connection in the proc netns, not the process connection.
 */
-fn divide_tcp_entry(
-    local_epc_id: u32,
-    proc_root: &str,
+pub(super) fn get_all_socket(
+    conf: &OsProcScanConfig,
     policy_getter: &mut PolicyGetter,
-    // sock min up time, use for filter short connection
-    sock_min_lifetime_sec: u64,
-    // HashSet<(port, proto, NetnsInode)>
-    all_iface_listen_sock: &HashSet<(u16, Protocol, u64)>,
-    // HashSet<(SocketAddr)>
-    spec_addr_listen_sock: &HashSet<SocketAddr>,
-    // Hashmap<inode, (pid,fd)>
-    inode_pid_fd_map: &HashMap<u64, (i32, i32)>,
-    // Hashmap<netns_id, netnss_idx>
-    netns_idx_map: &HashMap<u64, u16>,
-    // Vec< Vec<tcp_entrys>, netns >
-    tcp_entry: Vec<(Vec<TcpNetEntry>, u64)>,
-    sock_entries: &mut Vec<SockEntry>,
-) {
-    let now_sec = SystemTime::now()
+    epc_id: u32,
+    pids: Vec<u32>,
+) -> Result<Vec<SockEntry>, ProcError> {
+    let epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
 
-    for (tcp_entries, netns) in tcp_entry {
-        for t in tcp_entries {
-            if t.state != TcpState::Established {
+    // find fd in processes and their net namespaces
+    let mut socket_inode_to_pid = HashMap::new();
+    let mut namespace_to_pids = HashMap::new();
+
+    trace!("processes to find sockets: {pids:?}");
+    for pid in pids {
+        let process = match Process::new(pid as i32) {
+            Ok(p) => p,
+            Err(e) => {
+                debug!("get process #{pid} failed: {e}");
                 continue;
             }
+        };
+        let Ok(p_data) = ProcessData::try_from(&process) else {
+            continue;
+        };
 
-            let Some((pid, fd)) = inode_pid_fd_map.get(&t.inode) else {
-                continue;
-            };
-
-            /*
-                note that symbol ctime of {proc_root}/{pid}/fd/{fd} is the first time access the file,
-                not the time that the connection create. unless os_proc_socket_min_lifetime config to 0,
-                the new connection at lease the second times scan can be recognized.
-            */
-            let Ok(sock_up_sec) = sym_uptime(
-                now_sec,
-                &PathBuf::from_iter([
-                    proc_root.to_string(),
-                    pid.to_string(),
-                    "fd".to_string(),
-                    fd.to_string(),
-                ]),
-            ) else {
-                continue;
-            };
-            if sock_up_sec < sock_min_lifetime_sec {
+        match p_data.up_sec(epoch) {
+            Ok(up_sec) if up_sec >= u64::from(conf.os_proc_socket_min_lifetime) => (),
+            _ => {
+                debug!(
+                    "process #{pid} ignored because up_sec is invalid or less than {}s",
+                    conf.os_proc_socket_min_lifetime
+                );
                 continue;
             }
+        }
 
-            // now only support ipv4
-            let (Some(local_address), Some(remote_address)) = (
-                convert_addr_to_v4(t.local_address),
-                convert_addr_to_v4(t.remote_address),
-            ) else {
+        let netns = NsFile::from_pid_with_root(&conf.os_proc_root, pid).unwrap_or_default();
+        let fds = match process.fd() {
+            Ok(fds) => fds,
+            Err(e) => {
+                debug!("get process #{pid} fd failed: {e}");
+                continue;
+            }
+        };
+
+        let mut interested = false;
+        for fd in fds {
+            let Ok(fd) = fd else {
                 continue;
             };
-
-            sock_entries.push(SockEntry {
-                pid: *pid as u32,
-                proto: Protocol::Tcp,
-                role: if all_iface_listen_sock.contains(&(
-                    local_address.port(),
-                    Protocol::Tcp,
-                    netns,
-                )) || spec_addr_listen_sock.contains(&local_address)
-                {
-                    // sport in all_iface_listen_sock or SocketAddr in spec_addr_listen_sock, assume is server connection
-                    Role::Server
-                } else {
-                    Role::Client
-                },
-
-                local: SockAddrData {
-                    epc_id: local_epc_id,
-                    ip: local_address.ip(),
-                    port: local_address.port(),
-                },
-                remote: SockAddrData {
-                    epc_id: convert_i32_epc_id(policy_getter.lookup_epc_by_epc(
-                        local_address.ip(),
-                        remote_address.ip(),
-                        local_epc_id as i32,
-                    )),
-                    ip: remote_address.ip(),
-                    port: remote_address.port(),
-                },
-                netns_idx: *netns_idx_map.get(&netns).unwrap(),
-                real_client: None,
-            });
+            if let FDTarget::Socket(inode) = fd.target {
+                match get_fd_ctime(&conf.os_proc_root, pid, fd.fd) {
+                    Ok(ctime) if ctime >= conf.os_proc_socket_min_lifetime as u64 => {
+                        interested = true;
+                        socket_inode_to_pid.insert(inode, pid);
+                    }
+                    _ => {
+                        debug!(
+                            "process #{pid} fd #{} ignored because ctime invalid or less than {}",
+                            fd.fd, conf.os_proc_socket_min_lifetime
+                        );
+                        continue;
+                    }
+                }
+            }
+        }
+        if interested {
+            namespace_to_pids.entry(netns).or_insert(vec![]).push(pid);
         }
     }
-}
 
-fn divide_udp_entry(
-    local_epc_id: u32,
-    proc_root: &str,
-    policy_getter: &mut PolicyGetter,
-    // sock min up time, use for filter short connection
-    sock_min_lifetime_sec: u64,
-    // Hashmap<inode, (pid,fd)>
-    inode_pid_fd_map: &HashMap<u64, (i32, i32)>,
-    // Hashmap<netns_id, netnss_idx>
-    netns_idx_map: &HashMap<u64, u16>,
-    udp_entry: Vec<(Vec<UdpNetEntry>, u64)>,
-    sock_entries: &mut Vec<SockEntry>,
-) {
-    let now_sec = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    for (udp_entries, net_ns) in udp_entry {
-        for u in udp_entries {
-            let Some((pid, fd)) = inode_pid_fd_map.get(&u.inode) else {
-                continue;
+    // find sockets by net namespaces instead of processes because /proc/pid/net/{tcp,tcp6,udp,udp6} is the same for all processes in the same net namespace
+    // but we still need to use pid to access net namespaces
+    trace!("net namespaces to find sockets: {namespace_to_pids:?}");
+    let mut sockets = vec![];
+
+    'outer: for (index, (ns, pids)) in namespace_to_pids.iter_mut().enumerate() {
+        pids.sort_unstable();
+        for pid in pids.iter() {
+            trace!("visiting netns {ns} from pid {pid}");
+
+            let process = match Process::new(*pid as i32) {
+                Ok(p) => p,
+                Err(e) => {
+                    debug!("get process #{pid} failed: {e}");
+                    continue;
+                }
+            };
+            let mut tcp = match process.tcp() {
+                Ok(tcp) => tcp,
+                Err(e) => {
+                    debug!("get process #{pid} tcp failed: {e}");
+                    continue;
+                }
+            };
+            match process.tcp6() {
+                Ok(mut tcp6) => tcp.append(&mut tcp6),
+                Err(e) => {
+                    debug!("get process #{pid} tcp6 failed: {e}");
+                    continue;
+                }
+            };
+            let udp = match process.udp() {
+                Ok(udp) => udp,
+                Err(e) => {
+                    debug!("get process #{pid} udp failed: {e}");
+                    continue;
+                }
+            };
+            let udp6 = match process.udp6() {
+                Ok(udp6) => udp6,
+                Err(e) => {
+                    debug!("get process #{pid} udp6 failed: {e}");
+                    continue;
+                }
             };
 
-            /*
-                note that symbol ctime of {proc_root}/{pid}/fd/{fd} is the first time access the file,
-                not the time that the connection create. unless os_proc_socket_min_lifetime config to 0,
-                the new connection at lease the second times scan can be recognized.
-            */
-
-            let Ok(sock_up_sec) = sym_uptime(
-                now_sec,
-                &PathBuf::from_iter([
-                    proc_root.to_string(),
-                    pid.to_string(),
-                    "fd".to_string(),
-                    fd.to_string(),
-                ]),
-            ) else {
-                continue;
-            };
-            if sock_up_sec < sock_min_lifetime_sec {
-                continue;
-            }
-
-            if is_zero_addr(&u.remote_address) {
-                // foreign addr is zero, indicate the udp socker create use bind(), no idea to determine the local and remote, ignore
-                continue;
-            }
-
-            // now only support ipv4
-            let (Some(local_address), Some(remote_address)) = (
-                convert_addr_to_v4(u.local_address),
-                convert_addr_to_v4(u.remote_address),
-            ) else {
-                continue;
-            };
-
-            // foreign addr is not zero, indicate the udp socker create use connect()
-            sock_entries.push(SockEntry {
-                pid: *pid as u32,
-                proto: Protocol::Udp,
-                role: Role::Client,
-                local: SockAddrData {
-                    epc_id: local_epc_id,
-                    ip: local_address.ip(),
-                    port: local_address.port(),
-                },
-                remote: SockAddrData {
-                    epc_id: convert_i32_epc_id(policy_getter.lookup_epc_by_epc(
-                        local_address.ip(),
-                        remote_address.ip(),
-                        local_epc_id as i32,
-                    )),
-                    ip: remote_address.ip(),
-                    port: remote_address.port(),
-                },
-                netns_idx: *netns_idx_map.get(&net_ns).unwrap(),
-                real_client: None,
+            // tcp sockets that listen on 0.0.0.0
+            let mut listen_any: HashSet<u16> = HashSet::new();
+            // tcp sockets that listen on specific address
+            let mut listen_spec: HashSet<SocketAddr> = HashSet::new();
+            tcp.retain(|t| match t.state {
+                TcpState::Listen => {
+                    trace!("netns {ns} tcp listen on {}", t.local_address);
+                    if t.local_address.ip().is_unspecified() {
+                        trace!(
+                            "netns {ns} tcp listen on 0.0.0.0:{}",
+                            t.local_address.port()
+                        );
+                        listen_any.insert(t.local_address.port());
+                    } else {
+                        let addr = t.local_address.ip().to_canonical();
+                        if addr.is_ipv4() {
+                            listen_spec.insert((addr, t.local_address.port()).into());
+                        }
+                    }
+                    false
+                }
+                TcpState::Established => true,
+                _ => false,
             });
+            trace!("netns {ns} tcp listen on any: {listen_any:?}, listen on spec: {listen_spec:?}");
+            for mut tcp in tcp.into_iter() {
+                assert_eq!(tcp.state, TcpState::Established);
+
+                let pid = match socket_inode_to_pid.get(&tcp.inode) {
+                    Some(pid) => *pid,
+                    None => {
+                        debug!("process #{pid} tcp entry {tcp:?} ignored because inode not found or too recent");
+                        continue;
+                    }
+                };
+
+                let local_addr = &mut tcp.local_address;
+                let remote_addr = &mut tcp.remote_address;
+                local_addr.set_ip(local_addr.ip().to_canonical());
+                remote_addr.set_ip(remote_addr.ip().to_canonical());
+                if !(local_addr.is_ipv4() && remote_addr.is_ipv4()) {
+                    debug!("process #{pid} tcp entry {tcp:?} ignored because not ipv4");
+                    continue;
+                }
+
+                sockets.push(SockEntry {
+                    pid,
+                    proto: Protocol::Tcp,
+                    role: if listen_any.contains(&local_addr.port())
+                        || listen_spec.contains(&local_addr)
+                    {
+                        Role::Server
+                    } else {
+                        Role::Client
+                    },
+                    local: SockAddrData {
+                        epc_id: epc_id,
+                        ip: local_addr.ip(),
+                        port: local_addr.port(),
+                    },
+                    remote: SockAddrData {
+                        epc_id: convert_i32_epc_id(policy_getter.lookup_epc_by_epc(
+                            local_addr.ip(),
+                            remote_addr.ip(),
+                            epc_id as i32,
+                        )),
+                        ip: remote_addr.ip(),
+                        port: remote_addr.port(),
+                    },
+                    real_client: None,
+                    netns_idx: index as u16,
+                    netns: ns.clone(),
+                })
+            }
+
+            for mut udp in udp.into_iter().chain(udp6.into_iter()) {
+                let pid = match socket_inode_to_pid.get(&udp.inode) {
+                    Some(pid) => *pid,
+                    None => {
+                        debug!("process #{pid} udp entry {udp:?} ignored because inode not found or too recent");
+                        continue;
+                    }
+                };
+
+                if udp.remote_address.ip().is_unspecified() {
+                    // foreign addr is zero, indicate the udp socker create use bind(), no idea to determine the local and remote, ignore
+                    continue;
+                }
+
+                let local_addr = &mut udp.local_address;
+                let remote_addr = &mut udp.remote_address;
+                local_addr.set_ip(local_addr.ip().to_canonical());
+                remote_addr.set_ip(remote_addr.ip().to_canonical());
+                if !(local_addr.is_ipv4() && remote_addr.is_ipv4()) {
+                    debug!("process #{pid} udp entry {udp:?} ignored because not ipv4");
+                    continue;
+                }
+
+                sockets.push(SockEntry {
+                    pid,
+                    proto: Protocol::Udp,
+                    role: Role::Client,
+                    local: SockAddrData {
+                        epc_id: epc_id,
+                        ip: local_addr.ip(),
+                        port: local_addr.port(),
+                    },
+                    remote: SockAddrData {
+                        epc_id: convert_i32_epc_id(policy_getter.lookup_epc_by_epc(
+                            local_addr.ip(),
+                            remote_addr.ip(),
+                            epc_id as i32,
+                        )),
+                        ip: remote_addr.ip(),
+                        port: remote_addr.port(),
+                    },
+                    real_client: None,
+                    netns_idx: index as u16,
+                    netns: ns.clone(),
+                })
+            }
+
+            continue 'outer;
         }
+
+        debug!("unabled to find sockets in netns {ns}");
     }
+
+    Ok(sockets)
 }
 
 fn convert_i32_epc_id(epc_id: i32) -> u32 {
@@ -680,38 +478,39 @@ fn convert_i32_epc_id(epc_id: i32) -> u32 {
     }
 }
 
-/*
-    if sockaddr is ipv4, return self
-    if sockaddr is ipv6 and have prefix ::ffff:?:? or ::?:? (such as `::ffff:127.0.0.1`), is dual stack ip addr, convert to ipv4
-*/
-fn convert_addr_to_v4(addr: SocketAddr) -> Option<SocketAddr> {
-    const IPV6_V4_PREFIX: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255];
-    match &addr {
-        SocketAddr::V4(_) => Some(addr),
-        SocketAddr::V6(v6) => {
-            if &v6.ip().octets()[..12] != &IPV6_V4_PREFIX {
-                // not ipv6 dual stack addr
-                None
-            } else {
-                // extra latest 4 byte as ipv4 addr
-                Some(SocketAddr::new(
-                    IpAddr::V4(v6.ip().to_ipv4().unwrap()),
-                    v6.port(),
-                ))
-            }
-        }
-    }
+fn get_fd_ctime(proc_root: &str, pid: u32, fd: i32) -> Result<u64, std::io::Error> {
+    let path: PathBuf = [proc_root, &pid.to_string(), "fd", &fd.to_string()]
+        .iter()
+        .collect();
+    Ok(fs::symlink_metadata(path)?.st_ctime() as u64)
 }
 
-// return the (now_sec - sym_change_time) second
-pub(super) fn sym_uptime(now_sec: u64, path: &PathBuf) -> Result<u64, &'static str> {
-    // linux default not record the file birth time, use the change time instead of the birth time.
-    let s = std::fs::symlink_metadata(path)
-        .map_err(|_| "get symlink metadate fail")?
-        .st_ctime() as u64;
-    if now_sec >= s {
-        Ok(now_sec - s)
-    } else {
-        Err("sym up time after current")
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{config::handler::OsProcScanConfig, policy::Policy};
+
+    #[test]
+    fn get_all_sockets() {
+        let conf = OsProcScanConfig {
+            os_proc_root: "/proc".to_string(),
+            os_proc_socket_sync_interval: 1,
+            os_proc_socket_min_lifetime: 3,
+            os_app_tag_exec_user: "".to_string(),
+            os_app_tag_exec: vec![],
+            os_proc_sync_enabled: true,
+            os_proc_sync_tagged_only: false,
+        };
+        let (_, mut getter) = Policy::new(1, 0, 1 << 10, 1 << 14, false, false);
+        let pids = procfs::process::all_processes()
+            .unwrap()
+            .into_iter()
+            .map(|p| p.unwrap().pid() as u32)
+            .collect::<Vec<_>>();
+        let sockets = get_all_socket(&conf, &mut getter, 1, pids);
+        for s in sockets.unwrap().iter() {
+            println!("{s}");
+        }
     }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Branches:
- main
- 7.0
- 6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


