### PR TITLE
fix: test-server support set grpc-buffer-size

### DIFF
--- a/agent/src/bin/test-server.rs
+++ b/agent/src/bin/test-server.rs
@@ -61,6 +61,9 @@ pub struct Config {
     /// Displays the details of the agent information
     #[clap(short = 's', long, value_enum, default_value_t = Detail::None)]
     detail: Detail,
+    /// Set grpc buffer size, Unit: M
+    #[clap(short = 'g', long, default_value_t = 0)]
+    grpc_buffer_size: u64,
 }
 
 #[derive(Debug, Default)]
@@ -149,6 +152,7 @@ impl TestServer {
 
     fn set_config(&mut self, config: Config) {
         self.config = config;
+        self.config.grpc_buffer_size = self.config.grpc_buffer_size << 20;
 
         self.update_agent_config();
     }
@@ -190,6 +194,12 @@ impl TestServer {
                 hostname: Some("testsrv-agent-01".to_string()),
                 group_id: None,
             }),
+            only_partial_fields: if self.config.grpc_buffer_size > 0 {
+                Some(true)
+            } else {
+                None
+            },
+            new_grpc_buffer_size: Some(self.config.grpc_buffer_size),
             ..Default::default()
         }
     }

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -4026,8 +4026,6 @@ impl ConfigHandler {
             communication.request_via_nat_ip = new_communication.request_via_nat_ip;
         }
         if communication.grpc_buffer_size != new_communication.grpc_buffer_size {
-            communication.grpc_buffer_size = new_communication.grpc_buffer_size;
-
             if new_communication.grpc_buffer_size > 0 {
                 info!(
                     "Update global.communication.grpc_buffer_size from {:?} to {:?}, and it is actually used {:?}.",
@@ -4036,6 +4034,7 @@ impl ConfigHandler {
 
                 session.set_rx_size(new_communication.grpc_buffer_size.max(GRPC_BUFFER_SIZE_MIN));
             }
+            communication.grpc_buffer_size = new_communication.grpc_buffer_size;
         }
         if communication.max_throughput_to_ingester != new_communication.max_throughput_to_ingester
         {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

### Fix: test-server support set grpc-buffer-size
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 7.0
- 6.6
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


