### PR TITLE
fix: move existsed trace infos to attributes

### DIFF
--- a/agent/src/flow_generator/protocol_logs/consts.rs
+++ b/agent/src/flow_generator/protocol_logs/consts.rs
@@ -83,3 +83,6 @@ pub const SERVICE_NOT_FOUND: u8 = 60;
 pub const SERVICE_ERROR: u8 = 70;
 pub const SERVER_ERROR: u8 = 80;
 pub const SERVER_THREADPOOL_EXHAUSTED_ERROR: u8 = 100;
+
+pub const APM_TRACE_ID_ATTR: &str = "apm_trace_id";
+pub const APM_SPAN_ID_ATTR: &str = "apm_span_id";

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -16,6 +16,7 @@
 
 use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet};
+use std::mem::replace;
 use std::str;
 use std::sync::Arc;
 
@@ -366,10 +367,28 @@ impl HttpInfo {
 
         //trace info rewrite
         if let Some(trace_id) = custom.trace.trace_id {
-            self.trace_id = PrioField::new(PLUGIN_FIELD_PRIORITY, trace_id);
+            let prev = replace(
+                &mut self.trace_id,
+                PrioField::new(PLUGIN_FIELD_PRIORITY, trace_id),
+            );
+            if !prev.is_default() {
+                self.attributes.push(KeyVal {
+                    key: APM_TRACE_ID_ATTR.to_string(),
+                    val: prev.into_inner(),
+                });
+            }
         }
         if let Some(span_id) = custom.trace.span_id {
-            self.span_id = PrioField::new(PLUGIN_FIELD_PRIORITY, span_id);
+            let prev = replace(
+                &mut self.span_id,
+                PrioField::new(PLUGIN_FIELD_PRIORITY, span_id),
+            );
+            if !prev.is_default() {
+                self.attributes.push(KeyVal {
+                    key: APM_SPAN_ID_ATTR.to_string(),
+                    val: prev.into_inner(),
+                });
+            }
         }
         if let Some(x_request_id_0) = custom.trace.x_request_id_0 {
             self.x_request_id_0 = PrioField::new(PLUGIN_FIELD_PRIORITY, x_request_id_0);
@@ -427,13 +446,31 @@ impl HttpInfo {
         // trace info
         if CUSTOM_FIELD_POLICY_PRIORITY < self.trace_id.prio {
             if let Some(trace_id) = tags.remove(ExtraField::TRACE_ID) {
-                self.trace_id = PrioField::new(CUSTOM_FIELD_POLICY_PRIORITY, trace_id);
+                let prev = replace(
+                    &mut self.trace_id,
+                    PrioField::new(CUSTOM_FIELD_POLICY_PRIORITY, trace_id),
+                );
+                if !prev.is_default() {
+                    self.attributes.push(KeyVal {
+                        key: APM_TRACE_ID_ATTR.to_string(),
+                        val: prev.into_inner(),
+                    });
+                }
             }
         }
 
         if CUSTOM_FIELD_POLICY_PRIORITY < self.span_id.prio {
             if let Some(span_id) = tags.remove(ExtraField::SPAN_ID) {
-                self.span_id = PrioField::new(CUSTOM_FIELD_POLICY_PRIORITY, span_id);
+                let prev = replace(
+                    &mut self.span_id,
+                    PrioField::new(CUSTOM_FIELD_POLICY_PRIORITY, span_id),
+                );
+                if !prev.is_default() {
+                    self.attributes.push(KeyVal {
+                        key: APM_SPAN_ID_ATTR.to_string(),
+                        val: prev.into_inner(),
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
- when l7 infos already have trace_id/span_id during protocol extract, move into attributes instead of drop directly

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent 
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

cp from #10516
