### PR TITLE
feat: eBPF Modify the method of marking the close event

### DIFF
--- a/agent/src/ebpf/kernel/include/common.h
+++ b/agent/src/ebpf/kernel/include/common.h
@@ -52,6 +52,8 @@ enum message_type {
 	MSG_PRESTORE,
 	// 对于l7的协议推断需要再确认逻辑。
 	MSG_RECONFIRM,
+	// Indicates a socket close event
+	MSG_CLOSE,
 	// 用于信息相关清理，一般用于socket信息清除
 	MSG_CLEAR
 };
@@ -97,6 +99,10 @@ enum traffic_protocol {
 	PROTO_NUM = 200
 };
 
+/*
+ * Note that the maximum value here should not exceed 15,
+ * because 'struct socket_info_s' uses 4 bits to store 'data_source'.
+ */
 enum process_data_extra_source {
 	DATA_SOURCE_SYSCALL,
 	DATA_SOURCE_GO_TLS_UPROBE,
@@ -104,7 +110,7 @@ enum process_data_extra_source {
 	DATA_SOURCE_OPENSSL_UPROBE,
 	DATA_SOURCE_IO_EVENT,
 	DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE,
-	DATA_SOURCE_CLOSE,
+	DATA_SOURCE_RESERVED,
 	DATA_SOURCE_DPDK,
 	DATA_SOURCE_UNIX_SOCKET,
 };

--- a/agent/src/ebpf/kernel/include/socket_trace_common.h
+++ b/agent/src/ebpf/kernel/include/socket_trace_common.h
@@ -142,7 +142,8 @@ struct socket_info_s {
 	 * participate in tracing.
 	 */
 	__u16 no_trace:1;
-	__u16 unused_bits:11;
+	__u16 data_source:4; // The source of the stored data, defined in the 'enum process_data_extra_source'. 
+	__u16 unused_bits:7;
 	__u32 reasm_bytes;	// The amount of data bytes that have been reassembled.
 
 	/*

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -153,8 +153,6 @@ pub const DATA_SOURCE_IO_EVENT: u8 = 4;
 #[allow(dead_code)]
 pub const DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE: u8 = 5;
 #[allow(dead_code)]
-pub const DATA_SOURCE_CLOSE: u8 = 6;
-#[allow(dead_code)]
 pub const DATA_SOURCE_UNIX_SOCKET: u8 = 8;
 cfg_if::cfg_if! {
     if #[cfg(feature = "extended_observability")] {
@@ -190,6 +188,18 @@ pub const MSG_REASM_SEG: u8 = 6;
 // set to 'MSG_COMMON'.
 #[allow(dead_code)]
 pub const MSG_COMMON: u8 = 7;
+// Explanation of the case where the same socket has two sources:
+// Typical example:
+// TLS handshake and uprobe TLS encrypted data essentially share the same socket.
+// Initially, the handshake is traced via kprobe.
+// After a successful handshake, encrypted data is traced via uprobe.
+// Finally, a close event occurs.
+//
+// There is only one close event because there is only one socket communication.
+// The system sends only one close syscall, and at that time,
+// the close event's SOURCE is identified as uprobe.
+#[allow(dead_code)]
+pub const MSG_CLOSE: u8 = 10;
 
 //Register event types
 #[allow(dead_code)]


### PR DESCRIPTION
Extend the `msg_type` field in struct `SK_BPF_DATA` to support `MSG_CLOSE` for close events, and remove the use of the `source` field for identifying close events.



### This PR is for:


- Agent



#### Affected branches
- main
- v7.0
- v6.6