### PR TITLE
fix: miss created_at field in dm domain table

### DIFF
--- a/server/controller/db/metadb/migrator/schema/rawsql/dameng/ddl_create_table.sql
+++ b/server/controller/db/metadb/migrator/schema/rawsql/dameng/ddl_create_table.sql
@@ -442,6 +442,7 @@ BEGIN
     controller_ip       VARCHAR(64),
     lcuuid              VARCHAR(64) DEFAULT '''',
     synced_at           DATETIME DEFAULT NULL,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 )';
     EXECUTE IMMEDIATE 'TRUNCATE TABLE "domain"';


### PR DESCRIPTION

### This PR is for:

- Server

#### Affected branches
- v66