### PR TITLE
fix: applog resp status not ok

### DIFF
--- a/agent/src/flow_generator/protocol_logs/mq/zmtp.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/zmtp.rs
@@ -98,7 +98,7 @@ impl FrameType {
     }
 }
 
-#[derive(Serialize, Clone, Debug, Default)]
+#[derive(Serialize, Clone, Debug)]
 pub struct ZmtpInfo {
     msg_type: LogMessageType,
     req_msg_size: Option<u64>,
@@ -128,6 +128,34 @@ pub struct ZmtpInfo {
 
     #[serde(skip)]
     is_on_blacklist: bool,
+}
+
+impl Default for ZmtpInfo {
+    fn default() -> Self {
+        Self {
+            msg_type: Default::default(),
+            req_msg_size: None,
+            res_msg_size: None,
+            is_tls: false,
+            rtt: 0,
+            status: L7ResponseStatus::Ok,
+            err_msg: None,
+            subscription: None,
+            major_version: None,
+            minor_version: None,
+            more_frames: None,
+            socket_type: None,
+            frame_type: Default::default(),
+            mechanism: None,
+            command_name: None,
+            payload: Vec::new(),
+            captured_request_byte: 0,
+            captured_response_byte: 0,
+            attributes: Vec::new(),
+            l7_protocol_str: None,
+            is_on_blacklist: false,
+        }
+    }
 }
 
 impl ZmtpInfo {

--- a/agent/src/flow_generator/protocol_logs/sql/mongo.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mongo.rs
@@ -43,7 +43,7 @@ use crate::{
     utils::bytes,
 };
 
-#[derive(Serialize, Debug, Default, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub struct MongoDBInfo {
     msg_type: LogMessageType,
     #[serde(skip)]
@@ -83,6 +83,31 @@ pub struct MongoDBInfo {
     is_on_blacklist: bool,
     #[serde(skip)]
     reply_false: bool,
+}
+
+impl Default for MongoDBInfo {
+    fn default() -> Self {
+        Self {
+            msg_type: LogMessageType::Request,
+            is_tls: false,
+            req_len: 0,
+            resp_len: 0,
+            request_id: 0,
+            response_id: 0,
+            op_code: 0,
+            op_code_name: String::new(),
+            request: String::new(),
+            response: String::new(),
+            response_code: 0,
+            exception: String::new(),
+            status: L7ResponseStatus::Ok,
+            captured_request_byte: 0,
+            captured_response_byte: 0,
+            rrt: 0,
+            is_on_blacklist: false,
+            reply_false: false,
+        }
+    }
 }
 
 impl L7ProtocolInfoInterface for MongoDBInfo {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Branches:
- main
- 7.0
- 6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


