### PR TITLE
fix: the wrong direction in L7 metrics

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -39,7 +39,7 @@ use super::{
 use crate::{
     common::{
         endpoint::EPC_INTERNET,
-        enums::{EthernetType, IpProtocol, TapType},
+        enums::{EthernetType, IpProtocol},
         flow::{CloseType, L7Protocol, SignalSource},
     },
     config::handler::{CollectorAccess, CollectorConfig},
@@ -54,7 +54,6 @@ use crate::{
     },
 };
 use public::{
-    proto::common::TridentType,
     queue::{DebugSender, Error, Receiver},
     utils::net::MacAddr,
 };
@@ -500,65 +499,9 @@ impl Stash {
         directions: &[Direction; 2],
         config: &CollectorConfig,
     ) {
-        for ep in 0..2 {
-            let direction = match config.trident_type {
-                TridentType::TtDedicatedPhysicalMachine
-                    if acc_flow.flow.flow_key.tap_type != TapType::Cloud
-                        && directions[0] != Direction::None
-                        && directions[1] != Direction::None =>
-                {
-                    Direction::None
-                }
-                _ if directions[ep] == Direction::None => continue,
-                _ => directions[ep],
-            };
-            let is_active_host = if ep == 0 {
-                acc_flow.is_active_host0
-            } else {
-                acc_flow.is_active_host1
-            };
-            // single_stats: Do not count the inactive end (Internet/private network IP with no response packet)
-            if config.inactive_ip_enabled || is_active_host {
-                let flow_meter = if ep == FLOW_METRICS_PEER_DST {
-                    acc_flow.flow_meter.to_reversed()
-                } else {
-                    acc_flow.flow_meter
-                };
-                let tagger = get_single_tagger(
-                    self.global_thread_id,
-                    &acc_flow.flow,
-                    ep,
-                    direction,
-                    is_active_host,
-                    config,
-                    None,
-                    0,
-                    0,
-                    L7Protocol::Unknown,
-                    self.context.agent_mode,
-                );
-                self.fill_single_l4_stats(tagger, flow_meter);
-            }
-            let tagger = get_edge_tagger(
-                self.global_thread_id,
-                &acc_flow.flow,
-                direction,
-                acc_flow.is_active_host0,
-                acc_flow.is_active_host1,
-                config,
-                None,
-                0,
-                0,
-                L7Protocol::Unknown,
-                self.context.agent_mode,
-            );
-            // edge_stats: If the direction of a certain end is known, the statistical data
-            // will be recorded with the direction (corresponding tap-side), up to two times
-            self.fill_edge_l4_stats(tagger, acc_flow.flow_meter);
-        }
-        // edge_stats: If both ends of direction are None, record the
+        // edge_stats: If both ends of direction are None or not None, record the
         // statistical data with direction=0 (corresponding tap-side=rest)
-        if directions[0] == Direction::None && directions[1] == Direction::None {
+        if Direction::from(directions) == Direction::None {
             // if otel data's directions are unknown, set direction =  Direction::App
             let direction = if acc_flow.flow.signal_source == SignalSource::OTel {
                 Direction::App
@@ -578,6 +521,57 @@ impl Stash {
                 L7Protocol::Unknown,
                 self.context.agent_mode,
             );
+            self.fill_edge_l4_stats(tagger, acc_flow.flow_meter);
+            return;
+        }
+
+        for ep in 0..2 {
+            // Do not count the data of None direction
+            if directions[ep] == Direction::None {
+                continue;
+            }
+            let is_active_host = if ep == 0 {
+                acc_flow.is_active_host0
+            } else {
+                acc_flow.is_active_host1
+            };
+            // single_stats: Do not count the inactive end (Internet/private network IP with no response packet)
+            if config.inactive_ip_enabled || is_active_host {
+                let flow_meter = if ep == FLOW_METRICS_PEER_DST {
+                    acc_flow.flow_meter.to_reversed()
+                } else {
+                    acc_flow.flow_meter
+                };
+                let tagger = get_single_tagger(
+                    self.global_thread_id,
+                    &acc_flow.flow,
+                    ep,
+                    directions[ep],
+                    is_active_host,
+                    config,
+                    None,
+                    0,
+                    0,
+                    L7Protocol::Unknown,
+                    self.context.agent_mode,
+                );
+                self.fill_single_l4_stats(tagger, flow_meter);
+            }
+            let tagger = get_edge_tagger(
+                self.global_thread_id,
+                &acc_flow.flow,
+                directions[ep],
+                acc_flow.is_active_host0,
+                acc_flow.is_active_host1,
+                config,
+                None,
+                0,
+                0,
+                L7Protocol::Unknown,
+                self.context.agent_mode,
+            );
+            // edge_stats: If the direction of a certain end is known, the statistical data
+            // will be recorded with the direction (corresponding tap-side), up to two times
             self.fill_edge_l4_stats(tagger, acc_flow.flow_meter);
         }
     }
@@ -697,6 +691,33 @@ impl Stash {
         config: &CollectorConfig,
     ) {
         let flow = &meter.flow;
+        // edge_stats: If both ends of direction are None or not None, record the
+        // statistical data with direction=0 (corresponding tap-side=rest)
+        if Direction::from(directions) == Direction::None {
+            // if otel data's directions are unknown, set direction =  Direction::App
+            let direction = if flow.signal_source == SignalSource::OTel {
+                Direction::App
+            } else {
+                Direction::None
+            };
+            let mut tagger = get_edge_tagger(
+                self.global_thread_id,
+                &flow,
+                direction,
+                meter.is_active_host0,
+                meter.is_active_host1,
+                config,
+                meter.endpoint.clone(),
+                meter.biz_type,
+                meter.time_span,
+                meter.l7_protocol,
+                self.context.agent_mode,
+            );
+            tagger.code |= Code::L7_PROTOCOL;
+            self.fill_edge_l7_stats(tagger, meter.endpoint_hash, meter.app_meter);
+            return;
+        }
+
         for ep in 0..2 {
             // Do not count the data of None direction
             if directions[ep] == Direction::None {
@@ -741,31 +762,6 @@ impl Stash {
             tagger.code |= Code::L7_PROTOCOL;
             // edge_stats: If the direction of a certain end is known, the statistical data
             // will be recorded with the direction (corresponding tap-side), up to two times
-            self.fill_edge_l7_stats(tagger, meter.endpoint_hash, meter.app_meter);
-        }
-        // edge_stats: If both ends of direction are None, record the
-        // statistical data with direction=0 (corresponding tap-side=rest)
-        if directions[0] == Direction::None && directions[1] == Direction::None {
-            // if otel data's directions are unknown, set direction =  Direction::App
-            let direction = if flow.signal_source == SignalSource::OTel {
-                Direction::App
-            } else {
-                Direction::None
-            };
-            let mut tagger = get_edge_tagger(
-                self.global_thread_id,
-                &flow,
-                direction,
-                meter.is_active_host0,
-                meter.is_active_host1,
-                config,
-                meter.endpoint.clone(),
-                meter.biz_type,
-                meter.time_span,
-                meter.l7_protocol,
-                self.context.agent_mode,
-            );
-            tagger.code |= Code::L7_PROTOCOL;
             self.fill_edge_l7_stats(tagger, meter.endpoint_hash, meter.app_meter);
         }
     }

--- a/agent/src/common/flow.rs
+++ b/agent/src/common/flow.rs
@@ -1176,14 +1176,7 @@ impl Flow {
         }
         // 链路追踪统计位置
         self.directions = get_direction(&*self, trident_type, cloud_gateway_traffic);
-
-        if self.directions[0] != Direction::None && self.directions[1] == Direction::None {
-            self.tap_side = self.directions[0].into();
-        } else if self.directions[0] == Direction::None && self.directions[1] != Direction::None {
-            self.tap_side = self.directions[1].into();
-        } else {
-            self.tap_side = TapSide::Rest;
-        }
+        self.tap_side = Direction::from(&self.directions).into();
     }
 
     // Currently acl_gids only saves the policy ID of pcap, but does not save the policy ID of NPB

--- a/agent/src/metric/document.rs
+++ b/agent/src/metric/document.rs
@@ -180,6 +180,18 @@ impl Default for Direction {
     }
 }
 
+impl From<&[Direction; 2]> for Direction {
+    fn from(value: &[Direction; 2]) -> Self {
+        if value[0] != Direction::None && value[1] == Direction::None {
+            value[0]
+        } else if value[0] == Direction::None && value[1] != Direction::None {
+            value[1]
+        } else {
+            Direction::None
+        }
+    }
+}
+
 const SIDE_NODE: u8 = 1 << 3;
 const SIDE_HYPERVISOR: u8 = 2 << 3;
 const SIDE_GATEWAY_HYPERVISOR: u8 = 3 << 3;


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### fix: the wrong direction in L7 metrics
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 7.0
- 6.6
- 6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


