### PR TITLE
fix: incorrect l2end

### DIFF
--- a/agent/benches/labeler.rs
+++ b/agent/benches/labeler.rs
@@ -254,7 +254,7 @@ fn bench_policy(c: &mut Criterion) {
         b.iter_custom(|iters| {
             let start = Instant::now();
             for _ in 0..iters {
-                first.ebpf_fast_get(key.src_ip, key.dst_ip, 2, 0);
+                first.ebpf_fast_get(key.src_ip, key.dst_ip, 2, 0, true);
             }
             start.elapsed()
         })

--- a/agent/src/policy/fast_path.rs
+++ b/agent/src/policy/fast_path.rs
@@ -416,8 +416,13 @@ impl FastPath {
         l3_epc_id_dst: i32,
         endpoints: EndpointData,
     ) -> Arc<EndpointData> {
-        let (key_0, key_1) =
-            self.generate_ebpf_map_key(ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst);
+        let (key_0, key_1) = self.generate_ebpf_map_key(
+            ip_src,
+            ip_dst,
+            l3_epc_id_src,
+            l3_epc_id_dst,
+            endpoints.src_info.l2_end,
+        );
         let key = (key_0 as u128) << 64 | key_1 as u128;
         let endpoints = Arc::new(endpoints);
         self.ebpf_table.put(key, endpoints.clone());
@@ -435,6 +440,7 @@ impl FastPath {
         ip_dst: IpAddr,
         l3_epc_id_src: i32,
         l3_epc_id_dst: i32,
+        l2_end_0: bool,
     ) -> Option<Arc<EndpointData>> {
         if self.ebpf_table_flush_flag.load(Ordering::Relaxed) {
             self.ebpf_table.clear();
@@ -443,7 +449,7 @@ impl FastPath {
         }
 
         let (key_0, key_1) =
-            self.generate_ebpf_map_key(ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst);
+            self.generate_ebpf_map_key(ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst, l2_end_0);
         let key = (key_0 as u128) << 64 | key_1 as u128;
 
         self.ebpf_table.get(&key).and_then(|x| Some(x.clone()))
@@ -462,14 +468,16 @@ impl FastPath {
         ip_dst: IpAddr,
         l3_epc_id_src: i32,
         l3_epc_id_dst: i32,
+        l2_end_0: bool,
     ) -> (u64, u64) {
         let (src_masked_ip, dst_masked_ip) = self.generate_mask_ip(ip_src, ip_dst);
         let l3_epc_id_src = l3_epc_id_src as u64;
         let l3_epc_id_dst = l3_epc_id_dst as u64;
+        let (src_flags, dst_flags) = if l2_end_0 { (0xffff, 0) } else { (0, 0xffff) };
 
         (
-            (src_masked_ip as u64) | 0xffff << 32 | l3_epc_id_src << 48,
-            (dst_masked_ip as u64) | 0xffff << 32 | l3_epc_id_dst << 48,
+            (src_masked_ip as u64) | src_flags << 32 | l3_epc_id_src << 48,
+            (dst_masked_ip as u64) | dst_flags << 32 | l3_epc_id_dst << 48,
         )
     }
 
@@ -526,7 +534,7 @@ impl FastPath {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::net::{IpAddr, Ipv4Addr};
     use std::sync::Arc;
 
@@ -778,23 +786,50 @@ mod test {
         let ip_src = IpAddr::from("192.169.1.100".parse::<Ipv4Addr>().unwrap());
         let ip_dst = IpAddr::from("172.29.2.200".parse::<Ipv4Addr>().unwrap());
         let mut endpoints: EndpointData = Default::default();
+        endpoints.src_info.l2_end = true;
         endpoints.src_info.l3_epc_id = 10;
         endpoints.dst_info.l3_epc_id = 20;
 
         let e = table.ebpf_add_endpoints(ip_src, ip_dst, 10, 0, endpoints);
         assert_eq!(10, e.src_info.l3_epc_id);
         assert_eq!(20, e.dst_info.l3_epc_id);
-        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 10, 0).unwrap();
+        let e = table
+            .ebpf_get_endpoints(ip_src, ip_dst, 10, 0, true)
+            .unwrap();
         assert_eq!(10, e.src_info.l3_epc_id);
         assert_eq!(20, e.dst_info.l3_epc_id);
-        let e = table.ebpf_get_endpoints(ip_dst, ip_src, 0, 10).unwrap();
+        let e = table
+            .ebpf_get_endpoints(ip_dst, ip_src, 0, 10, false)
+            .unwrap();
         assert_eq!(20, e.src_info.l3_epc_id);
         assert_eq!(10, e.dst_info.l3_epc_id);
-        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 0, 0);
+        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 0, 0, true);
         assert!(e.is_none());
-        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 0, 10);
+        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 0, 10, false);
         assert!(e.is_none());
-        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 10, 20);
+        let e = table.ebpf_get_endpoints(ip_src, ip_dst, 10, 20, true);
         assert!(e.is_none());
+
+        let ip_src = IpAddr::from("192.168.1.100".parse::<Ipv4Addr>().unwrap());
+        let ip_dst = IpAddr::from("192.168.1.200".parse::<Ipv4Addr>().unwrap());
+        let mut endpoints: EndpointData = Default::default();
+        endpoints.src_info.l2_end = true;
+        endpoints.src_info.l3_epc_id = 10;
+        endpoints.dst_info.l3_epc_id = 10;
+        let e = table.ebpf_add_endpoints(ip_src, ip_dst, 10, 10, endpoints);
+        assert_eq!(true, e.src_info.l2_end);
+        assert_eq!(false, e.dst_info.l2_end);
+
+        let e = table
+            .ebpf_get_endpoints(ip_src, ip_dst, 10, 10, true)
+            .unwrap();
+        assert_eq!(true, e.src_info.l2_end);
+        assert_eq!(false, e.dst_info.l2_end);
+
+        let e = table
+            .ebpf_get_endpoints(ip_dst, ip_src, 10, 10, false)
+            .unwrap();
+        assert_eq!(false, e.src_info.l2_end);
+        assert_eq!(true, e.dst_info.l2_end);
     }
 }

--- a/agent/src/policy/first_path.rs
+++ b/agent/src/policy/first_path.rs
@@ -714,13 +714,14 @@ impl FirstPath {
         ip_dst: IpAddr,
         l3_epc_id_src: i32,
         l3_epc_id_dst: i32,
+        l2_end_0: bool,
     ) -> Option<Arc<EndpointData>> {
         if self.fast_disable {
             return None;
         }
 
         self.fast
-            .ebpf_get_endpoints(ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst)
+            .ebpf_get_endpoints(ip_src, ip_dst, l3_epc_id_src, l3_epc_id_dst, l2_end_0)
     }
 
     pub fn ebpf_fast_add(

--- a/agent/src/policy/policy.rs
+++ b/agent/src/policy/policy.rs
@@ -404,10 +404,13 @@ impl Policy {
             (0, local_epc_id)
         };
 
-        if let Some(endpoints) =
-            self.table
-                .ebpf_fast_get(key.src_ip, key.dst_ip, l3_epc_id_0, l3_epc_id_1)
-        {
+        if let Some(endpoints) = self.table.ebpf_fast_get(
+            key.src_ip,
+            key.dst_ip,
+            l3_epc_id_0,
+            l3_epc_id_1,
+            key.l2_end_0,
+        ) {
             let entry = self.lookup_gpid_entry(key, &endpoints);
             self.send_ebpf(
                 key.src_ip,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### fix: incorrect l2end
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 7.0
- 6.6
- 6.5
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


