### PR TITLE
fix: empty trace id shoud not be stored

### DIFF
--- a/agent/src/flow_generator/protocol_logs.rs
+++ b/agent/src/flow_generator/protocol_logs.rs
@@ -641,6 +641,9 @@ impl PrioFields {
     // insertion is kept in ascending order by prio; if prio is the same, insert it at the end (stable sort)
     #[inline]
     fn insert_sorted(&mut self, field: PrioField<String>) {
+        if field.field.is_empty() {
+            return;
+        }
         // find the first position greater than it (>), skip those that are equal
         let pos = match self.0.binary_search_by(|x| x.prio.cmp(&field.prio)) {
             Ok(mut i) => {

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -477,8 +477,10 @@ impl SofaRpcLog {
             let sofa_hdr = SofaHdr::from(hdr_payload);
             info.target_serv = sofa_hdr.service;
             info.method = sofa_hdr.method;
-            info.trace_ids
-                .merge_field(BASE_FIELD_PRIORITY, sofa_hdr.trace_id);
+            if !sofa_hdr.trace_id.is_empty() {
+                info.trace_ids
+                    .merge_field(BASE_FIELD_PRIORITY, sofa_hdr.trace_id);
+            }
 
             if !sofa_hdr.new_rpc_trace_context.is_empty() {
                 info.fill_with_trace_ctx(sofa_hdr.new_rpc_trace_context);


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


