### PR TITLE
fix: querier deduplicate group error

### DIFF
--- a/server/querier/engine/clickhouse/view/view.go
+++ b/server/querier/engine/clickhouse/view/view.go
@@ -398,24 +398,30 @@ func (sv *SubView) ToString() string {
 
 func (sv *SubView) removeDup(ns NodeSet) []Node {
 	// 对NodeSet集合去重
-	tmpMap := make(map[string]interface{})
+	tmpMap := make(map[string]bool)
 	nodeList := ns.getList()
 	targetList := nodeList[:0]
 	for _, node := range nodeList {
 		str := node.ToString()
-		strNoPreffix := strings.Trim(str, "`")
-		if _, ok := tmpMap[strNoPreffix]; !ok {
-			targetList = append(targetList, node)
-			tmpMap[strNoPreffix] = nil
-			// if the tag after as already exists, it is also considered duplicate​​​
-			strUpper := strNoPreffix
-			if strings.Contains(strNoPreffix, " as ") {
-				strUpper = strings.ReplaceAll(strNoPreffix, " as ", " AS ")
+		postAs := ""
+		// x as y
+		// if the tag after as already exists, it is also considered duplicate​​​
+		if strings.Contains(str, " ") {
+			strSlice := strings.Fields(str)
+			if len(strSlice) == 3 && strings.ToUpper(strSlice[1]) == "AS" {
+				postAs = strings.Trim(strSlice[2], "`")
 			}
-			strSlice := strings.Split(strUpper, " AS ")
-			if len(strSlice) == 2 {
-				postAsNoPrefix := strings.Trim(strSlice[1], "`")
-				tmpMap[postAsNoPrefix] = nil
+		}
+		if postAs != "" {
+			if !tmpMap[postAs] {
+				targetList = append(targetList, node)
+				tmpMap[postAs] = true
+			}
+		} else {
+			strNoBackquote := strings.Trim(str, "`")
+			if !tmpMap[strNoBackquote] {
+				targetList = append(targetList, node)
+				tmpMap[strNoBackquote] = true
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


