### PR TITLE
fix: incorrect l2end

### DIFF
--- a/agent/benches/labeler.rs
+++ b/agent/benches/labeler.rs
@@ -262,7 +262,14 @@ fn bench_policy(c: &mut Criterion) {
         b.iter_custom(|iters| {
             let start = Instant::now();
             for _ in 0..iters {
-                first.endpoint_fast_get(EndpointTableType::Ebpf, key.src_ip, key.dst_ip, 2, 0);
+                first.endpoint_fast_get(
+                    EndpointTableType::Ebpf,
+                    key.src_ip,
+                    key.dst_ip,
+                    2,
+                    0,
+                    true,
+                );
             }
             start.elapsed()
         })

--- a/agent/src/policy/first_path.rs
+++ b/agent/src/policy/first_path.rs
@@ -735,13 +735,20 @@ impl FirstPath {
         ip_dst: IpAddr,
         l3_epc_id_src: i32,
         l3_epc_id_dst: i32,
+        l2_end_0: bool,
     ) -> Option<Arc<EndpointData>> {
         if self.fast_disable {
             return None;
         }
 
-        self.fast
-            .get_endpoints(table_type, ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst)
+        self.fast.get_endpoints(
+            table_type,
+            ip_src,
+            ip_dst,
+            l3_epc_id_src,
+            l3_epc_id_dst,
+            l2_end_0,
+        )
     }
 
     pub fn endpoint_fast_add(

--- a/agent/src/policy/policy.rs
+++ b/agent/src/policy/policy.rs
@@ -408,6 +408,7 @@ impl Policy {
             key.dst_ip,
             l3_epc_id_0,
             l3_epc_id_1,
+            key.l2_end_0,
         ) {
             let entry = self.lookup_gpid_entry(key, &endpoints);
             self.send_ebpf(


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### fix: incorrect l2end
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 7.0
- 6.6
- 6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


