### PR TITLE
fix: for local IP data, tag it with Agent information

### DIFF
--- a/server/ingester/flow_log/log_data/l4_flow_log.go
+++ b/server/ingester/flow_log/log_data/l4_flow_log.go
@@ -523,14 +523,6 @@ func (i *Internet) Fill(f *pb.Flow) {
 	i.Province1 = geo.QueryProvince(f.FlowKey.IpDst)
 }
 
-func isLocalIP(isIPv6 bool, ip4 uint32, ip6 net.IP) bool {
-	ip := ip6
-	if !isIPv6 {
-		ip = utils.IpFromUint32(ip4)
-	}
-	return !ip.IsGlobalUnicast()
-}
-
 func (k *KnowledgeGraph) fill(
 	platformData *grpc.PlatformInfoTable,
 	isIPv6, isVipInterface0, isVipInterface1 bool,
@@ -552,14 +544,14 @@ func (k *KnowledgeGraph) fill(
 	// 对于本地的流量，也需要使用MAC来匹配
 	if tapSide == uint32(flow_metrics.Local) {
 		// for local non-unicast IPs, MAC matching is preferred.
-		if isLocalIP(isIPv6, ip40, ip60) {
+		if utils.IsLocalIP(isIPv6, ip40, ip60) {
 			if mac0 != 0 {
 				lookupByMac0 = true
 			} else {
 				lookupByAgent0 = true
 			}
 		}
-		if isLocalIP(isIPv6, ip41, ip61) {
+		if utils.IsLocalIP(isIPv6, ip41, ip61) {
 			if mac1 != 0 {
 				lookupByMac1 = true
 			} else {
@@ -570,12 +562,12 @@ func (k *KnowledgeGraph) fill(
 		// For ebpf traffic, if MAC is valid, MAC lookup is preferred
 		if mac0 != 0 {
 			lookupByMac0 = true
-		} else if isLocalIP(isIPv6, ip40, ip60) {
+		} else if utils.IsLocalIP(isIPv6, ip40, ip60) {
 			lookupByAgent0 = true
 		}
 		if mac1 != 0 {
 			lookupByMac1 = true
-		} else if isLocalIP(isIPv6, ip41, ip61) {
+		} else if utils.IsLocalIP(isIPv6, ip41, ip61) {
 			lookupByAgent1 = true
 		}
 	}

--- a/server/libs/utils/utils.go
+++ b/server/libs/utils/utils.go
@@ -113,6 +113,14 @@ func GetIpHash(ip net.IP) uint32 {
 	return ipHash
 }
 
+func IsLocalIP(isIPv6 bool, ip4 uint32, ip6 net.IP) bool {
+	ip := ip6
+	if !isIPv6 {
+		ip = IpFromUint32(ip4)
+	}
+	return !ip.IsGlobalUnicast()
+}
+
 func Bool2Int(b bool) int {
 	if b {
 		return 1


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


