### PR TITLE
feat: agent - eBPF Support Rocky Linux 5.14

### DIFF
--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -571,7 +571,8 @@ int load_ebpf_object(struct ebpf_object *obj)
 	if (ret != 0) {
 		ebpf_warning("bpf load '%s' failed, error:%s (%d).\n",
 			     obj->name, strerror(errno), errno);
-		if (!strcmp(obj->name, "socket-trace-bpf-linux-kfunc")) {
+		if (!strcmp(obj->name, "socket-trace-bpf-linux-kfunc") ||
+		    !strcmp(obj->name, "socket-trace-bpf-linux-5.2_plus")) {
 			ebpf_info("Try other eBPF bytecode binaries ...\n");
 			release_object(obj);
 			return ret;


### PR DESCRIPTION
When loading the `socket-trace-bpf-linux-5.2_plus` eBPF bytecode on **Rocky Linux kernel 5.14**, the kernel verifier reports that the instruction limit has been exceeded. The error message is as follows:

```
BPF program is too large. Processed 1000001 insn
processed 1000001 insns (limit 1000000) max_states_per_insn 60 total_states 48637 peak_states 4495 mark_read 85

[2025-10-22T03:58:39.026Z INFO  socket_tracer::ebpf] [eBPF] WARN func load_obj__progs() [user/load.c:634] bcc_prog_load() failed. name: df_T_exit_sendmsg, Argument list too long errno: 7
```

This issue has **not been observed on other kernel versions**, and it is considered a **bug in the eBPF verifier** of the 5.14 kernel. To work around this problem, we **load the `socket-trace-bpf-linux-common` eBPF bytecode** instead, which reduces the number of instructions and avoids exceeding the verifier limit.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:



- Agent



#### Affected branches
- main
- v7.0
- v6.6