### PR TITLE
fix: tagrecorder allows sub_domain to be null

### DIFF
--- a/server/controller/tagrecorder/ch_pod_k8s_label.go
+++ b/server/controller/tagrecorder/ch_pod_k8s_label.go
@@ -79,9 +79,10 @@ func (c *ChPodK8sLabel) onResourceUpdated(md *message.Metadata, updateMessage *m
 				})
 			}
 		}
-		if len(keysToDelete) > 0 {
-			c.SubscriberComponent.dbOperator.delete(keysToDelete, targetsToDelete, db)
-		}
+	}
+
+	if len(keysToDelete) > 0 {
+		c.SubscriberComponent.dbOperator.delete(keysToDelete, targetsToDelete, db)
 	}
 }
 

--- a/server/controller/tagrecorder/healer/data_gen.go
+++ b/server/controller/tagrecorder/healer/data_gen.go
@@ -335,7 +335,12 @@ func (s *dataGeneratorComponent[GT]) generate() error {
 		} else {
 			q = q.Where("domain = ?", s.md.GetDomainLcuuid())
 			if s.filterSubDomain {
-				q = q.Where("sub_domain = ?", s.md.GetSubDomainLcuuid())
+				subDomainLcuuid := s.md.GetSubDomainLcuuid()
+				if subDomainLcuuid != "" {
+					q = q.Where("sub_domain = ?", subDomainLcuuid)
+				} else {
+					q = q.Where("(sub_domain = '' or sub_domain is null)")
+				}
 			}
 		}
 		return q


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


