### PR TITLE
fix: Flush cached stats when flow ends

### DIFF
--- a/agent/src/common/l7_protocol_log.rs
+++ b/agent/src/common/l7_protocol_log.rs
@@ -511,6 +511,26 @@ impl RrtCache {
         ret
     }
 
+    pub fn collect_flow_perf_stats(&mut self, flow_id: u64) -> Option<L7PerfStats> {
+        let Some(keys) = self.flows.pop(&flow_id) else {
+            return None;
+        };
+        let value = keys.into_iter().map(|(key, _)| self.logs.pop(&key)).fold(
+            L7PerfStats::default(),
+            |mut stats: L7PerfStats, entry| {
+                if let Some(entry) = entry {
+                    stats.sequential_merge(&L7PerfStats::from(&entry));
+                }
+                stats
+            },
+        );
+        if value == L7PerfStats::default() {
+            None
+        } else {
+            Some(value)
+        }
+    }
+
     pub fn remove_flow(&mut self, flow_id: u64) {
         if let Some(keys) = self.flows.pop(&flow_id) {
             for (key, _) in keys {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

Branches:
- main
- 7.0
- 6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


