### PR TITLE
feat: store traces for packet signal source data

### DIFF
--- a/server/ingester/flow_log/decoder/decoder.go
+++ b/server/ingester/flow_log/decoder/decoder.go
@@ -42,6 +42,7 @@ import (
 	"github.com/deepflowio/deepflow/server/libs/codec"
 	"github.com/deepflowio/deepflow/server/libs/datatype"
 	"github.com/deepflowio/deepflow/server/libs/datatype/pb"
+	flow_metrics "github.com/deepflowio/deepflow/server/libs/flow-metrics"
 	"github.com/deepflowio/deepflow/server/libs/grpc"
 	"github.com/deepflowio/deepflow/server/libs/queue"
 	"github.com/deepflowio/deepflow/server/libs/receiver"
@@ -445,8 +446,10 @@ func (d *Decoder) spanWrite(l *log_data.L7FlowLog) {
 		return
 	}
 
-	if (l.SignalSource == uint16(datatype.SIGNAL_SOURCE_EBPF) ||
-		l.SignalSource == uint16(datatype.SIGNAL_SOURCE_OTEL)) && l.TraceId != "" {
+	if ((l.SignalSource == uint16(datatype.SIGNAL_SOURCE_EBPF) || l.SignalSource == uint16(datatype.SIGNAL_SOURCE_OTEL)) ||
+		// Resolving service rendering issues when cloud hosts do not support eBPF
+		(l.TapSide == flow_metrics.Client.String() || l.TapSide == flow_metrics.Server.String())) &&
+		l.TraceId != "" {
 		l.AddReferenceCount()
 		d.spanBuf = append(d.spanBuf, (*dbwriter.SpanWithTraceID)(l))
 		if len(d.spanBuf) >= BUFFER_SIZE {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server


<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


