### PR TITLE
fix: the wrong direction in L7 metrics

### DIFF
--- a/agent/src/common/flow.rs
+++ b/agent/src/common/flow.rs
@@ -1179,14 +1179,7 @@ impl Flow {
         }
         // 链路追踪统计位置
         self.directions = get_direction(&*self, agent_type, cloud_gateway_traffic);
-
-        if self.directions[0] != Direction::None && self.directions[1] == Direction::None {
-            self.tap_side = self.directions[0].into();
-        } else if self.directions[0] == Direction::None && self.directions[1] != Direction::None {
-            self.tap_side = self.directions[1].into();
-        } else {
-            self.tap_side = TapSide::Rest;
-        }
+        self.tap_side = Direction::from(&self.directions).into();
     }
 
     // Currently acl_gids only saves the policy ID of pcap, but does not save the policy ID of NPB

--- a/agent/src/metric/document.rs
+++ b/agent/src/metric/document.rs
@@ -192,6 +192,18 @@ impl Default for Direction {
     }
 }
 
+impl From<&[Direction; 2]> for Direction {
+    fn from(value: &[Direction; 2]) -> Self {
+        if value[0] != Direction::None && value[1] == Direction::None {
+            value[0]
+        } else if value[0] == Direction::None && value[1] != Direction::None {
+            value[1]
+        } else {
+            Direction::None
+        }
+    }
+}
+
 const SIDE_NODE: u8 = 1 << 3;
 const SIDE_HYPERVISOR: u8 = 2 << 3;
 const SIDE_GATEWAY_HYPERVISOR: u8 = 3 << 3;


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### fix: the wrong direction in L7 metrics
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 7.0
- 6.6
- 6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


