### PR TITLE
feat: eBPF support static OpenSSL linking for uprobe-based decryption

### DIFF
--- a/agent/src/ebpf/user/ssl_tracer.c
+++ b/agent/src/ebpf/user/ssl_tracer.c
@@ -65,22 +65,22 @@ static void openssl_parse_and_register(int pid, struct tracer_probes_conf *conf)
 	char *path = NULL;
 
 	if (pid <= 1)
-		goto out;
+		return;
 
 	if (!is_user_process(pid))
-		goto out;
+		return;
 
 	path = get_so_path_by_pid_and_name(pid, "ssl");
-	if (!path)
-		goto out;
+	if (!path) {
+		path = get_elf_path_by_pid(pid);
+		if (!path)
+			return;
+	}
 
 	ebpf_info("openssl uprobe, pid:%d, path:%s\n", pid, path);
 	add_probe_sym_to_tracer_probes(pid, path, conf, symbols,
 				       NELEMS(symbols));
-
-out:
 	free(path);
-	return;
 }
 
 static void clear_ssl_probes_by_pid(struct bpf_tracer *tracer, int pid)


### PR DESCRIPTION
Previously we only supported targets that were dynamically linked (using shared libssl/libcrypto) when locating hook offsets for uprobe-based decryption. Add support for targets where OpenSSL is statically linked into the binary.

Changes:
- Add logic to detect and handle statically linked OpenSSL in target binaries.


### This PR is for:

- Agent


#### Affected branches
- main
- v7.0
- v6.6