### PR TITLE
fix: the materialized view(1s/1h/1d) data is incorrect

### DIFF
--- a/server/libs/ckdb/table.go
+++ b/server/libs/ckdb/table.go
@@ -18,7 +18,9 @@ package ckdb
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+	"time"
 )
 
 const (
@@ -357,6 +359,42 @@ func getAggr(column *Column) string {
 	return "sum"
 }
 
+func (t *Table) OrderKeysCount() int {
+	orderKeys := t.OrderKeys
+	for _, c := range t.Columns {
+		if !c.GroupBy {
+			continue
+		}
+		if !stringSliceHas(orderKeys, c.Name) {
+			orderKeys = append(orderKeys, c.Name)
+		}
+	}
+	return len(orderKeys)
+}
+
+func (t *Table) IsAggrTableWrong(createTableSQL string) bool {
+	re := regexp.MustCompile(`(?i)ORDER BY\s*\(([^)]+)\)`)
+	match := re.FindStringSubmatch(createTableSQL)
+	if len(match) < 2 {
+		return false
+	}
+	orderKeys := strings.Split(match[1], ",")
+	return len(orderKeys) != t.OrderKeysCount()
+}
+
+func (t *Table) AggrTable(orgID uint16, aggrInterval AggregationInterval) string {
+	return fmt.Sprintf("%s.`%s.%s_agg`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
+}
+
+func (t *Table) AggrTable1S(orgID uint16) string {
+	return t.AggrTable(orgID, AggregationSecond)
+}
+
+func (t *Table) MakeAggrTableRenameSQL1S(orgID uint16) string {
+	table := t.AggrTable1S(orgID)
+	return fmt.Sprintf("RENAME TABLE %s to %s_%d`", table, table[:len(table)-1], time.Now().Unix())
+}
+
 func (t *Table) MakeAggrTableCreateSQL1S(orgID uint16) string {
 	return t.MakeAggrTableCreateSQL(orgID, AggregationSecond, t.TTL)
 }
@@ -373,6 +411,15 @@ func (t *Table) MakeAggrGlobalTableCreateSQL1S(orgID uint16) string {
 	return t.MakeAggrGlobalTableCreateSQL(orgID, AggregationSecond)
 }
 
+func (t *Table) AggrTable1H(orgID uint16) string {
+	return t.AggrTable(orgID, AggregationHour)
+}
+
+func (t *Table) MakeAggrTableRenameSQL1H(orgID uint16) string {
+	table := t.AggrTable1H(orgID)
+	return fmt.Sprintf("RENAME TABLE %s to %s_%d`", table, table[:len(table)-1], time.Now().Unix())
+}
+
 func (t *Table) MakeAggrTableCreateSQL1H(orgID uint16) string {
 	return t.MakeAggrTableCreateSQL(orgID, AggregationHour, DEFAULT_1H_TTL)
 }
@@ -387,6 +434,15 @@ func (t *Table) MakeAggrLocalTableCreateSQL1H(orgID uint16) string {
 
 func (t *Table) MakeAggrGlobalTableCreateSQL1H(orgID uint16) string {
 	return t.MakeAggrGlobalTableCreateSQL(orgID, AggregationHour)
+}
+
+func (t *Table) AggrTable1D(orgID uint16) string {
+	return t.AggrTable(orgID, AggregationDay)
+}
+
+func (t *Table) MakeAggrTableRenameSQL1D(orgID uint16) string {
+	table := t.AggrTable1D(orgID)
+	return fmt.Sprintf("RENAME TABLE %s to %s_%d`", table, table[:len(table)-1], time.Now().Unix())
 }
 
 func (t *Table) MakeAggrTableCreateSQL1D(orgID uint16) string {
@@ -412,7 +468,7 @@ func (t *Table) tablePrefix() string {
 func (t *Table) MakeAggrTableCreateSQL(orgID uint16, aggrInterval AggregationInterval, ttlHour int) string {
 	tableAgg := fmt.Sprintf("%s.`%s.%s_agg`", t.OrgDatabase(orgID), t.tablePrefix(), aggrInterval.String())
 	columns := []string{}
-	orderKeys := t.OrderKeys
+	groupKeys := t.OrderKeys
 	for _, c := range t.Columns {
 		// ignore fields starting with '_', such as _tid, _id
 		if strings.HasPrefix(c.Name, "_") || c.IgnoredInAggrTable {
@@ -431,6 +487,9 @@ func (t *Table) MakeAggrTableCreateSQL(orgID uint16, aggrInterval AggregationInt
 			comment := ""
 			if c.Comment != "" {
 				comment = fmt.Sprintf("COMMENT '%s'", c.Comment)
+			}
+			if !stringSliceHas(groupKeys, c.Name) {
+				groupKeys = append(groupKeys, c.Name)
 			}
 			columns = append(columns, fmt.Sprintf("%s %s %s %s", c.Name, c.Type.String(), comment, codec))
 		} else {
@@ -462,8 +521,8 @@ func (t *Table) MakeAggrTableCreateSQL(orgID uint16, aggrInterval AggregationInt
 		tableAgg,
 		strings.Join(columns, ",\n"),
 		engine,
-		strings.Join(t.OrderKeys[:t.PrimaryKeyCount], ","),
-		strings.Join(orderKeys, ","), // 以order by的字段排序, 相同的做聚合
+		strings.Join(groupKeys, ","),
+		strings.Join(groupKeys, ","), // 以order by的字段排序, 相同的做聚合
 		aggrInterval.PartitionBy().String(t.TimeKey),
 		t.makeTTLString(ttlHour),
 		t.StoragePolicy)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


