### PR TITLE
fix: agent - eBPF Adjust the display of the file directory (#10551)

### DIFF
--- a/agent/src/ebpf/user/mount.c
+++ b/agent/src/ebpf/user/mount.c
@@ -138,7 +138,8 @@ int get_mount_id(pid_t pid, int fd)
 	return mount_id;
 }
 
-static bool __unused has_mount_entry(struct list_head *mount_head, kern_dev_t s_dev)
+static bool __unused has_mount_entry(struct list_head *mount_head,
+				     kern_dev_t s_dev)
 {
 	struct list_head *p, *n;
 	struct mount_entry *e;
@@ -154,17 +155,19 @@ static bool __unused has_mount_entry(struct list_head *mount_head, kern_dev_t s_
 }
 
 static void inline set_mount_info(struct mount_entry *e, char *mount_path,
-				  char *mount_source, int mount_size,
-				  fs_type_t * file_type)
+				  char *mount_source, char *root,
+				  int mount_size, fs_type_t * file_type)
 {
 	fast_strncat_trunc(e->mount_point, "", mount_path, mount_size);
 	fast_strncat_trunc(e->mount_source, "", mount_source, mount_size);
+	fast_strncat_trunc(e->root, "", root, mount_size);
 	*file_type = e->file_type;
 }
 
 void get_mount_info(pid_t pid, int mnt_id, u32 mntns_id,
 		    kern_dev_t s_dev, char *mount_path,
-		    char *mount_source, int mount_size, fs_type_t * file_type)
+		    char *mount_source, char *root,
+		    int mount_size, fs_type_t * file_type)
 {
 	struct list_head *p, *n;
 	struct mount_entry *e;
@@ -183,13 +186,13 @@ void get_mount_info(pid_t pid, int mnt_id, u32 mntns_id,
 		if (e && mnt_id > -1) {
 			if (e->mount_id == mnt_id) {
 				set_mount_info(e, mount_path, mount_source,
-					       mount_size, file_type);
+					       root, mount_size, file_type);
 				break;
 			}
 
 		} else if (e && e->s_dev == s_dev) {
-			set_mount_info(e, mount_path, mount_source, mount_size,
-				       file_type);
+			set_mount_info(e, mount_path, mount_source, root,
+				       mount_size, file_type);
 			break;
 		}
 	}
@@ -250,6 +253,7 @@ static void free_mount_info(struct mount_info *m)
 			list_head_del(&e->list);
 			free(e->mount_point);
 			free(e->mount_source);
+			free(e->root);
 			free(e);
 		}
 	}
@@ -423,15 +427,22 @@ static int build_mount_info(pid_t pid, struct list_head *mount_head,
 		}
 		entry->mount_source = strdup(mount_source);
 		if (entry->mount_source == NULL) {
-			free(entry);
 			free(entry->mount_point);
+			free(entry);
 			goto exit;
 		}
+		entry->root = strdup(root);
+		if (entry->root == NULL) {
+			free(entry->mount_point);
+			free(entry->mount_source);
+			free(entry);
+			goto exit;
 
+		}
 		count++;
 		*bytes_count +=
 		    (strlen(entry->mount_point) + strlen(entry->mount_source) +
-		     2);
+		     strlen(entry->root) + 3);
 		list_add_tail(&entry->list, mount_head);
 	}
 
@@ -605,13 +616,15 @@ void check_root_mount_info(bool output_log)
 }
 
 /*
- * Replace the longest suffix of str1 (that is a prefix of str2) with str1.
- * Result is written to 'out' with a maximum size of 'out_size'.
- * e.g.:
- *    const char *str1 = "10.33.49.27:/srv/nfs/data"; (mount source)
- *    const char *str2 = "/nfs/data/"; (file path via eBPF)
- *    const char *new_prefix = "/mnt/nfs"; (mount point)
- * target: "/mnt/nfs/"
+ * Replace the longest suffix of 'str1' that matches the beginning of 'str2'
+ * with 'new_prefix', and append the remaining part of 'str2'.
+ * The result is written to 'out' with a maximum size of 'out_size'.
+ *
+ * Example:
+ *    str1       = "10.33.49.27:/srv/nfs/data"      (mount source)
+ *    str2       = "/nfs/data/logs/"                (file path via eBPF)
+ *    new_prefix = "/mnt/nfs"                       (mount point)
+ *    Result     = "/mnt/nfs/logs"
  */
 static int replace_suffix_prefix(const char *str1, const char *str2,
 				 const char *new_prefix
@@ -641,7 +654,8 @@ static int replace_suffix_prefix(const char *str1, const char *str2,
 
 u32 copy_file_metrics(int pid, void *dst, void *src, int len,
 		      u32 mntns_id, const char *mount_point,
-		      const char *mount_source, fs_type_t file_type)
+		      const char *mount_source, const char *root,
+		      fs_type_t file_type)
 {
 #define MNTNS_ID_BUF_SZ 12
 	if (len <= 0)
@@ -653,7 +667,7 @@ u32 copy_file_metrics(int pid, void *dst, void *src, int len,
 		len = u32_to_str_safe(mntns_id, mntns_str, sizeof(mntns_str));
 		mntns_str[len] = ':';
 	}
-	
+
 	struct user_io_event_buffer *u_event;
 	struct __io_event_buffer *event = (struct __io_event_buffer *)src;
 	char *buffer = event->filename;
@@ -708,9 +722,42 @@ copy_event:
 					  buffer, sizeof(u_event->file_dir));
 	} else {
 		const char *point = mount_point;
+		int root_len = strlen(root);
+		int dir_len = strlen(temp);
+		int file_len = strlen(event->filename);
 		// Ensure no duplicate slashes appear in the path (e.g., //tmp/filename)
-		if (mount_point[0] == '/' && mount_point[1] == '\0')
+		if (mount_point[0] == '/' && mount_point[1] == '\0') {
 			point = "";
+		} else {
+			/*
+			 * Handle bind mount
+			 *
+			 * Directory mount:
+			 * mount root         = "/mnt/clickhouse"
+			 * mount point        = "/var/lib/clickhouse_storage"
+			 * file path via eBPF = "/mnt/clickhouse/store/151/"
+			 *
+			 * File mount:
+			 * root : /var/lib/kubelet/pods/31247686-d43f-4993-a5c0-76dadaf089e6/etc-hosts
+			 * point: /etc/hosts
+			 */
+			if (dir_len > root_len
+			    && memcmp(root, temp, root_len) == 0
+			    && temp[root_len] == '/') {
+				point = "";
+			} else if ((root_len == dir_len + file_len)
+				   && (memcmp(temp, root, dir_len) == 0)) {
+				const char *p = strrchr(root, '/');
+				p = p ? p + 1 : root;
+
+				if ((strlen(p) == file_len)
+				    && (memcmp(p, event->filename, file_len) ==
+					0)) {
+					point = "";
+				}
+			}
+		}
+
 		temp_index =
 		    fast_strncat_trunc(point, temp, buffer,
 				       sizeof(u_event->file_dir));

--- a/agent/src/ebpf/user/mount.h
+++ b/agent/src/ebpf/user/mount.h
@@ -69,6 +69,7 @@ struct mount_entry {
 	fs_type_t file_type;
 	char *mount_point;
 	char *mount_source;
+	char *root;
 };
 
 /**
@@ -159,12 +160,14 @@ int mount_info_cache_remove(pid_t pid, u64 mntns_id);
  * @param[in]  s_dev          Device ID (major:minor encoded)
  * @param[out] mount_path     Output buffer for mount point path
  * @param[out] mount_source   Output buffer for mount source (e.g., device or NFS path)
+ * @param[out] root	      Output buffer for mount root
  * @param[in]  mount_size     Size of output buffers
  * @param[out] file_type      File type
  */
 void get_mount_info(pid_t pid, int mnt_id, u32 mntns_id,
 		    kern_dev_t s_dev, char *mount_path,
-		    char *mount_source, int mount_size, fs_type_t * file_type);
+		    char *mount_source, char *root,
+		    int mount_size, fs_type_t * file_type);
 
 /**
  * @brief Copy and transform event data containing file paths from eBPF trace.
@@ -178,12 +181,14 @@ void get_mount_info(pid_t pid, int mnt_id, u32 mntns_id,
  * @param[in]  mntns_id      The mount namespace ID of the file
  * @param[in]  mount_point   Mount point path
  * @param[in]  mount_source  Mount source path
+ * @param[in]  root	     Mount root path
  * @param[in]  file_type     File type (FS_TYPE_REGULAR, FS_TYPE_VIRTUAL, FS_TYPE_NETWORK)
  * @return Number of bytes written to dst
  */
 uint32_t copy_file_metrics(int pid, void *dst, void *src, int len,
 			   u32 mntns_id, const char *mount_point,
-			   const char *mount_source, fs_type_t file_type);
+			   const char *mount_source, const char *root,
+			   fs_type_t file_type);
 /**
  * @brief Check for changes in the host root mount namespace's mount information.
  *

--- a/agent/src/ebpf/user/proc.c
+++ b/agent/src/ebpf/user/proc.c
@@ -289,8 +289,8 @@ int get_proc_info_from_cache(pid_t pid, uint8_t * cid, int cid_size,
 			     uint8_t * name, int name_size, int mnt_id,
 			     uint32_t mntns_id, uint32_t *self_mntns_id,
 			     kern_dev_t s_dev, char *mount_point,
-			     char *mount_source, int mount_size,
-			     fs_type_t *file_type)
+			     char *mount_source, char *root,
+			     int mount_size, fs_type_t *file_type)
 {
 	int ret = -1;
 	symbol_caches_hash_t *h = &syms_cache_hash;
@@ -323,7 +323,7 @@ int get_proc_info_from_cache(pid_t pid, uint8_t * cid, int cid_size,
 
 	if (s_dev != DEV_INVALID) {
 		get_mount_info(pid, mnt_id, mntns_id, s_dev, mount_point,
-			       mount_source, mount_size, file_type);
+			       mount_source, root, mount_size, file_type);
 	}
 
 	return ret;

--- a/agent/src/ebpf/user/proc.h
+++ b/agent/src/ebpf/user/proc.h
@@ -212,6 +212,7 @@ int create_and_init_proc_info_caches(void);
  * @param s_dev         Device number to be resolved into a mount point path.
  * @param mount_point   Output buffer to store the mount point path matching `s_dev`.
  * @param mount_source  Output buffer to store the mount source path.
+ * @param root  	Output buffer to store the mount root path.
  * @param mount_size    Size of the `mount_point` buffer in bytes.
  * @param file_type     File type
  *
@@ -228,8 +229,8 @@ int get_proc_info_from_cache(pid_t pid, uint8_t *cid, int cid_size,
 			     uint8_t *name, int name_size, int mnt_id,
 			     uint32_t mntns_id, uint32_t *self_mntns_id,
 			     kern_dev_t s_dev, char *mount_point,
-			     char *mount_source, int mount_size,
-			     fs_type_t *file_type);
+			     char *mount_source, char *root,
+			     int mount_size, fs_type_t *file_type);
 void update_proc_info_cache(pid_t pid, enum proc_act_type type);
 
 // Lower version kernels do not support hooking so files in containers

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1153,6 +1153,7 @@ static void reader_raw_cb(void *cookie, void *raw, int raw_size)
 	int len;
 	void *data_buf_ptr;
 	char mount_point[MAX_PATH_LENGTH] = {0}, mount_source[MAX_PATH_LENGTH] = {0};
+	char root[MAX_PATH_LENGTH] = {0};
 	fs_type_t file_type = FS_TYPE_UNKNOWN;
 
 	// 所有载荷的数据总大小（去掉头）
@@ -1242,7 +1243,7 @@ static void reader_raw_cb(void *cookie, void *raw, int raw_size)
 						       sizeof(submit_data->process_kname),
 						       mnt_id, mntns_id, &self_mntns_id,
 						       s_dev, mount_point, mount_source,
-						       sizeof(mount_point), &file_type);
+						       root, sizeof(mount_point), &file_type);
 
 			// Not found in the process cache, attempting to retrieve from procfs.
 			if (ret) {
@@ -1304,7 +1305,7 @@ static void reader_raw_cb(void *cookie, void *raw, int raw_size)
 				    copy_file_metrics(sd->tgid, submit_data->cap_data
 						      + offset, sd->data, len,
 						      display_mntns_id, mount_point,
-						      mount_source, file_type);
+						      mount_source, root, file_type);
 			} else {
 				memcpy_fast(submit_data->cap_data + offset,
 					    sd->data, len);


### PR DESCRIPTION
* fix: agent - eBPF Adjust the display of the file directory

In the case of a bind mount, the eBPF captured file path contains the mount root prefix. For example:

```
mount_root      = "/mnt/clickhouse"
mount_point     = "/var/lib/clickhouse_storage"
ebpf_file_path  = "/mnt/clickhouse/store/151/"
```
Previously, the logic was:

```
file_dir = mount_point + ebpf_file_path

```

which results in:

```
file_dir = "/var/lib/clickhouse_storage/mnt/clickhouse/store/151/"
```

This is obviously incorrect.

Correct the path to:
```
file_dir = "/mnt/clickhouse/store/151/"
```

* update codes



### This PR is for:


- Agent


#### Affected branches
- main
- v6.6
- v7.0
