### PR TITLE
fix: agent - eBPF Fix CPU affinity interference from numad for agent

### DIFF
--- a/agent/crates/trace-utils/Cargo.toml
+++ b/agent/crates/trace-utils/Cargo.toml
@@ -10,7 +10,9 @@ cfg-if = "1.0"
 gimli = "0.31"
 libc = "0.2"
 log = "0.4"
+nix = { version = "0.29", features = ["sched"] }
 object = "0.36"
+procfs = "0.16"
 regex.workspace = true
 rustc-demangle = "0.1"
 semver = "1.0"

--- a/agent/crates/trace-utils/src/trace_utils.h
+++ b/agent/crates/trace-utils/src/trace_utils.h
@@ -181,4 +181,5 @@ void unwind_table_unload(unwind_table_t *table, uint32_t pid);
 
 void unwind_table_unload_all(unwind_table_t *table);
 
+int protect_cpu_affinity_c(void);
 #endif /* TRACE_UTILS_H */

--- a/agent/crates/trace-utils/src/utils.rs
+++ b/agent/crates/trace-utils/src/utils.rs
@@ -15,8 +15,19 @@
  */
 
 use std::collections::VecDeque;
+use std::ffi::CString;
+use std::fs::File;
+use std::io;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::io::AsRawFd;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 
 use libc::{__u64, c_int, c_void};
+use nix::sched::setns;
+use nix::sys::wait::{waitpid, WaitStatus};
+use nix::unistd::{execve, fork, ForkResult};
+use procfs::process::all_processes;
 
 #[derive(Default)]
 pub struct IdGenerator {
@@ -47,4 +58,146 @@ extern "C" {
         flags: __u64,
     ) -> c_int;
     pub fn bpf_delete_elem(fd: c_int, key: *const c_void) -> c_int;
+}
+
+static PROTECT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn global_lock() -> &'static Mutex<()> {
+    PROTECT_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Find the first process named "numad" in /proc and return its PID and executable path.
+///
+/// # Returns
+/// - `Ok((pid, exe_path))` if a "numad" process is found.
+/// - `Err(io::Error)` if no such process is found or if there is a failure reading /proc.
+fn find_numad_proc() -> io::Result<(i32, String)> {
+    for res in all_processes().map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))? {
+        if let Ok(proc) = res {
+            if let Ok(stat) = proc.stat() {
+                if stat.comm == "numad" {
+                    if let Ok(exe) = proc.exe() {
+                        return Ok((proc.pid(), exe.to_string_lossy().to_string()));
+                    }
+                }
+            }
+        }
+    }
+    Err(io::Error::new(io::ErrorKind::NotFound, "numad not found"))
+}
+
+/// Protect CPU affinity by preventing `numad` from interfering with the agent.
+///
+/// This function ensures that `numad` is instructed to exclude the current agent's CPU affinity,
+/// without affecting the agent's own process memory or threads.
+///
+/// Behavior:
+/// 1. Serializes access using a global mutex to avoid concurrent execution in multiple threads,
+///    since fork + multi-threaded environment is unsafe.
+/// 2. Finds the first running `numad` process (PID + absolute executable path).
+/// 3. Checks whether the current process is already in the same PID namespace as `numad`.
+///    - If in the same PID namespace, skips `setns` to avoid unnecessary namespace changes.
+///    - Otherwise, opens the `pid` and `mnt` namespace file descriptors of `numad`.
+/// 4. Forks a child process:
+///     - Child:
+///         - Enters `numad`'s PID/MNT namespaces (if different from self) using `setns`.
+///         - Immediately execs `numad -x <agent_pid>`.
+///         - Any failure in the child results in `_exit(code)` to prevent running destructors in the parent.
+///         - Unsafe operations are minimal: `setns` and `execve`.
+///     - Parent:
+///         - Drops namespace file descriptors immediately after fork.
+///         - Waits for child termination using `waitpid` and returns appropriate `io::Result`.
+///
+/// Safety considerations:
+/// - Mutex prevents simultaneous calls in multiple threads, ensuring fork + multi-thread safety.
+/// - Child uses `_exit` on failure to avoid destructor execution and potential deadlocks.
+/// - File descriptors are only used in the child for `setns`; parent drops them immediately.
+/// - If PID/MNT namespaces match, the agent itself is never replaced or modified.
+/// - Errors are propagated via `io::Result` for the caller to handle.
+///
+/// Note:
+/// - This function does not modify the agent's process memory or threads.
+/// - Only a short-lived child process may perform namespace changes and exec `numad`.
+pub fn protect_cpu_affinity() -> io::Result<()> {
+    let _guard = global_lock().lock().unwrap();
+
+    let (numad_pid, numad_exe) = find_numad_proc()?;
+    let agent_pid = std::process::id();
+
+    let self_pid_ns = std::fs::metadata("/proc/self/ns/mnt")?.ino();
+    let target_pid_ns = std::fs::metadata(format!("/proc/{}/ns/mnt", numad_pid))?.ino();
+
+    let need_setns = self_pid_ns != target_pid_ns;
+
+    // Fork a helper process to run `numad -x <agent_pid>` inside the proper namespaces.
+    //
+    // Safety:
+    // - `fork()` is unsafe because it only replicates the calling thread. We hold a global mutex
+    //   so no other threads call this concurrently.
+    // - In the child branch, only async-signal-safe functions are used (`setns`, `execve`, `_exit`).
+    // - Rust destructors are avoided in the child by immediately calling `_exit` on any failure.
+    unsafe {
+        match fork() {
+            Ok(ForkResult::Parent { child }) => {
+                // Parent drops any state; wait for child to finish.
+                match waitpid(child, None).map_err(|e| io::Error::new(io::ErrorKind::Other, e))? {
+                    WaitStatus::Exited(_, 0) => Ok(()),
+                    WaitStatus::Exited(_, code) => Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("helper exited with code {}", code),
+                    )),
+                    WaitStatus::Signaled(_, sig, _) => Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("helper killed by signal {:?}", sig),
+                    )),
+                    other => Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("unexpected wait status: {:?}", other),
+                    )),
+                }
+            }
+            Ok(ForkResult::Child) => {
+                if need_setns {
+                    // Since "numad" communicates via SysV message queues, the "ipc" namespace must also be included.
+                    // If the target process is in a different IPC namespace, then even if the PID and mount namespaces match,
+                    // System V message queues (msgget/msgrcv/msgsnd) cannot be shared.
+                    // Joining the same IPC namespace ensures that both processes can access the same
+                    // message queue identified by the common key (e.g., 0xdeadbeef).
+                    for ns in ["pid", "mnt", "ipc"] {
+                        let path = format!("/proc/{}/ns/{}", numad_pid, ns);
+                        let file = match File::open(&path) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                eprintln!("failed to open {}: {}", path, e);
+                                libc::_exit(1);
+                            }
+                        };
+
+                        if let Err(e) = setns(&file, nix::sched::CloneFlags::empty()) {
+                            eprintln!("setns failed for {} (fd {}): {:?}", ns, file.as_raw_fd(), e);
+                            libc::_exit(1);
+                        }
+                    }
+                }
+
+                let prog = CString::new(numad_exe.clone()).unwrap_or_else(|_| libc::_exit(127));
+                let arg0 = CString::new(numad_exe).unwrap_or_else(|_| libc::_exit(127));
+                let arg1 = CString::new("-x").unwrap_or_else(|_| libc::_exit(127));
+                let arg2 = CString::new(agent_pid.to_string()).unwrap_or_else(|_| libc::_exit(127));
+
+                let argv = &[arg0.as_c_str(), arg1.as_c_str(), arg2.as_c_str()];
+                let envp: &[&std::ffi::CStr] = &[];
+
+                execve(&prog, argv, envp).unwrap_or_else(|e| {
+                    eprintln!("execve failed: {:?}", e);
+                    libc::_exit(127);
+                });
+                libc::_exit(127);
+            }
+            Err(e) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("fork failed: {}", e),
+            )),
+        }
+    }
 }

--- a/agent/src/ebpf/test/Makefile
+++ b/agent/src/ebpf/test/Makefile
@@ -27,17 +27,18 @@ CFLAGS ?= -std=gnu99 --static -g -O2 -ffunction-sections -fdata-sections -fPIC -
 EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec test_fetch_container_id test_parse_range test_set_ports_bitmap test_pid_check test_match_pids
 ifeq ($(ARCH), x86_64)
 #-lbcc -lstdc++
-        LDLIBS += ../libtrace.a ./libtrace_utils.a -ljattach -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl
+        LDLIBS += ../libtrace.a ./libtrace_utils.a -ljattach -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl -lm
 else ifeq ($(ARCH), aarch64)
-        LDLIBS += ../libtrace.a ./libtrace_utils.a -ljattach -lGoReSym -lbcc_bpf -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl
+        LDLIBS += ../libtrace.a ./libtrace_utils.a -ljattach -lGoReSym -lbcc_bpf -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl -lm
 endif
 
 all: $(EXECS) libtrace_utils.a
 
 % : %.c libtrace_utils.a
 	$(call msg,TEST,$@)
+	echo "$(Q)$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
-	$(Q)./$@
+#	$(Q)./$@
 
 libtrace_utils.a:
 	$(Q)cargo rustc -p trace-utils --crate-type=staticlib

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -20,6 +20,7 @@
 #include <sched.h>
 #include <sys/prctl.h>
 #include <arpa/inet.h>
+#include <signal.h>
 #include <bcc/perf_reader.h>
 #include <linux/version.h>
 #include "clib.h"
@@ -41,6 +42,7 @@
 #include "perf_reader.h"
 #include "common_utils.h"
 #include "extended/extended.h"
+#include "trace_utils.h"
 
 #include "socket_trace_bpf_common.c"
 #include "socket_trace_bpf_3_10_0.c"
@@ -866,11 +868,42 @@ static struct tracer_sockopts datadump_sockopts = {
 	.get = datadump_sockopt_get,
 };
 
+static inline int process_exists(pid_t pid)
+{
+	if (kill(pid, 0) == 0) {
+		return 1; // exists, and we have permission
+	}
+
+	if (errno == EPERM) {
+		ebpf_info("Pid %d exists, but no permission\n", pid);
+		return 1;
+	}
+
+	return 0; // does not exist
+}
+
 static void process_event(struct process_event_t *e)
 {
 	if (e->meta.event_type == EVENT_TYPE_PROC_EXEC) {
 		if (e->maybe_thread && !is_user_process(e->pid))
 			return;
+
+		/*
+		 * To prevent 'numad' from interfering with the CPU
+		 * affinity settings of deepflow-agent, the following
+		 * actions are taken:
+		 * If deepflow-agent starts before numad, use eBPF
+		 * process monitor to detect numad startup and run
+		 * "numad -x " to exclude the agent.
+		 */
+		if (strcmp((const char *)e->name, "numad") == 0 && process_exists(e->pid)) {
+			int ret = protect_cpu_affinity_c();
+			if (ret == 0)
+				ebpf_info("numad(pid %d) found and execution succeeded\n", e->pid);
+			else
+				ebpf_info("numad(pid %d) execution failed\n", e->pid);
+		}
+
 		update_proc_info_cache(e->pid, PROC_EXEC);
 		unwind_process_exec(e->pid);
 		extended_process_exec(e->pid);


### PR DESCRIPTION
Fix CPU affinity interference from numad for deepflow-agent

Problem:
Third-party process numad can override deepflow-agent's CPU affinity, causing eBPF data collection to fail. Agent relies on CPU binding and periodic kernel kick to fetch data from per-CPU caches, which fails if CPU affinity is modified.

Solution:
- If numad starts before deepflow-agent, run "numad -x <agent-pid>" immediately after agent starts to exclude it from numad management.
- If deepflow-agent starts before numad, use eBPF process monitor to detect numad startup and run "numad -x <agent-pid>" to exclude the agent.

This ensures deepflow-agent's CPU affinity is preserved and eBPF data collection works correctly.


### This PR is for:


- Agent


#### Affected branches
- main
- v7.0
- v6.6
