### PR TITLE
feat: eBPF Modify the method of marking the close event

### DIFF
--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -52,6 +52,8 @@ enum message_type {
 	MSG_PRESTORE,
 	// 对于l7的协议推断需要再确认逻辑。
 	MSG_RECONFIRM,
+	// Indicates a socket close event
+	MSG_CLOSE,
 	// 用于信息相关清理，一般用于socket信息清除
 	MSG_CLEAR
 };
@@ -96,6 +98,10 @@ enum traffic_protocol {
 	PROTO_NUM = 200
 };
 
+/*
+ * Note that the maximum value here should not exceed 15,
+ * because 'struct socket_info_s' uses 4 bits to store 'data_source'.
+ */
 enum process_data_extra_source {
 	DATA_SOURCE_SYSCALL,
 	DATA_SOURCE_GO_TLS_UPROBE,
@@ -103,7 +109,7 @@ enum process_data_extra_source {
 	DATA_SOURCE_OPENSSL_UPROBE,
 	DATA_SOURCE_IO_EVENT,
 	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
-	DATA_SOURCE_CLOSE,
+	DATA_SOURCE_RESERVED,
 	DATA_SOURCE_DPDK,
 	DATA_SOURCE_UNIX_SOCKET,
 };

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -142,7 +142,8 @@ struct socket_info_s {
 	 * participate in tracing.
 	 */
 	__u16 no_trace:1;
-	__u16 unused_bits:11;
+	__u16 data_source:4; // The source of the stored data, defined in the 'enum process_data_extra_source'. 
+	__u16 unused_bits:7;
 	__u32 reasm_bytes;	// The amount of data bytes that have been reassembled.
 
 	/*

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -1443,6 +1443,7 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		sk_info->direction = conn_info->direction;
 		sk_info->pre_direction = conn_info->direction;
 		sk_info->role = conn_info->role;
+		sk_info->data_source = extra->source;
 		sk_info->update_time = time_stamp / NS_PER_SEC;
 		sk_info->need_reconfirm = conn_info->need_reconfirm;
 		sk_info->correlation_id = conn_info->correlation_id;
@@ -1528,8 +1529,10 @@ __data_submit(struct pt_regs *ctx, struct conn_info_s *conn_info,
 		 * be re inferred to determine the upper layer protocol of TLS.
 		 */
 		if (socket_info_ptr->l7_proto == PROTO_TLS ||
-		    socket_info_ptr->l7_proto == PROTO_UNKNOWN)
+		    socket_info_ptr->l7_proto == PROTO_UNKNOWN) {
 			socket_info_ptr->l7_proto = conn_info->protocol;
+			socket_info_ptr->data_source = extra->source;
+		}
 
 		/*
 		 * Ensure that the accumulation operation of capturing the
@@ -2806,6 +2809,7 @@ KRETFUNC_PROG(do_readv, unsigned long fd, const struct iovec __user * vec,
 
 static __inline void __push_close_event(__u64 pid_tgid, __u64 uid, __u64 seq,
 					__u16 l7_proto,
+					enum process_data_extra_source source,
 					struct member_fields_offset *offset,
 					void *ctx)
 {
@@ -2832,10 +2836,10 @@ static __inline void __push_close_event(__u64 pid_tgid, __u64 uid, __u64 seq,
 	v->tgid = (__u32) (pid_tgid >> 32);
 	v->pid = (__u32) pid_tgid;
 	v->timestamp = bpf_ktime_get_ns();
-	v->source = DATA_SOURCE_CLOSE;
+	v->source = source;
 	v->syscall_len = 0;
 	v->data_seq = seq;
-	v->msg_type = MSG_COMMON;
+	v->msg_type = MSG_CLOSE;
 	v->data_type = l7_proto;
 	bpf_get_current_comm(v->comm, sizeof(v->comm));
 
@@ -2895,6 +2899,7 @@ KFUNC_PROG(__arm64_sys_close, const struct pt_regs *regs)
 
 	__u64 id = bpf_get_current_pid_tgid();
 	__u64 conn_key = gen_conn_key_id(id >> 32, (__u64) fd);
+	enum process_data_extra_source source = 0;
 	struct socket_info_s *socket_info_ptr =
 	    socket_info_map__lookup(&conn_key);
 	if (socket_info_ptr == NULL) {
@@ -2902,11 +2907,14 @@ KFUNC_PROG(__arm64_sys_close, const struct pt_regs *regs)
 		return 0;
 	}
 
-	if (socket_info_ptr->uid)
+	if (socket_info_ptr->uid) {
 		__sync_fetch_and_add(&socket_info_ptr->seq, 1);
+		source = socket_info_ptr->data_source;
+	}
+
 	delete_socket_info(conn_key, socket_info_ptr);
 	__push_close_event(id, socket_info_ptr->uid, socket_info_ptr->seq,
-			   socket_info_ptr->l7_proto,
+			   socket_info_ptr->l7_proto, source,
 			   offset, (void *)ctx);
 	return 0;
 }

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -151,8 +151,6 @@ pub const DATA_SOURCE_IO_EVENT: u8 = 4;
 #[allow(dead_code)]
 pub const DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE: u8 = 5;
 #[allow(dead_code)]
-pub const DATA_SOURCE_CLOSE: u8 = 6;
-#[allow(dead_code)]
 pub const DATA_SOURCE_UNIX_SOCKET: u8 = 8;
 cfg_if::cfg_if! {
     if #[cfg(feature = "extended_observability")] {
@@ -188,6 +186,18 @@ pub const MSG_REASM_SEG: u8 = 6;
 // set to 'MSG_COMMON'.
 #[allow(dead_code)]
 pub const MSG_COMMON: u8 = 7;
+// Explanation of the case where the same socket has two sources:
+// Typical example:
+// TLS handshake and uprobe TLS encrypted data essentially share the same socket.
+// Initially, the handshake is traced via kprobe.
+// After a successful handshake, encrypted data is traced via uprobe.
+// Finally, a close event occurs.
+//
+// There is only one close event because there is only one socket communication.
+// The system sends only one close syscall, and at that time,
+// the close event's SOURCE is identified as uprobe.
+#[allow(dead_code)]
+pub const MSG_CLOSE: u8 = 10;
 
 //Register event types
 #[allow(dead_code)]


### PR DESCRIPTION
Extend the `msg_type` field in struct `SK_BPF_DATA` to support `MSG_CLOSE` for close events, and remove the use of the `source` field for identifying close events.



### This PR is for:


- Agent



#### Affected branches
- main
- v7.0
- v6.6