### PR TITLE
fix: use aavg instead of avg in deepflow avg countings

### DIFF
--- a/server/querier/app/prometheus/service/converters.go
+++ b/server/querier/app/prometheus/service/converters.go
@@ -109,7 +109,7 @@ var hostUniversalTags = []string{
 // convert promql aggregation functions to querier functions
 var aggFunctions = map[string]string{
 	"sum":          view.FUNCTION_SUM,
-	"avg":          view.FUNCTION_AVG,
+	"avg":          view.FUNCTION_AAVG,
 	"count":        view.FUNCTION_COUNT,
 	"min":          view.FUNCTION_MIN,
 	"max":          view.FUNCTION_MAX,
@@ -216,7 +216,7 @@ func (p *prometheusReader) promReaderTransToSQL(ctx context.Context, req *prompb
 
 			// aggregation for metrics, assert aggOperator is not empty
 			switch aggOperator {
-			case view.FUNCTION_SUM, view.FUNCTION_AVG, view.FUNCTION_MIN, view.FUNCTION_MAX, view.FUNCTION_STDDEV:
+			case view.FUNCTION_SUM, view.FUNCTION_AAVG, view.FUNCTION_AVG, view.FUNCTION_MIN, view.FUNCTION_MAX, view.FUNCTION_STDDEV:
 				metricWithAggFunc = fmt.Sprintf("%s(`%s`)", aggOperator, metricName)
 			case "1":
 				// group


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes avg calculation
#### Steps to reproduce the bug
#### Changes to fix the bug
- use aavg instead of avg in `avg` for deepflow metrics