### PR TITLE
feat: eBPF support pushing two DNS query messages from a single syscall

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -259,8 +259,17 @@ struct data_args_t {
 	const char *buf;
 	// For sendmsg()/recvmsg()/writev()/readv().
 	const struct iovec *iov;
-	void *sk;
 	size_t iovlen;
+	/*
+	 * When calling `sendmmsg()`, if multiple `struct mmsghdr` instances
+	 * are passed, these structures are stored contiguously in memory as an array.
+	 * Each `mmsghdr` contains information for an individual message to be sent.
+	 * To access the second structure, its address corresponds to the array
+	 * element’s address (i.e., `&msgvec[1]`).
+	 */ 
+	const struct iovec *extra_iov;
+	size_t extra_iovlen;
+	void *sk;
 	union {
 		// For sendmmsg()
 		unsigned int *msg_len;

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -2212,8 +2212,8 @@ static inline int __set_data_limit_max(int limit_size)
 
 /**
  * Set maximum amount of data passed to the agent by eBPF programe.
- * @limit_size : The maximum length of data. If @limit_size exceeds 8192,
- *               it will automatically adjust to 8192 bytes.
+ * @limit_size : The maximum length of data. If @limit_size exceeds 16384,
+ *               it will automatically adjust to 16384 bytes.
  *               If limit_size is 0, Use the default values 4096.
  *
  * @return the set maximum buffer size value on success, < 0 on failure.


### PR DESCRIPTION
Single sendmmsg calls may contain multiple DNS queries (e.g., A and AAAA records) stored in separate user-space memory buffers. Previously, only one message could be processed, dropping subsequent queries.

This change introduces logic to read and push additional DNS query payloads via `extra_iov`, ensuring both A (IPv4) and AAAA (IPv6) records are captured and exported correctly.

Example:
  A single DNS request may include:
    - A record query
    - AAAA record query
    
These are processed sequentially and pushed as separate messages.



### This PR is for:


- Agent



#### Affected branches
- main
- v6.6
- v7.0



