### PR TITLE
feat: agent - eBPF Support Rocky Linux 5.14

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -2596,7 +2596,8 @@ static int check_dependencies(void)
 }
 
 static int select_bpf_binary(char load_name[NAME_LEN], void **bin_buffer,
-			     int *bin_buf_size, bool skip_kfunc)
+			     int *bin_buf_size, bool skip_kfunc,
+			     bool skip_k_5_2)
 {
 	void *bpf_bin_buffer;
 	int buffer_sz;
@@ -2628,7 +2629,7 @@ static int select_bpf_binary(char load_name[NAME_LEN], void **bin_buffer,
 		snprintf(load_name, NAME_LEN, "socket-trace-bpf-linux-kylin");
 		bpf_bin_buffer = (void *)socket_trace_kylin_ebpf_data;
 		buffer_sz = sizeof(socket_trace_kylin_ebpf_data);
-	} else if (major > 5 || (major == 5 && minor >= 2)) {
+	} else if (!skip_k_5_2 && (major > 5 || (major == 5 && minor >= 2))) {
 		g_k_type = K_TYPE_VER_5_2_PLUS;
 		snprintf(load_name, NAME_LEN,
 			 "socket-trace-bpf-linux-5.2_plus");
@@ -2732,7 +2733,7 @@ int running_socket_tracer(tracer_callback_t handle,
 	}
 
 	select_bpf_binary(bpf_load_buffer_name, &bpf_bin_buffer, &buffer_sz,
-			  !use_kfunc_bin);
+			  !use_kfunc_bin, false);
 
 	/*
 	 * Initialize datadump
@@ -2789,16 +2790,38 @@ int running_socket_tracer(tracer_callback_t handle,
 	conf_max_trace_entries = max_trace_entries;
 
 	bool has_attempted = false;
-retry_load:
-	if (tracer_bpf_load(tracer)) {
-		if (!has_attempted && g_k_type == K_TYPE_KFUNC) {
-			has_attempted = true;
-			select_bpf_binary(bpf_load_buffer_name, &bpf_bin_buffer,
-					  &buffer_sz, true);
-			reconfig_load_resources(tracer, bpf_load_buffer_name,
-						bpf_bin_buffer, buffer_sz, tps);
-			goto retry_load;
+	while (true) {
+		if (tracer_bpf_load(tracer) == 0) {
+			// Loading succeeded, exit the loop
+			break;
 		}
+
+		if (!has_attempted) {
+			if (g_k_type == K_TYPE_KFUNC) {
+				has_attempted = true;
+				select_bpf_binary(bpf_load_buffer_name,
+						  &bpf_bin_buffer, &buffer_sz,
+						  true, false);
+				reconfig_load_resources(tracer,
+							bpf_load_buffer_name,
+							bpf_bin_buffer,
+							buffer_sz, tps);
+				continue;	/* Retry the load */
+			}
+
+			if (g_k_type == K_TYPE_VER_5_2_PLUS) {
+				has_attempted = true;
+				select_bpf_binary(bpf_load_buffer_name,
+						  &bpf_bin_buffer, &buffer_sz,
+						  true, true);
+				reconfig_load_resources(tracer,
+							bpf_load_buffer_name,
+							bpf_bin_buffer,
+							buffer_sz, tps);
+				continue;	/* Retry the load */
+			}
+		}
+
 		return -EINVAL;
 	}
 

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -571,7 +571,8 @@ int load_ebpf_object(struct ebpf_object *obj)
 	if (ret != 0) {
 		ebpf_warning("bpf load '%s' failed, error:%s (%d).\n",
 			     obj->name, strerror(errno), errno);
-		if (!strcmp(obj->name, "socket-trace-bpf-linux-kfunc")) {
+		if (!strcmp(obj->name, "socket-trace-bpf-linux-kfunc") ||
+		    !strcmp(obj->name, "socket-trace-bpf-linux-5.2_plus")) {
 			ebpf_info("Try other eBPF bytecode binaries ...\n");
 			release_object(obj);
 			return ret;


### PR DESCRIPTION
When loading the `socket-trace-bpf-linux-5.2_plus` eBPF bytecode on **Rocky Linux kernel 5.14**, the kernel verifier reports that the instruction limit has been exceeded. The error message is as follows:

```
BPF program is too large. Processed 1000001 insn
processed 1000001 insns (limit 1000000) max_states_per_insn 60 total_states 48637 peak_states 4495 mark_read 85

[2025-10-22T03:58:39.026Z INFO  socket_tracer::ebpf] [eBPF] WARN func load_obj__progs() [user/load.c:634] bcc_prog_load() failed. name: df_T_exit_sendmsg, Argument list too long errno: 7
```

This issue has **not been observed on other kernel versions**, and it is considered a **bug in the eBPF verifier** of the 5.14 kernel. To work around this problem, we **load the `socket-trace-bpf-linux-common` eBPF bytecode** instead, which reduces the number of instructions and avoids exceeding the verifier limit.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:



- Agent



#### Affected branches
- main
- v7.0
- v6.6