### PR TITLE
feat: agent - eBPF Obtain the mount point for file (#10057)

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -92,6 +92,7 @@ OBJS := user/elf.o \
 	user/mem.o \
 	user/vec.o \
 	user/bihash.o \
+	user/mount.o \
 	user/profile/profile_common.o \
 	$(patsubst %.c,%.o,$(wildcard user/extended/*.c)) \
 	$(patsubst %.c,%.o,$(wildcard user/extended/profile/*.c)) \

--- a/agent/src/ebpf/kernel/files_rw.bpf.c
+++ b/agent/src/ebpf/kernel/files_rw.bpf.c
@@ -33,10 +33,11 @@ static __inline bool is_regular_file(int fd,
 }
 
 static __inline void set_file_metric_data(struct __io_event_buffer *buffer,
+					  struct __socket_data *v,
 					  int fd,
 					  struct member_fields_offset *off_ptr)
 {
-#define MAX_DIRECTORY_DEPTH 20
+#define MAX_DIRECTORY_DEPTH 19
 
 	struct member_fields_offset *offset = off_ptr;
 	if (offset == NULL) {
@@ -48,9 +49,39 @@ static __inline void set_file_metric_data(struct __io_event_buffer *buffer,
 	if (file == NULL)
 		return;
 
+	/*
+	 * Get the underlying device number of the superblock, which indicates
+	 * the device where the file system is mounted, and use it in user space
+	 * to determine the mount point of the file.
+	 *
+	 * struct file {
+	 *    ...
+	 *    struct inode *f_inode;
+	 * };
+	 * struct inode {
+	 *    ...
+	 *    struct super_block *i_sb;
+	 * };
+	 * struct super_block {
+	 *    ...
+	 *    kern_dev_t s_dev;
+	 * };
+	 */
+	void *f_inode = NULL, *i_sb = NULL;
+	bpf_probe_read_kernel(&f_inode, sizeof(f_inode),
+			      file + offset->struct_file_f_inode_offset);
+	if (!f_inode)
+		return;
+
+	bpf_probe_read_kernel(&i_sb, sizeof(i_sb),
+			      f_inode + offset->struct_inode_i_sb_offset);
+	if (!i_sb)
+		return;
+
+	bpf_probe_read_kernel(&v->s_dev, sizeof(v->s_dev),
+			      i_sb + offset->struct_super_block_s_dev_offset);
 	bpf_probe_read_kernel(&buffer->offset, sizeof(buffer->offset),
 			      file + offset->struct_file_f_pos_offset);
-
 	void *dentry = NULL, *parent;
 	bpf_probe_read_kernel(&dentry, sizeof(dentry),
 			      file + offset->struct_file_dentry_offset);
@@ -133,7 +164,6 @@ static __inline int trace_io_event_common(void *ctx,
 	buffer->bytes_count = data_args->bytes_count;
 	buffer->latency = latency;
 	buffer->operation = direction;
-	set_file_metric_data(buffer, data_args->fd, offset);
 	struct __socket_data_buffer *v_buff =
 	    bpf_map_lookup_elem(&NAME(data_buf), &k0);
 	if (!v_buff)
@@ -149,15 +179,14 @@ static __inline int trace_io_event_common(void *ctx,
 
 	v = (struct __socket_data *)(v_buff->data + v_buff->len);
 	__builtin_memset(v, 0, offsetof(typeof(struct __socket_data), data));
+	set_file_metric_data(buffer, v, data_args->fd, offset);
+	v->fd = data_args->fd;
 	v->tgid = tgid;
 	v->pid = (__u32) pid_tgid;
 	v->coroutine_id = trace_key.goid;
 	v->timestamp = data_args->enter_ts;
-
 	v->syscall_len = sizeof(*buffer);
-
 	v->source = DATA_SOURCE_IO_EVENT;
-
 	v->thread_trace_id = trace_id;
 	v->msg_type = MSG_COMMON;
 	bpf_get_current_comm(v->comm, sizeof(v->comm));

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -61,7 +61,10 @@ struct __socket_data {
 	__u32 extra_data_count;
 
 	/* 追踪信息 */
-	__u32 tcp_seq;
+	union {
+		__u32 tcp_seq;
+		__u32 s_dev; // Device number of the superblock, which indicates the device where the file system is mounted.
+	};
 	__u64 thread_trace_id;
 
 	/* 追踪数据信息 */
@@ -71,7 +74,10 @@ struct __socket_data {
 	__u8 is_tls:1;
 
 	__u64 syscall_len;	// 本次系统调用读、写数据的总长度
-	__u64 data_seq;		// cap_data在Socket中的相对顺序号
+	union {
+		__u64 data_seq;		// cap_data在Socket中的相对顺序号
+		__u32 fd;
+	};
 	__u16 data_type;	// HTTP, DNS, MySQL
 	__u16 data_len;		// 数据长度
 	__u8 socket_role;	// this message is created by: 0:unkonwn 1:client(connect) 2:server(accept)
@@ -346,6 +352,8 @@ struct member_fields_offset {
 	__u32 struct_files_private_data_offset;	// offsetof(struct file, private_data)
 	__u32 struct_file_f_inode_offset;	// offsetof(struct file, f_inode)
 	__u32 struct_inode_i_mode_offset;	// offsetof(struct inode, i_mode)
+	__u32 struct_inode_i_sb_offset;		// offsetof(struct inode, i_sb)
+	__u32 struct_super_block_s_dev_offset;	// offsetof(struct super_block, s_dev)
 	__u32 struct_file_dentry_offset;	// offsetof(struct file, f_path) + offsetof(struct path, dentry)
 	__u32 struct_dentry_name_offset;	// offsetof(struct dentry, d_name) + offsetof(struct qstr, name)
 	__u32 struct_sock_family_offset;	// offsetof(struct sock_common, skc_family)

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -382,4 +382,18 @@ enum cfg_feature_idx {
  */
 #define PERIODIC_PUSH_DELAY_THRESHOLD_NS 50000000ULL	// 50 milliseconds
 
+/*
+ * The update interval for process information is 5 minutes in nanoseconds.
+ */
+#define PROCESS_CACHE_UPDATE_INTERVAL_NS 300000000000ULL
+
+/*
+ * The update interval for mount information is 20 secs in nanoseconds.
+ */
+#define MOUNT_CACHE_UPDATE_INTERVAL_NS 20000000000ULL
+
+/*
+ * Output to the log once every hour to prevent the log file from containing too much content.
+ */
+#define OUTPUT_LOG_INTERVAL_NS 3600000000000ULL
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/mount.c
+++ b/agent/src/ebpf/user/mount.c
@@ -1,0 +1,611 @@
+/*
+ * Copyright (c) 2025 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <arpa/inet.h>
+#include <sched.h>
+#include <sys/stat.h>
+#include <sys/prctl.h>
+#include "clib.h"
+#include "symbol.h"
+#include "proc.h"
+#include "tracer.h"
+#include "probe.h"
+#include "table.h"
+#include "utils.h"
+#include "socket.h"
+#include "log.h"
+#include "config.h"
+
+#define MOUNT_INFO_NULL      ((struct mount_info *)0)
+#define MOUNT_INFO_INVAL     ((struct mount_info *)(intptr_t)-1)
+#define IS_MOUNT_INFO_ERR(ptr) (ptr == MOUNT_INFO_NULL || ptr == MOUNT_INFO_INVAL)
+mount_info_hash_t mount_info_hash;
+// Stores the mount namespace ID of the host root
+static u64 host_root_mntns_id = 0;
+
+// Stores the hash value of the host root's mountinfo data
+static u32 host_root_mountinfo_hash = 0;
+
+static bool inline enable_mount_info_cache(void)
+{
+	return (mount_info_hash.buckets != NULL);
+}
+
+static int hash_mountinfo_file(pid_t pid, u32 * out_hash)
+{
+	if (!out_hash)
+		return -1;
+
+	char path[64];
+	snprintf(path, sizeof(path), "/proc/%d/mountinfo", pid);
+
+	FILE *fp = fopen(path, "rb");
+	if (!fp) {
+		return -1;
+	}
+
+	const u32 seed = 0;
+	u32 hash = seed;
+
+	unsigned char buffer[4096];
+	size_t read_len;
+
+	while ((read_len = fread(buffer, 1, sizeof(buffer), fp)) > 0) {
+		hash = murmurhash(buffer, read_len, hash);
+	}
+
+	if (ferror(fp)) {
+		fclose(fp);
+		return -1;
+	}
+
+	fclose(fp);
+
+	*out_hash = hash;
+	return 0;
+}
+
+int get_mount_ns_id(pid_t pid, u64 * mntns_id)
+{
+	if (mntns_id == NULL) {
+		return -1;
+	}
+
+	char path[64];
+	struct stat st;
+
+	// Construct path: /proc/[pid]/ns/mnt
+	snprintf(path, sizeof(path), "/proc/%d/ns/mnt", pid);
+
+	// Use stat() to retrieve inode number (which is the mount namespace ID)
+	if (stat(path, &st) == -1) {
+		ebpf_debug("The stat() call failed with error "
+			   "message: \"%s\", and error number: %d.",
+			   strerror(errno), errno);
+		return -1;	// errno is set by stat()
+	}
+
+	*mntns_id = (u64) st.st_ino;
+	return 0;
+}
+
+static bool has_mount_entry(struct list_head *mount_head, kern_dev_t s_dev)
+{
+	struct list_head *p, *n;
+	struct mount_entry *e;
+	if (!mount_head->next)
+		return false;
+	list_for_each_safe(p, n, mount_head) {
+		e = container_of(p, struct mount_entry, list);
+		if (e && e->s_dev == s_dev)
+			return true;
+	}
+
+	return false;
+}
+
+void find_mount_point_path(pid_t pid, u64 * mntns_id, kern_dev_t s_dev,
+			   char *mount_path, char *mount_source,
+			   int mount_size, bool * is_nfs)
+{
+	struct list_head *p, *n;
+	struct mount_entry *e;
+	struct mount_info *m = mount_info_cache_lookup(pid, *mntns_id);
+	if (m == MOUNT_INFO_INVAL)
+		return;
+
+	if (m == MOUNT_INFO_NULL) {
+		get_mount_ns_id(pid, mntns_id);
+		m = create_proc_mount_info(pid, *mntns_id);
+		if (m == NULL)
+			return;
+		AO_INC(&m->refcount);
+	}
+
+	if (!m->mount_head.next) {
+		AO_DEC(&m->refcount);
+		return;
+	}
+
+	list_for_each_safe(p, n, &m->mount_head) {
+		e = container_of(p, struct mount_entry, list);
+		if (e && e->s_dev == s_dev) {
+			fast_strncat_trunc(e->mount_point, "", mount_path, mount_size);
+			fast_strncat_trunc(e->mount_source, "", mount_source, mount_size);
+			*is_nfs = e->is_nfs;
+			break;
+		}
+	}
+
+	AO_DEC(&m->refcount);
+}
+
+int mount_info_cache_init(const char *name)
+{
+	// Get the mount namespace ID of the host root.
+	get_mount_ns_id(1, &host_root_mntns_id);
+	// Get host root's mountinfo data
+	hash_mountinfo_file(1, &host_root_mountinfo_hash);
+	mount_info_hash_t *h = &mount_info_hash;
+	memset(h, 0, sizeof(*h));
+	u32 nbuckets = SYMBOLIZER_CACHES_HASH_BUCKETS_NUM;
+	u64 hash_memory_size = SYMBOLIZER_CACHES_HASH_MEM_SZ;	// 2G bytes
+	return mount_info_hash_init(h, (char *)name, nbuckets,
+				    hash_memory_size);
+}
+
+struct mount_info *mount_info_cache_lookup(pid_t pid, u64 mntns_id)
+{
+	if (mntns_id == 0 && pid > 0) {
+		if (get_mount_ns_id(pid, &mntns_id))
+			return MOUNT_INFO_INVAL;
+	}
+
+	mount_info_hash_t *h = &mount_info_hash;
+	struct mount_cache_kvp kv;
+	kv.k.mntns_id = mntns_id;
+	kv.v.mount_info_p = 0;
+	struct mount_info *p = NULL;
+	if (mount_info_hash_search(h, (mount_info_hash_kv *) & kv,
+				   (mount_info_hash_kv *) & kv) == 0) {
+		p = (struct mount_info *)kv.v.mount_info_p;
+		AO_INC(&p->refcount);
+		return p;
+	}
+
+	return MOUNT_INFO_NULL;
+}
+
+static void free_mount_info(struct mount_info *m)
+{
+	// Ensure there are no references before releasing.
+	while (AO_GET(&m->refcount) > 1)
+		CLIB_PAUSE();
+
+	struct list_head *p, *n;
+	struct mount_entry *e;
+	if (!m->mount_head.next)
+		goto exit;
+
+	list_for_each_safe(p, n, &m->mount_head) {
+		e = container_of(p, struct mount_entry, list);
+		if (e) {
+			list_head_del(&e->list);
+			free(e->mount_point);
+			free(e->mount_source);
+			free(e);
+		}
+	}
+
+exit:
+	ebpf_info("Release mount information: mntns_id %lu entry_count %d"
+		  " proc_count %d refcount %d bytes_count %u bytes.\n",
+		  m->mntns_id, m->entry_count, m->proc_count,
+		  m->refcount, m->bytes_count);
+	free(m);
+}
+
+static int delete_mount_info_from_cache(pid_t pid, struct mount_info *m)
+{
+	if (m->mntns_id == host_root_mntns_id)
+		return -1;
+	mount_info_hash_t *h = &mount_info_hash;
+	struct mount_cache_kvp kv;
+	kv.k.mntns_id = m->mntns_id;
+	kv.v.mount_info_p = 0;
+	if (mount_info_hash_add_del
+	    (h, (mount_info_hash_kv *) & kv, 0 /* delete */ )) {
+		ebpf_warning("failed.(pid %d, mntns_id %lu)\n", pid,
+			     m->mntns_id);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int add_mount_info_to_cache(pid_t pid, struct mount_info *m)
+{
+	mount_info_hash_t *h = &mount_info_hash;
+	struct mount_cache_kvp kv;
+	kv.k.mntns_id = m->mntns_id;
+	kv.v.mount_info_p = pointer_to_uword(m);
+	if (mount_info_hash_add_del
+	    (h, (mount_info_hash_kv *) & kv,
+	     2 /* is_add = 2, Add but do not overwrite?  */ )) {
+		ebpf_warning("failed.(pid %d, mntns_id %lu)\n", pid,
+			     m->mntns_id);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int build_mount_info(pid_t pid, struct list_head *mount_head,
+			    u32 * bytes_count)
+{
+	char path[64];
+	int count = 0;
+	*bytes_count = 0;
+	memset(mount_head, 0, sizeof(*mount_head));
+	snprintf(path, sizeof(path), "/proc/%d/mountinfo", pid);
+	FILE *fp = fopen(path, "r");
+	if (!fp) {
+		ebpf_warning("fopen '%s' failed with %s(%d)\n", path,
+			     strerror(errno), errno);
+		return -1;
+	}
+
+	init_list_head(mount_head);
+	char line[PATH_MAX];
+	while (fgets(line, sizeof(line), fp)) {
+		// mountinfo format ref: https://man7.org/linux/man-pages/man5/proc.5.html
+		int id, parent, major, minor;
+		char root[MAX_PATH_LENGTH], mount_point[MAX_PATH_LENGTH];
+		char fs_type[64], mount_source[MAX_PATH_LENGTH];
+		// [ID] [ParentID] [major:minor] [fs_root] [mount_point] [options] - [fs_type] [mount_source] [fs_options]
+		// Example: 44 32 0:36 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw
+		int matched = sscanf(line, "%d %d %d:%d %s %s %*[^-] - %s %s",
+				     &id, &parent, &major, &minor, root,
+				     mount_point, fs_type, mount_source);
+		if (matched != 8)
+			continue;
+
+		bool is_nfs = strncmp("nfs", fs_type, 3) == 0;
+		/*
+		 * Filter out bind mounts, because for bind mounts, the data obtained via eBPF starts from
+		 * `[fs_root]`, which is already a path on the host. There's no need to translate it into
+		 * the mount point path inside the container.
+		 * For example, a path like `/var/lib/mysql/xxxx.data` is already a host path and does not
+		 * need to be translated into `/bitnami/mysql/xxxx.data` (which is the container path).
+		 * e.g.: 1729 1710 253:0 /var/lib/mysql /bitnami/mysql rw,relatime - xfs /dev/mapper/centos-root rw,attr2,inode64,noquota
+		 */
+		if (!(root[0] == '/' && root[1] == '\0') && !is_nfs)
+			continue;
+
+		kern_dev_t s_dev = ((major & 0xfff) << 20) | (minor & 0xfffff);
+		if (has_mount_entry(mount_head, s_dev))
+			continue;
+		struct mount_entry *entry =
+		    calloc(1, sizeof(struct mount_entry));
+		if (entry == NULL) {
+			ebpf_warning("calloc failed with %s(%d)\n",
+				     strerror(errno), errno);
+			goto exit;
+		}
+
+		entry->s_dev = s_dev;
+		entry->is_nfs = is_nfs;
+		entry->mount_point = strdup(mount_point);
+		if (entry->mount_point == NULL) {
+			free(entry);
+			goto exit;
+		}
+		entry->mount_source = strdup(mount_source);
+		if (entry->mount_source == NULL) {
+			free(entry);
+			free(entry->mount_point);
+			goto exit;
+		}
+
+		count++;
+		*bytes_count +=
+		    (strlen(entry->mount_point) + strlen(entry->mount_source) +
+		     2);
+		list_add_tail(&entry->list, mount_head);
+	}
+
+exit:
+	fclose(fp);
+	if (*bytes_count > 0 && count > 0)
+		*bytes_count += (count * sizeof(struct mount_entry));
+	return count;
+}
+
+struct mount_info *create_proc_mount_info(pid_t pid, u64 mntns_id)
+{
+	struct mount_info *m;
+	// Mount info is not currently available and needs to be rebuilt.
+	m = (struct mount_info *)calloc(1, sizeof(*m));
+	if (m == NULL) {
+		ebpf_warning("calloc() failed with error "
+			     "message: \"%s\", and error number: %d.",
+			     strerror(errno), errno);
+		goto err;
+	}
+
+	m->proc_count = 1;
+	m->mntns_id = mntns_id;
+	m->refcount = 0;
+	m->entry_count = build_mount_info(pid, &m->mount_head, &m->bytes_count);
+	if (m->entry_count == -1 || m->entry_count == 0)
+		goto err;
+
+	m->bytes_count += sizeof(*m);
+	hash_mountinfo_file(pid, &m->file_hash);
+	if (add_mount_info_to_cache(pid, m))
+		goto err;
+
+	ebpf_info
+	    ("Create mount information: pid %d mntns_id %lu entry_count "
+	     "%d proc_count %d refcount %d bytes_count %u bytes\n",
+	     pid, m->mntns_id, m->entry_count, m->proc_count,
+	     m->refcount, m->bytes_count);
+
+	return m;
+err:
+	if (m)
+		free_mount_info(m);
+
+	return NULL;
+}
+
+// Called when the process execute
+int mount_info_cache_add_if_absent(pid_t pid, u64 mntns_id)
+{
+	struct mount_info *m = mount_info_cache_lookup(pid, mntns_id);
+	if (m == MOUNT_INFO_INVAL) {
+		return -1;
+	} else if (m == MOUNT_INFO_NULL) {
+		if (create_proc_mount_info(pid, mntns_id) == NULL)
+			return -1;
+	} else {
+		// It already exists in the cache; the process count needs to be incremented.
+		AO_INC(&m->proc_count);
+		AO_DEC(&m->refcount);
+	}
+
+	return 0;
+}
+
+// Called when the process exits
+int mount_info_cache_remove(pid_t pid, u64 mntns_id)
+{
+	struct mount_info *m = mount_info_cache_lookup(pid, mntns_id);
+	if (IS_MOUNT_INFO_ERR(m))
+		return -1;
+
+	// No processes are sharing the mount namespace anymore.
+	if (AO_SUB_F(&m->proc_count, 1) == 0) {
+		if (delete_mount_info_from_cache(pid, m) == 0)
+			free_mount_info(m);
+		else
+			AO_DEC(&m->refcount);
+
+		return 0;
+	}
+
+	AO_DEC(&m->refcount);
+	return 0;
+}
+
+static u64 mnt_bytes;
+static int check_mount_kvp_cb(mount_info_hash_kv * kvp, void *ctx)
+{
+	struct mount_cache_kvp *kv = (struct mount_cache_kvp *)kvp;
+	struct mount_info *p = NULL;
+	if (kv->v.mount_info_p) {
+		p = (struct mount_info *)kv->v.mount_info_p;
+		AO_INC(&p->refcount);
+		mnt_bytes += p->bytes_count;
+		AO_DEC(&p->refcount);
+		ebpf_debug("mount info file_hash %u %u mntns_id %lu"
+			   " proc_count %d refcount %d entry_count %d bytes_count %u bytes.\n",
+			   p->file_hash, p->mntns_id, p->proc_count,
+			   p->refcount, p->entry_count, p->bytes_count);
+	}
+
+	(*(u64 *) ctx)++;
+	return BIHASH_WALK_CONTINUE;
+}
+
+void collect_mount_info_stats(bool output_log)
+{
+	u64 elems_count = 0;
+	mount_info_hash_t *h = &mount_info_hash;
+	mount_info_hash_foreach_key_value_pair(h,
+					       check_mount_kvp_cb,
+					       (void *)&elems_count);
+	if (output_log)
+		ebpf_info("Checked %d entries in the mount info cache, "
+			  "occupies %lu bytes of memory.\n",
+			  elems_count, mnt_bytes);
+	mnt_bytes = 0;
+}
+
+void check_and_cleanup_mount_info(pid_t pid, u64 mntns_id)
+{
+	struct mount_info *m = mount_info_cache_lookup(pid, mntns_id);
+	if (IS_MOUNT_INFO_ERR(m))
+		return;
+
+	u32 new_hash = 0;
+	if (hash_mountinfo_file(pid, &new_hash)) {
+		AO_DEC(&m->refcount);
+		return;
+	}
+
+	if (new_hash != m->file_hash) {
+		if (delete_mount_info_from_cache(pid, m) == 0)
+			free_mount_info(m);
+		else
+			AO_DEC(&m->refcount);
+
+		return;
+	}
+
+	AO_DEC(&m->refcount);
+}
+
+// Periodically check whether the host node's mount information has changed.
+void check_root_mount_info(bool output_log)
+{
+	u32 new_hash = 0;
+	hash_mountinfo_file(1, &new_hash);
+	if (new_hash != 0 && new_hash != host_root_mountinfo_hash) {
+		u64 tmp_mntns_id = host_root_mntns_id;
+		struct mount_info *m =
+		    mount_info_cache_lookup(1, host_root_mntns_id);
+		if (!IS_MOUNT_INFO_ERR(m)) {
+			// Ensure that the root mount point can be cleaned up.
+			host_root_mntns_id = 0;
+			if (delete_mount_info_from_cache(1, m) == 0)
+				free_mount_info(m);
+			else
+				AO_DEC(&m->refcount);
+			host_root_mntns_id = tmp_mntns_id;
+		}
+
+		ebpf_info
+		    ("The mount information of the host root namespace has changed; updating the mount info.\n");
+		host_root_mountinfo_hash = new_hash;
+	}
+}
+
+/*
+ * Replace the longest suffix of str1 (that is a prefix of str2) with str1.
+ * Result is written to 'out' with a maximum size of 'out_size'.
+ * e.g.:
+ *    const char *str1 = "10.33.49.27:/srv/nfs/data"; (mount source)
+ *    const char *str2 = "/nfs/data/ddd"; (file path via eBPF)
+ *    const char *new_prefix = "/mnt/nfs"; (mount point)
+ * target: "10.33.49.27:/srv/nfs/data/ddd"
+ */
+static int replace_suffix_prefix(const char *str1, const char *str2,
+				 const char *new_prefix
+				 __attribute__ ((unused)), char *out,
+				 size_t out_size)
+{
+	size_t len1 = strlen(str1);
+	size_t len2 = strlen(str2);
+
+	// Try all possible suffixes of str1
+	for (size_t i = 0; i < len1; ++i) {
+		const char *suffix = str1 + i;
+		size_t suffix_len = len1 - i;
+
+		// Check if this suffix matches the prefix of str2
+		if (suffix_len <= len2
+		    && strncmp(suffix, str2, suffix_len) == 0) {
+			// Match found: replace the suffix with new_prefix
+			return fast_strncat_trunc(str1, str2 + suffix_len, out,
+						  out_size);
+		}
+	}
+
+	// No match found: copy str2 as-is
+	return fast_strncat_trunc(str2, "", out, out_size);
+}
+
+u32 copy_regular_file_data(int pid, void *dst, void *src, int len,
+			   const char *mount_point, const char *mount_source,
+			   bool is_nfs)
+{
+	if (len <= 0)
+		return 0;
+
+	struct user_io_event_buffer *u_event;
+	struct __io_event_buffer *event = (struct __io_event_buffer *)src;
+	char *buffer = event->filename;
+	u32 buffer_len = event->len;
+	u32 buf_offset =
+	    offsetof(typeof(struct user_io_event_buffer), filename);
+
+	/*
+	 * Due to the maximum length limitation of the data, the file
+	 * path may be truncated. Here, only the valid length is considered.
+	 */
+	if (buf_offset + buffer_len > len) {
+		buffer_len = len - buf_offset;
+	}
+
+	int event_len;
+	int i, temp_index = 0;
+	char temp[buffer_len + 1];
+	temp[0] = '\0';
+
+	/*
+	 * The path content is in the form "a\0b\0c\0" and needs to
+	 * be converted into the directory format "/c/b/a".
+	 *
+	 * e.g.:
+	 *
+	 * buffer "comm\019317\0task\032148\0/\0"
+	 * convert to "/32148/task/19317/comm"
+	 */
+	if (buffer_len <= 1)
+		goto copy_event;
+
+	char *p;
+	int copy_len;
+	for (i = buffer_len - 2; i >= 0; i--) {
+		if (i == 0) {
+			p = &buffer[0];
+		} else {
+			if (buffer[i] != '\0')
+				continue;
+			p = &buffer[i + 1];
+		}
+
+		copy_len =
+		    fast_strncat_trunc(p, (temp_index > 0 && i != 0) ? "/" : "",
+				       temp + temp_index,
+				       sizeof(temp) - temp_index);
+		temp_index += copy_len;
+	}
+
+copy_event:
+	u_event = (struct user_io_event_buffer *)dst;
+	buffer = u_event->filename;
+	if (is_nfs)
+		temp_index =
+		    replace_suffix_prefix(mount_source, temp, mount_point,
+					  buffer, sizeof(event->filename));
+	else
+		temp_index =
+		    fast_strncat_trunc(mount_point, temp, buffer,
+				       sizeof(event->filename));
+
+	buffer_len = temp_index + 1;
+	u_event->bytes_count = event->bytes_count;
+	u_event->operation = event->operation;
+	u_event->latency = event->latency;
+	u_event->offset = event->offset;
+	event_len = offsetof(typeof(struct user_io_event_buffer),
+			     filename) + buffer_len;
+	return event_len;
+}

--- a/agent/src/ebpf/user/mount.h
+++ b/agent/src/ebpf/user/mount.h
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DF_USER_MOUNT_H
+#define DF_USER_MOUNT_H
+/*
+ * mount_info_hash_t maps from pid to BCC symbol cache.
+ */
+
+#define mount_info_hash_t        clib_bihash_8_8_t
+#define mount_info_hash_init     clib_bihash_init_8_8
+#define mount_info_hash_kv       clib_bihash_kv_8_8_t
+#define print_hash_mount_info    print_bihash_8_8
+#define mount_info_hash_search   clib_bihash_search_8_8
+#define mount_info_hash_add_del  clib_bihash_add_del_8_8
+#define mount_info_hash_free     clib_bihash_free_8_8
+#define mount_info_hash_key_value_pair_cb        clib_bihash_foreach_key_value_pair_cb_8_8
+#define mount_info_hash_foreach_key_value_pair   clib_bihash_foreach_key_value_pair_8_8
+
+typedef u32 kern_dev_t;
+#define DEV_INVALID ((kern_dev_t)-1)
+
+/**
+ * struct mount_entry - Represents a mount point within a mount namespace
+ * @list:         Linked list node for chaining multiple mount entries
+ * @s_dev:        Device ID (from stat.st_dev), typically encoded as major:minor
+ * @is_nfs:       True if the mount source is a network file system (e.g., NFS)
+ * @mount_point:  Absolute path of the mount point (e.g., "/mnt/data")
+ * @mount_source: Source of the mount (e.g., "/dev/sda1" or "host:/export")
+ */
+struct mount_entry {
+	struct list_head list;
+	kern_dev_t s_dev;
+	bool is_nfs;
+	char *mount_point;
+	char *mount_source;
+};
+
+/**
+ * struct mount_info - Stores parsed mount namespace metadata
+ * @mount_head:   Linked list node for chaining mount_info structures
+ * @refcount:     Reference count indicating how many references exist to this structure
+ * @proc_count:   Number of processes sharing this mount namespace
+ * @mntns_id:     Mount namespace ID (typically from stat.st_dev or nsfs inode)
+ * @bytes_count:  How many bytes does the mount information occupy in total?
+ * @file_hash:    Hash of the /proc/<create_pid>/mountinfo file, used to detect changes
+ * @entry_count:  Number of mount entries associated with this namespace
+ */
+struct mount_info {
+	struct list_head mount_head;
+	int refcount;
+	int proc_count;
+	u64 mntns_id;
+	u32 bytes_count;
+	u32 file_hash;
+	int entry_count;
+};
+
+struct mount_cache_kvp {
+	struct {
+		u64 mntns_id;
+	} k;
+
+	struct {
+		u64 mount_info_p;
+	} v;
+};
+
+/**
+ * @brief Initialize the mount info cache.
+ *
+ * @param[in] name  A name label for logging or internal hash structure
+ * @return 0 on success, -1 on failure
+ */
+int mount_info_cache_init(const char *name);
+
+/**
+ * @brief Retrieve mount namespace ID for the given PID.
+ *
+ * @param[in]  pid        Target process PID
+ * @param[out] mntns_id   Pointer to store mount namespace inode
+ * @return 0 on success, -1 on failure
+ */
+int get_mount_ns_id(pid_t pid, u64 * mntns_id);
+
+/**
+ * @brief Lookup mount info from cache using PID or mount ns ID.
+ *
+ * @param[in] pid        Process ID (can be 0 if mntns_id is specified)
+ * @param[in] mntns_id   Mount namespace ID (0 means lookup by PID)
+ * @return pointer to mount_info on hit, MOUNT_INFO_NULL or MOUNT_INFO_INVAL on miss/failure
+ */
+struct mount_info *mount_info_cache_lookup(pid_t pid, u64 mntns_id);
+
+/**
+ * @brief Add mount info to cache if not already present.
+ *
+ * Called when a process starts. If the mount info does not exist in cache,
+ * it will be parsed and added. If it exists, increases process count.
+ *
+ * @param[in] pid        Process ID
+ * @param[in] mntns_id   Mount namespace ID
+ * @return 0 on success, -1 on failure
+ */
+int mount_info_cache_add_if_absent(pid_t pid, u64 mntns_id);
+
+/**
+ * @brief Remove reference to mount info in cache on process exit.
+ *
+ * Decreases process count. If count reaches 0, the mount info is deleted.
+ *
+ * @param[in] pid        Process ID
+ * @param[in] mntns_id   Mount namespace ID
+ * @return 0 on success, -1 on failure
+ */
+int mount_info_cache_remove(pid_t pid, u64 mntns_id);
+
+/**
+ * @brief Find the mount path and source device for a given device ID in a namespace.
+ *
+ * @param[in]  pid            Process ID
+ * @param[in/out]  mntns_id   Mount namespace ID adress
+ * @param[in]  s_dev          Device ID (major:minor encoded)
+ * @param[out] mount_path     Output buffer for mount point path
+ * @param[out] mount_source   Output buffer for mount source (e.g., device or NFS path)
+ * @param[in]  mount_size     Size of output buffers
+ * @param[out] is_nfs         Set to true if the mount is NFS
+ */
+void find_mount_point_path(pid_t pid, u64 * mntns_id, kern_dev_t s_dev,
+			   char *mount_path, char *mount_source,
+			   int mount_size, bool * is_nfs);
+
+/**
+ * @brief Copy and transform event data containing file paths from eBPF trace.
+ *
+ * For NFS mounts, replaces path prefix using mount source; otherwise uses mount point.
+ *
+ * @param[in]  pid           Process ID
+ * @param[out] dst           Destination buffer
+ * @param[in]  src           Source buffer (raw eBPF event)
+ * @param[in]  len           Length of destination buffer
+ * @param[in]  mount_point   Mount point path
+ * @param[in]  mount_source  Mount source path
+ * @param[in]  is_nfs        True if mount is NFS
+ * @return Number of bytes written to dst
+ */
+uint32_t copy_regular_file_data(int pid, void *dst, void *src, int len,
+				const char *mount_point,
+				const char *mount_source, bool is_nfs);
+/**
+ * @brief Check for changes in the host root mount namespace's mount information.
+ *
+ * This function periodically computes the hash of `/proc/1/mountinfo` to detect
+ * changes in the host root's mount namespace. If a change is detected, the old
+ * cached mount information is removed and the updated data is re-added to the cache.
+ *
+ * It uses PID 1 (usually the init process) as a reference for the host root mount namespace.
+ *
+ * @param output_log       Should a log be output?
+ *
+ * @note This function assumes `host_root_mountinfo_hash` and `host_root_mntns_id`
+ *       are globally defined and initialized appropriately.
+ */
+void check_root_mount_info(bool output_log);
+
+/**
+ * create_proc_mount_info - Create and cache mount information for a process
+ * @pid:        The process ID whose mountinfo should be parsed
+ * @mntns_id:   The mount namespace ID associated with the process
+ *
+ * This function creates a new mount_info structure for the given process ID,
+ * parses the mount entries under /proc/[pid]/mountinfo, and stores the result
+ * into an internal cache.
+ *
+ * Return: struct mount_info address on success, NULL on failure.
+ */
+struct mount_info *create_proc_mount_info(pid_t pid, u64 mntns_id);
+
+/**
+ * check_and_cleanup_mount_info - Check if a mount_info entry is stale and remove it if needed
+ * @pid:        PID of the process associated with the mount namespace
+ * @mntns_id:   Mount namespace identifier (typically from nsfs or stat)
+ *
+ * This function searches for the mount_info entry associated with the given
+ * mount namespace. It verifies whether the cached entry is outdated by comparing
+ * the current hash of /proc/[pid]/mountinfo with the stored file_hash.
+ * If the entry is determined to be stale (e.g., the file has changed or is no longer used),
+ * it is removed from the cache and cleaned up.
+ *
+ * This helps prevent stale mount namespace information from persisting in memory.
+ */
+void check_and_cleanup_mount_info(pid_t pid, u64 mntns_id);
+
+/**
+ * collect_mount_info_stats - Traverse and optionally log statistics about mount info cache
+ * @output_log: If true, logs the number of checked entries in the mount info cache
+ *
+ * This function iterates through all key-value pairs in the mount_info_hash cache,
+ * using a callback to check and optionally update statistics such as the number of entries.
+ * It can optionally output a log message summarizing the number of entries examined.
+ * 
+ * After traversal, it resets the global variable `mnt_bytes` to 0, possibly preparing
+ * for future accumulation of mount memory size statistics.
+ */
+void collect_mount_info_stats(bool output_log);
+#endif /* DF_USER_MOUNT_H */

--- a/agent/src/ebpf/user/proc.c
+++ b/agent/src/ebpf/user/proc.c
@@ -89,12 +89,6 @@ static struct ring *proc_event_ring;
  */
 static volatile u64 java_syms_fetch_delay;	// In seconds.
 
-/*
- * When a process exits, save the symbol cache pids
- * to be deleted.
- */
-static struct symbol_cache_pids pids_cache;
-
 static struct bcc_symbol_option lazy_opt = {
 	.use_debug_file = false,
 	.check_debug_file_crc = false,
@@ -163,9 +157,9 @@ static bool inline enable_proc_info_cache(void)
 
 void free_proc_cache(struct symbolizer_proc_info *p)
 {
+	int pid = (int)p->pid;
 	if (p->is_java) {
 		/* Delete target ns Java files */
-		int pid = (int)p->pid;
 		if (pid > 0) {
 			clean_local_java_symbols_files(pid);
 		}
@@ -179,6 +173,7 @@ void free_proc_cache(struct symbolizer_proc_info *p)
 	vec_free(p->thread_names);
 	p->thread_names = NULL;
 	p->syms_cache = 0;
+	mount_info_cache_remove(pid, p->mntns_id);
 	clib_mem_free((void *)p);
 }
 
@@ -196,88 +191,16 @@ static void free_symbolizer_cache_kvp(struct symbolizer_cache_kvp *kv)
 	}
 }
 
-static inline void symbol_cache_pids_lock(void)
-{
-	while (__atomic_test_and_set(pids_cache.lock, __ATOMIC_ACQUIRE))
-		CLIB_PAUSE();
-}
-
-static inline void symbol_cache_pids_unlock(void)
-{
-	__atomic_clear(pids_cache.lock, __ATOMIC_RELEASE);
-}
-
-static inline bool is_existed_in_exit_cache(struct symbolizer_cache_kvp *kv)
-{
-	/*
-	 * Make sure that there are no duplicate items of 'pid' in
-	 * 'cache del pids.pid caches', so as to avoid program crashes
-	 * caused by repeated release of occupied memory resources.
-	 */
-	struct symbolizer_cache_kvp *kv_tmp;
-	vec_foreach(kv_tmp, pids_cache.exit_pids_cache) {
-		if ((int)kv_tmp->k.pid == kv->k.pid) {
-			struct symbolizer_proc_info *list_p =
-			    (struct symbolizer_proc_info *)kv_tmp->v.
-			    proc_info_p;
-			struct symbolizer_proc_info *curr_p =
-			    (struct symbolizer_proc_info *)kv->v.proc_info_p;
-			ebpf_warning
-			    (" At list pid %lu kvp_pid %lu info_p 0x%lx (p->cache 0x%lx)"
-			     " curr: pid %lu kvp_pid %lu info_p 0x%lx (p->cache 0x%lx)\n",
-			     (u64) list_p->pid, kv_tmp->k.pid,
-			     kv_tmp->v.proc_info_p,
-			     kv_tmp->v.proc_info_p !=
-			     0 ? list_p->syms_cache : 0, (u64) curr_p->pid,
-			     kv->k.pid, kv->v.proc_info_p,
-			     kv->v.proc_info_p != 0 ? curr_p->syms_cache : 0);
-			return true;
-		}
-	}
-
-	return false;
-}
-
-static inline bool is_existed_in_exec_cache(struct symbolizer_cache_kvp *kv)
-{
-	/*
-	 * Make sure that there are no duplicate items of 'pid' in
-	 * 'cache del pids.pid caches', so as to avoid program crashes
-	 * caused by repeated release of occupied memory resources.
-	 */
-	struct symbolizer_cache_kvp *kv_tmp;
-	vec_foreach(kv_tmp, pids_cache.exec_pids_cache) {
-		if ((int)kv_tmp->k.pid == kv->k.pid) {
-			struct symbolizer_proc_info *list_p =
-			    (struct symbolizer_proc_info *)kv_tmp->v.
-			    proc_info_p;
-			struct symbolizer_proc_info *curr_p =
-			    (struct symbolizer_proc_info *)kv->v.proc_info_p;
-			if (curr_p != 0 && list_p != 0) {
-				ebpf_warning
-				    (" At list pid %lu kvp_pid %lu info_p 0x%lx (p->cache 0x%lx)"
-				     " curr: pid %lu kvp_pid %lu info_p 0x%lx (p->cache 0x%lx)\n",
-				     (u64) list_p->pid, kv_tmp->k.pid,
-				     kv_tmp->v.proc_info_p,
-				     kv_tmp->v.proc_info_p !=
-				     0 ? list_p->syms_cache : 0,
-				     (u64) curr_p->pid, kv->k.pid,
-				     kv->v.proc_info_p,
-				     kv->v.proc_info_p !=
-				     0 ? curr_p->syms_cache : 0);
-			}
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static inline struct symbolizer_proc_info *add_proc_info_to_cache(struct
 								  symbolizer_cache_kvp
 								  *kv)
 {
 	pid_t pid = (pid_t) kv->k.pid;
+	if (kv->v.proc_info_p) {
+		free_symbolizer_cache_kvp(kv);
+		kv->k.pid = pid;
+		kv->v.proc_info_p = 0;
+	}
 	symbol_caches_hash_t *h = &syms_cache_hash;
 	struct symbolizer_proc_info *p = NULL;
 	p = clib_mem_alloc_aligned("sym_proc_info",
@@ -308,19 +231,71 @@ static inline struct symbolizer_proc_info *add_proc_info_to_cache(struct
 		return NULL;
 	} else {
 		__sync_fetch_and_add(&h->hash_elems_count, 1);
+		// Associate mount information when a new process starts.
+		mount_info_cache_add_if_absent(pid, p->mntns_id);
 	}
 
 	return p;
 }
 
-static inline int del_proc_info_from_cache(struct symbolizer_cache_kvp *kv)
+static inline int __del_proc_info_from_cache(struct symbolizer_cache_kvp *kv)
 {
-	free_symbolizer_cache_kvp(kv);
+	symbol_caches_hash_t *h = &syms_cache_hash;
+	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) kv,
+				      (symbol_caches_hash_kv *) kv) == 0) {
+		struct symbolizer_proc_info *p;
+		p = (struct symbolizer_proc_info *)kv->v.proc_info_p;
+		if (p != NULL) {
+			AO_INC(&p->use);
+			p->is_exit = 1;
+			AO_DEC(&p->use);
+		}
+
+		if (symbol_caches_hash_add_del
+		    (h, (symbol_caches_hash_kv *) kv, 0 /* delete */ )) {
+			ebpf_warning("failed.(pid %d)\n", (pid_t) kv->k.pid);
+			return -1;
+		} else {
+			__sync_fetch_and_add(&h->hash_elems_count, -1);
+			if (p)
+				free_symbolizer_cache_kvp(kv);
+			return 0;
+		}
+	} else {
+		ebpf_debug
+		    ("The process with PID %d does not exist in the cache."
+		     " Failed to clean up process information.\n", kv->k.pid);
+	}
+
+	return -1;
+}
+
+static int del_proc_info_from_cache(struct symbolizer_cache_kvp *kv)
+{
+	/*
+	 * Note that the entry has already been removed from the hash cache before
+	 * calling del_proc_info_from_cache(). This step performs cleanup of the associated data.
+	 */
+	pid_t pid = (pid_t) kv->k.pid;
+	if (kv->v.proc_info_p) {
+		free_symbolizer_cache_kvp(kv);
+		kv->k.pid = pid;
+		kv->v.proc_info_p = 0;
+	}
+
+	/*
+	 * To prevent a scenario where Process A exits and Process B starts immediately
+	 * afterward using the same PID — and then Process B also exits — we perform an
+	 * extra safety check here.
+	 */
+	__del_proc_info_from_cache(kv);
 	return 0;
 }
 
-int get_cid_and_name_from_cache(pid_t pid, uint8_t *cid, int cid_size,
-				uint8_t *name, int name_size)
+int get_proc_info_from_cache(pid_t pid, uint8_t * cid, int cid_size,
+			     uint8_t * name, int name_size, kern_dev_t s_dev,
+			     char *mount_point, char *mount_source,
+			     int mount_size, bool * is_nfs)
 {
 	symbol_caches_hash_t *h = &syms_cache_hash;
 	struct symbolizer_cache_kvp kv;
@@ -328,6 +303,8 @@ int get_cid_and_name_from_cache(pid_t pid, uint8_t *cid, int cid_size,
 	kv.v.proc_info_p = 0;
 	memset(cid, 0, cid_size);
 	memset(name, 0, name_size);
+	memset(mount_point, 0, mount_size);
+	memset(mount_source, 0, mount_size);
 	struct symbolizer_proc_info *p = NULL;
 	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
 				      (symbol_caches_hash_kv *) & kv) == 0) {
@@ -342,6 +319,10 @@ int get_cid_and_name_from_cache(pid_t pid, uint8_t *cid, int cid_size,
 			memcpy_s_inline((void *)name, name_size, p->comm,
 					sizeof(p->comm));
 		}
+		if (s_dev != DEV_INVALID)
+			find_mount_point_path(pid, &p->mntns_id, s_dev,
+					      mount_point, mount_source,
+					      mount_size, is_nfs);
 		AO_DEC(&p->use);
 		return 0;
 	}
@@ -372,6 +353,40 @@ static inline int add_proc_ev_info_to_ring(enum proc_act_type type,
 	return 0;
 }
 
+static void add_proc_event_to_queue(pid_t pid, enum proc_act_type type)
+{
+	symbol_caches_hash_t *h = &syms_cache_hash;
+	struct symbolizer_cache_kvp kv = {};
+	kv.k.pid = (u64) pid;
+	kv.v.proc_info_p = 0;
+	if (type == PROC_EXEC) {
+		__sync_fetch_and_add(&proc_exec_event_count, 1);
+	} else {
+		__sync_fetch_and_add(&proc_exit_event_count, 1);
+	}
+
+	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
+				      (symbol_caches_hash_kv *) & kv) == 0) {
+		struct symbolizer_proc_info *p;
+		p = (struct symbolizer_proc_info *)kv.v.proc_info_p;
+		if (p != NULL) {
+			AO_INC(&p->use);
+			p->is_exit = 1;
+			AO_DEC(&p->use);
+		}
+
+		if (symbol_caches_hash_add_del
+		    (h, (symbol_caches_hash_kv *) & kv, 0 /* delete */ )) {
+			ebpf_warning("failed.(pid %d)\n", (pid_t) kv.k.pid);
+			return;
+		} else {
+			__sync_fetch_and_add(&h->hash_elems_count, -1);
+		}
+	}
+
+	add_proc_ev_info_to_ring(type, &kv);
+}
+
 /*
  * When a process exits, synchronize and update its corresponding
  * symbol cache. In addition, updating the Java process symbol t-
@@ -386,70 +401,13 @@ void update_proc_info_cache(pid_t pid, enum proc_act_type type)
 		return;
 	}
 
-	symbol_caches_hash_t *h = &syms_cache_hash;
-	struct symbolizer_cache_kvp kv = {};
-	kv.k.pid = (u64) pid;
-	kv.v.proc_info_p = 0;
-
-	if (type == PROC_EXEC) {
-		__sync_fetch_and_add(&proc_exec_event_count, 1);
-		if (add_proc_ev_info_to_ring(type, &kv) < 0) {
-			int ret = VEC_OK;
-			symbol_cache_pids_lock();
-			if (is_existed_in_exec_cache(&kv)) {
-				symbol_cache_pids_unlock();
-				return;
-			}
-
-			vec_add1(pids_cache.exec_pids_cache, kv, ret);
-			if (ret != VEC_OK) {
-				ebpf_warning("vec add failed.\n");
-			}
-			symbol_cache_pids_unlock();
-		}
-	} else
-		__sync_fetch_and_add(&proc_exit_event_count, 1);
-
-	if (symbol_caches_hash_search(h, (symbol_caches_hash_kv *) & kv,
-				      (symbol_caches_hash_kv *) & kv) == 0) {
-		int ret = VEC_OK;
-		struct symbolizer_proc_info *p;
-		p = (struct symbolizer_proc_info *)kv.v.proc_info_p;
-		if (p != NULL) {
-			AO_INC(&p->use);
-			p->is_exit = 1;
-			AO_DEC(&p->use);
-			CLIB_MEMORY_STORE_BARRIER();
-		}
-		if (add_proc_ev_info_to_ring(type, &kv) < 0) {
-			symbol_cache_pids_lock();
-			if (is_existed_in_exit_cache(&kv)) {
-				symbol_cache_pids_unlock();
-				return;
-			}
-
-			vec_add1(pids_cache.exit_pids_cache, kv, ret);
-			if (ret != VEC_OK) {
-				ebpf_warning("vec add failed.\n");
-			}
-			symbol_cache_pids_unlock();
-		}
-
-		if (symbol_caches_hash_add_del
-		    (h, (symbol_caches_hash_kv *) & kv, 0 /* delete */ )) {
-			ebpf_warning("failed.(pid %d)\n", (pid_t) kv.k.pid);
-			return;
-		} else {
-			__sync_fetch_and_add(&h->hash_elems_count, -1);
-		}
-	}
+	add_proc_event_to_queue(pid, type);
 }
 
 void exec_proc_info_cache_update(void)
 {
-	struct symbolizer_cache_kvp *kv;
 	if (proc_event_ring == NULL)
-		goto vector_handle;
+		return;
 	int nr;
 	void *rx_burst[MAX_EVENTS_BURST];
 	do {
@@ -467,40 +425,10 @@ void exec_proc_info_cache_update(void)
 			clib_mem_free(ev_info);
 		}
 	} while (nr > 0);
-
-vector_handle:
-	symbol_cache_pids_lock();
-	vec_foreach(kv, pids_cache.exit_pids_cache) {
-		del_proc_info_from_cache(kv);
-	}
-	vec_free(pids_cache.exit_pids_cache);
-
-	vec_foreach(kv, pids_cache.exec_pids_cache) {
-		add_proc_info_to_cache(kv);
-	}
-	vec_free(pids_cache.exec_pids_cache);
-
-	symbol_cache_pids_unlock();
 }
 
 static int init_symbol_cache(const char *name)
 {
-	/*
-	 * Thread-safe for pids_cache.pids
-	 */
-	pids_cache.lock =
-	    clib_mem_alloc_aligned("pids_alloc_lock",
-				   CLIB_CACHE_LINE_BYTES,
-				   CLIB_CACHE_LINE_BYTES, NULL);
-	if (pids_cache.lock == NULL) {
-		ebpf_error("pids_cache.lock alloc memory failed.\n");
-		return (-1);
-	}
-
-	pids_cache.lock[0] = 0;
-	pids_cache.exit_pids_cache = NULL;
-	pids_cache.exec_pids_cache = NULL;
-
 	symbol_caches_hash_t *h = &syms_cache_hash;
 	memset(h, 0, sizeof(*h));
 	u32 nbuckets = SYMBOLIZER_CACHES_HASH_BUCKETS_NUM;
@@ -546,7 +474,8 @@ static int config_symbolizer_proc_info(struct symbolizer_proc_info *p, int pid)
 	p->thread_names_lock = 0;
 	p->netns_id = get_netns_id_from_pid(pid);
 
-	fetch_container_id_from_proc(pid, p->container_id, sizeof(p->container_id));
+	fetch_container_id_from_proc(pid, p->container_id,
+				     sizeof(p->container_id));
 
 	p->stime = (u64) get_process_starttime_and_comm(pid,
 							p->comm,
@@ -567,6 +496,8 @@ static int config_symbolizer_proc_info(struct symbolizer_proc_info *p, int pid)
 		p->verified = false;
 	}
 
+	get_mount_ns_id(pid, &p->mntns_id);
+	mount_info_cache_add_if_absent(pid, p->mntns_id);
 	p->use = 1;
 
 	return ETR_OK;
@@ -830,6 +761,9 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 
 int create_and_init_proc_info_caches(void)
 {
+	// Initialize the mount information cache.
+	mount_info_cache_init("mount-info-cache");
+
 	/*
 	 * Building a 'proc_event_ring' for handling process events.
 	 * Enabling a multi-producer, single-consumer (MPSC) model.
@@ -896,6 +830,89 @@ int create_and_init_proc_info_caches(void)
 
 	closedir(fddir);
 	return ETR_OK;
+}
+
+struct symbolizer_cache_kvp *clear_procs;
+struct mntns_pid_s {
+	pid_t pid;
+	u64 mntns_id;
+};
+struct mntns_pid_s *mntns_id_list;
+static inline void insert_mntns_vecs(struct mntns_pid_s *mp)
+{
+	struct mntns_pid_s *m;
+	vec_foreach(m, mntns_id_list) {
+		if (m->mntns_id == mp->mntns_id)
+			return;
+	}
+
+	int ret = VEC_OK;
+	vec_add1(mntns_id_list, *mp, ret);
+	if (ret != VEC_OK) {
+		ebpf_warning("vec add failed.\n");
+	}
+}
+
+static int check_proc_kvp_cb(symbol_caches_hash_kv * kvp, void *ctx)
+{
+	struct symbolizer_cache_kvp *kv = (struct symbolizer_cache_kvp *)kvp;
+	pid_t pid = 0;
+	bool del_proc = false;
+	struct symbolizer_proc_info *p = NULL;
+	if (kv->v.proc_info_p) {
+		p = (struct symbolizer_proc_info *)kv->v.proc_info_p;
+		AO_INC(&p->use);
+		pid = p->pid;
+		if ((p->stime == 0) ||
+		    (p->stime != 0 && p->stime != get_process_starttime(pid))) {
+			p->is_exit = 1;
+			del_proc = true;
+		}
+		AO_DEC(&p->use);
+	}
+
+	if (p) {
+		int ret = VEC_OK;
+		if (del_proc) {
+			vec_add1(clear_procs, *kv, ret);
+			if (ret != VEC_OK) {
+				ebpf_warning("vec add failed.\n");
+			}
+		}
+		struct mntns_pid_s mp;
+		mp.pid = p->pid;
+		mp.mntns_id = p->mntns_id;
+		insert_mntns_vecs(&mp);
+	}
+
+	(*(u64 *) ctx)++;
+	return BIHASH_WALK_CONTINUE;
+}
+
+void check_and_update_proc_info(bool output_log)
+{
+	u64 elems_count = 0, clear_count = 0;
+	struct symbolizer_cache_kvp *kv;
+	symbol_caches_hash_t *h = &syms_cache_hash;
+	symbol_caches_hash_foreach_key_value_pair(h,
+						  check_proc_kvp_cb,
+						  (void *)&elems_count);
+	vec_foreach(kv, clear_procs) {
+		if (__del_proc_info_from_cache(kv) == 0)
+			clear_count++;
+	}
+	vec_free(clear_procs);
+
+	struct mntns_pid_s *m;
+	vec_foreach(m, mntns_id_list) {
+		check_and_cleanup_mount_info(m->pid, m->mntns_id);
+	}
+	vec_free(mntns_id_list);
+
+	if (clear_count > 0 || output_log)
+		ebpf_info("Checked %d entries in the process cache and "
+			  "cleaned up %d invalid process records.\n",
+			  elems_count, clear_count);
 }
 
 static int __unused free_symbolizer_kvp_cb(symbol_caches_hash_kv * kv,
@@ -996,11 +1013,16 @@ void update_proc_info_cache(pid_t pid, enum proc_act_type type)
 	return;
 }
 
-int get_cid_and_name_from_cache(pid_t pid, uint8_t *cid, int cid_size,
-				uint8_t *name, int name_size)
+int get_proc_info_from_cache(pid_t pid, uint8_t * cid, int cid_size,
+			     uint8_t * name, int name_size, kern_dev_t s_dev,
+			     char *mount_point, char *mount_source,
+			     int mount_size, bool * is_nfs)
 {
 	memset(cid, 0, cid_size);
 	memset(name, 0, name_size);
+	memset(mount_point, 0, mount_size);
+	memset(mount_source, 0, mount_size);
+	*is_nfs = false;
 	return -1;
 }
 

--- a/agent/src/ebpf/user/ring.c
+++ b/agent/src/ebpf/user/ring.c
@@ -196,7 +196,7 @@ struct ring *ring_create(const char *name, unsigned count,
 	/* reserve a memory zone for this ring. If we can't get config or
 	 * we are secondary process, the memzone_reserve function will set
 	 * errno for us appropriately - hence no check in this this function */
-	r = calloc(ring_size, 1);
+	r = calloc(1, ring_size);
 	if (r != NULL) {
 		/* no need to check return value here, we already checked the
 		 * arguments above */

--- a/agent/src/ebpf/user/string.h
+++ b/agent/src/ebpf/user/string.h
@@ -184,4 +184,39 @@ strcpy_s_inline(void *__restrict__ dest, rsize_t dmax,
 	return err;
 }
 
+/**
+ * @brief Concatenates two strings into a destination buffer with truncation protection.
+ *
+ * This function copies `s1` and `s2` into `dst` sequentially,
+ * ensuring that the total length does not exceed `dst_len - 1`
+ * (reserving space for the null terminator).
+ *
+ * If the combined length of `s1` and `s2` exceeds `dst_len - 1`,
+ * the result will be truncated safely and always null-terminated.
+ *
+ * @param s1       First input string (null-terminated).
+ * @param s2       Second input string (null-terminated).
+ * @param dst      Destination buffer to write concatenated result.
+ * @param dst_len  Size of the destination buffer (including null terminator).
+ *
+ * @return The number of characters written to `dst`, excluding the null terminator.
+ */
+static_always_inline int fast_strncat_trunc(const char *s1, const char *s2, char *dst,
+					    size_t dst_len)
+{
+	const char *p1 = s1, *p2 = s2;
+	char *d = dst;
+	char *end = dst + dst_len - 1;	// leave room for '\0'
+
+	// Copy s1
+	while (*p1 && d < end)
+		*d++ = *p1++;
+
+	// Copy s2
+	while (*p2 && d < end)
+		*d++ = *p2++;
+
+	*d = '\0';
+	return (int)(d - dst);
+}
 #endif /* included_string_h */

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -582,7 +582,7 @@ struct clear_list_elem {
 static bool inline insert_list(void *elt, uint32_t len, struct list_head *h)
 {
 	struct clear_list_elem *cle;
-	cle = calloc(sizeof(*cle) + len, 1);
+	cle = calloc(1, sizeof(*cle) + len);
 	if (cle == NULL) {
 		ebpf_warning("calloc() failed.\n");
 		return false;

--- a/agent/src/ebpf/user/utils.c
+++ b/agent/src/ebpf/user/utils.c
@@ -257,7 +257,7 @@ static void exec_clear_residual_probes(const char *events_file,
 		if ((lf = strchr(line, '\n')))
 			*lf = '\0';
 
-		pe = (struct probe_elem *)calloc(sizeof(*pe), 1);
+		pe = (struct probe_elem *)calloc(1, sizeof(*pe));
 		if (pe == NULL) {
 			ebpf_warning("calloc() failed.\n");
 			break;
@@ -544,8 +544,8 @@ u64 get_process_starttime_and_comm(pid_t pid, char *name_base, int len)
 
 	fd = open(file, O_RDONLY);
 	if (fd <= 2) {
-		ebpf_warning("open %s failed with %s(%d)\n", file,
-			     strerror(errno), errno);
+		ebpf_debug("open %s failed with %s(%d)\n", file,
+			   strerror(errno), errno);
 		return 0;
 	}
 
@@ -612,13 +612,14 @@ int fetch_kernel_version(int *major, int *minor, int *rev, int *num)
 	int match_num = 0;
 	*num = 0;
 	// e.g.: 3.10.0-940.el7.centos.x86_64, 4.19.17-1.el7.x86_64
-	match_num = sscanf(sys_info.release, "%u.%u.%u-%u", major, minor, rev, num);
+	match_num =
+	    sscanf(sys_info.release, "%u.%u.%u-%u", major, minor, rev, num);
 	if (match_num == 4 || match_num == 3) {
 		return ETR_OK;
 	} else {
 		has_error = true;
 	}
-		
+
 	// Get the real version of Debian
 	// #1 SMP Debian 4.19.289-2 (2023-08-08)
 	// e.g.:
@@ -924,7 +925,7 @@ bool check_netns_enabled(void)
 
 	return true;
 }
-	
+
 // Function to retrieve the host PID from the first line of /proc/pid/sched
 // The expected format is "java (1234, #threads: 12)"
 // where 1234 is the host PID (before Linux 4.1)
@@ -1633,9 +1634,9 @@ u32 djb2_32bit(const char *str)
 	u32 hash = 5381;
 	int c;
 	while ((c = *str++)) {
-		hash = ((hash << 5) + hash) + c; // hash * 33 + c
+		hash = ((hash << 5) + hash) + c;	// hash * 33 + c
 	}
-	return hash; // 32-bit output
+	return hash;		// 32-bit output
 }
 
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
@@ -1670,47 +1671,103 @@ int create_work_thread(const char *name, pthread_t * t, void *fn, void *arg)
 }
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */
 
-
 static inline int compare(const void *a, const void *b)
 {
-	return (*(uint16_t *)a - *(uint16_t *)b);	// Compare two uint16_t values
+	return (*(uint16_t *) a - *(uint16_t *) b);	// Compare two uint16_t values
 }
 
-void format_port_ranges(uint16_t *ports, size_t size, char *ret_str, int str_sz)
+void format_port_ranges(uint16_t * ports, size_t size, char *ret_str,
+			int str_sz)
 {
 	if (size == 0)
 		return;		// Return immediately if there are no ports
-	
+
 	// Sort the ports array using qsort
 	qsort(ports, size, sizeof(uint16_t), compare);
-	
+
 	int bytes_cnt = 0;	// To keep track of how many bytes we've written to ret_str
-	bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "Ports: ");
-	
+	bytes_cnt +=
+	    snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "Ports: ");
+
 	size_t i = 0;
 	while (i < size) {
 		size_t start = i;
-		
+
 		// Find the end position of a consecutive range
 		while (i + 1 < size && ports[i] + 1 == ports[i + 1]) {
 			i++;
 		}
-		
+
 		// If start == i, it means it's a single number; otherwise, it's a range
 		if (start == i) {
-			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt,
-						"%d", ports[start]);	// Print a single number
+			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "%d", ports[start]);	// Print a single number
 		} else {
-			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt,
-						"%d-%d", ports[start], ports[i]);	// Print the range
+			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "%d-%d", ports[start], ports[i]);	// Print the range
 		}
-		
+
 		// Print a comma if not the last range/number
 		if (i + 1 < size) {
-			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, ", ");
+			bytes_cnt +=
+			    snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt,
+				     ", ");
 		}
-		
+
 		i++;
 	}
 }
 
+uint32_t murmurhash(const void *key, size_t len, uint32_t seed)
+{
+	const uint8_t *data = (const uint8_t *)key;
+	const int nblocks = (int)(len / 4);
+	uint32_t h1 = seed;
+
+	const uint32_t c1 = 0xcc9e2d51;
+	const uint32_t c2 = 0x1b873593;
+
+	// Body
+	const uint32_t *blocks = (const uint32_t *)(data);
+	for (int i = 0; i < nblocks; i++) {
+		uint32_t k1 = blocks[i];
+
+		k1 *= c1;
+		k1 = (k1 << 15) | (k1 >> (32 - 15));
+		k1 *= c2;
+
+		h1 ^= k1;
+		h1 = (h1 << 13) | (h1 >> (32 - 13));
+		h1 = h1 * 5 + 0xe6546b64;
+	}
+
+	// Tail
+	const uint8_t *tail = (const uint8_t *)(data + nblocks * 4);
+	uint32_t k1 = 0;
+
+	switch (len & 3) {
+	case 3:
+		k1 ^= tail[2] << 16;
+		// fall through
+	case 2:
+		k1 ^= tail[1] << 8;
+		// fall through
+	case 1:
+		k1 ^= tail[0];
+		k1 *= c1;
+		k1 = (k1 << 15) | (k1 >> (32 - 15));
+		k1 *= c2;
+		h1 ^= k1;
+		break;
+	}
+
+	// Finalization
+	h1 ^= (uint32_t) len;
+
+	// fmix function from MurmurHash3 finalizer
+	h1 ^= h1 >> 16;
+	h1 *= 0x85ebca6b;
+	h1 ^= h1 >> 13;
+	h1 *= 0xc2b2ae35;
+	h1 ^= h1 >> 16;
+
+	return h1;
+}

--- a/agent/src/ebpf/user/utils.h
+++ b/agent/src/ebpf/user/utils.h
@@ -329,6 +329,19 @@ u32 djb2_32bit(const char *str);
  * @return None. The result is written to `ret_str`.
  */
 void format_port_ranges(uint16_t *ports, size_t size, char *ret_str, int str_sz);
+
+/**
+ * @brief Compute 32-bit MurmurHash3 of the given data buffer.
+ *
+ * MurmurHash3 is a non-cryptographic hash function known for good distribution and speed.
+ *
+ * @param[in] key   Pointer to the input data buffer to hash.
+ * @param[in] len   Length in bytes of the input data.
+ * @param[in] seed  Initial seed value for the hash; can be zero or any 32-bit integer.
+ *
+ * @return 32-bit hash value computed over the input data.
+ */
+uint32_t murmurhash(const void *key, size_t len, uint32_t seed);
 #if !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL)
 int create_work_thread(const char *name, pthread_t *t, void *fn, void *arg);
 #endif /* !defined(AARCH64_MUSL) && !defined(JAVA_AGENT_ATTACH_TOOL) */


### PR DESCRIPTION
To retrieve the full file path, we split the task into two parts:

1. **Use eBPF to obtain the file path and device number.**
2. **Use a Mountns-based cache to retrieve mount information**.

Using the device number obtained via eBPF, we look up the corresponding mount point and mount source from the cache and process the data as follows:

### 1. **Skip bind mounts**

The format of each line in `mountinfo` is:

```
[ID] [ParentID] [major:minor] [fs_root] [mount_point] [options] - [fs_type] [mount_source] [fs_options]
```

Bind mounts are filtered out because, in such cases, the file path retrieved by eBPF starts directly from `[fs_root]`, which is already a valid host path. There is no need to translate it into the container’s mount point path.

**Example:**
For the line:

```
1729 1710 253:0 /var/lib/mysql /bitnami/mysql rw,relatime - xfs /dev/mapper/centos-root rw,attr2,inode64,noquota
```

A file path like `/var/lib/mysql/xxxx.data` obtained via eBPF is already a host path and should **not** be translated to `/bitnami/mysql/xxxx.data`.

### 2. **Handle NFS mounts**

If the mount source is an NFS path, we perform path translation as follows:

* `str1` = NFS source, e.g., `"10.33.49.27:/srv/nfs/data"`
* `str2` = Path obtained from eBPF, e.g., `"/nfs/data/file1"`
* `str3` = Mount point, e.g., `"/mnt/nfs"`

**Result:**
`"10.33.49.27:/srv/nfs/data/file1"`

### 3. **Handle other mount types**

For other mount types (e.g., `proc`, `sysfs`, `tmpfs`, etc.), we combine the mount point with the eBPF-reported relative path:

**Final file path = mount point + path obtained from eBPF**

### 4. **Add periodic checks for process cache and root mount information changes.**

By default, changes in process information is checked every 5 minutes and reflected in the cache. The mount information change check interval is 20 seconds.

Added periodic checks for process and mount information caches:

* **Periodic check of the process information cache**: Stale process records are detected and cleaned up. These stale entries may remain if the process terminated due to OOM (Out Of Memory) or segmentation fault, and the exit was not captured by the process exit hook. Meanwhile, the mount information associated with each process is also checked, and if any changes are detected, the mount data will be updated accordingly.

* **Periodic check of the mount information cache**: The system updates the cached mount info of the host's root mount namespace if it has changed. For container mount namespaces, their corresponding cached mount info is automatically released when the container process exits.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->




- Agent



#### Affected branches
- main
- v6.6
- v7.0