### PR TITLE
feat: resource events first get gprocess info from podId

### DIFF
--- a/server/ingester/event/decoder/decoder.go
+++ b/server/ingester/event/decoder/decoder.go
@@ -338,7 +338,7 @@ func (d *Decoder) handleResourceEvent(event *eventapi.ResourceEvent) {
 	podGroupType := uint8(0)
 	if event.IfNeedTagged {
 		s.Tagged = 1
-		resourceInfo := d.platformData.QueryResourceInfo(s.OrgId, event.InstanceType, event.InstanceID)
+		resourceInfo := d.platformData.QueryResourceInfo(s.OrgId, event.InstanceType, event.InstanceID, event.PodID)
 		if resourceInfo != nil {
 			s.RegionID = uint16(resourceInfo.RegionID)
 			s.AZID = uint16(resourceInfo.AZID)

--- a/server/libs/grpc/grpc_platformdata.go
+++ b/server/libs/grpc/grpc_platformdata.go
@@ -389,7 +389,7 @@ func (t *PlatformInfoTable) QueryCustomService(orgId uint16, epcID int32, isIPv6
 	return t.ServiceTable[orgId].QueryCustomService(epcID, isIPv6, ipv4, ipv6, serverPort)
 }
 
-func (t *PlatformInfoTable) QueryResourceInfo(orgId uint16, resourceType uint32, resourceID uint32) *Info {
+func (t *PlatformInfoTable) QueryResourceInfo(orgId uint16, resourceType, resourceID, podID uint32) *Info {
 	switch trident.DeviceType(resourceType) {
 	case trident.DeviceType_DEVICE_TYPE_POD:
 		return t.podIDInfos[orgId][resourceID]
@@ -400,6 +400,9 @@ func (t *PlatformInfoTable) QueryResourceInfo(orgId uint16, resourceType uint32,
 	case trident.DeviceType_DEVICE_TYPE_VM:
 		return t.vmInfos[orgId][resourceID]
 	case trident.DeviceType_DEVICE_TYPE_PROCESS:
+		if podID > 0 {
+			return t.QueryPodIdInfo(orgId, podID)
+		}
 		if _, podId := t.QueryGprocessInfo(orgId, resourceID); podId > 0 {
 			return t.QueryPodIdInfo(orgId, podId)
 		}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


