### PR TITLE
perf: Reduce the load and bandwidth usage on MySQL

### DIFF
--- a/server/controller/monitor/vtap/vtap.go
+++ b/server/controller/monitor/vtap/vtap.go
@@ -88,16 +88,30 @@ func (v *VTapCheck) Stop() {
 
 func (v *VTapCheck) launchServerCheck(db *metadb.DB) {
 	var vtaps []metadbmodel.VTap
+	var vms []metadbmodel.VM
+	var podNodes []metadbmodel.PodNode
 	var reg = regexp.MustCompile(` |:`)
 
 	log.Debugf("vtap launch_server check start", db.LogPrefixORGID)
+
+	db.Select("id", "lcuuid", "name", "region").Find(&vms)
+	lcuuidToVM := make(map[string]metadbmodel.VM)
+	for _, vm := range vms {
+		lcuuidToVM[vm.Lcuuid] = vm
+	}
+
+	db.Select("id", "lcuuid", "name", "region").Find(&podNodes)
+	lcuuidToPodNode := make(map[string]metadbmodel.PodNode)
+	for _, podNode := range podNodes {
+		lcuuidToPodNode[podNode.Lcuuid] = podNode
+	}
 
 	db.Select("id", "type", "lcuuid", "name", "launch_server_id", "region", "type", "launch_server").Find(&vtaps)
 	for _, vtap := range vtaps {
 		switch vtap.Type {
 		case common.VTAP_TYPE_WORKLOAD_V:
-			var vm metadbmodel.VM
-			if ret := db.Where("lcuuid = ?", vtap.Lcuuid).First(&vm); ret.Error != nil {
+			vm, ok := lcuuidToVM[vtap.Lcuuid]
+			if !ok {
 				log.Infof("delete vtap: %s %s, because no related vm", vtap.Name, vtap.Lcuuid, db.LogPrefixORGID)
 				db.Delete(&vtap)
 			} else {
@@ -161,8 +175,8 @@ func (v *VTapCheck) launchServerCheck(db *metadb.DB) {
 				}
 			}
 		case common.VTAP_TYPE_POD_HOST, common.VTAP_TYPE_POD_VM:
-			var podNode metadbmodel.PodNode
-			if ret := db.Where("lcuuid = ?", vtap.Lcuuid).First(&podNode); ret.Error != nil {
+			podNode, ok := lcuuidToPodNode[vtap.Lcuuid]
+			if !ok {
 				log.Infof("delete vtap: %s %s", vtap.Name, vtap.Lcuuid, db.LogPrefixORGID)
 				db.Delete(&vtap)
 			} else {
@@ -238,13 +252,16 @@ func (v *VTapCheck) typeCheck(db *metadb.DB) {
 	var vtaps []metadbmodel.VTap
 	var podNodes []metadbmodel.PodNode
 	var conns []metadbmodel.VMPodNodeConnection
+	var vms []metadbmodel.VM
 
 	log.Debugf("vtap type check start", db.LogPrefixORGID)
 
-	db.Find(&podNodes)
-	idToPodNode := make(map[int]*metadbmodel.PodNode)
-	for i, podNode := range podNodes {
-		idToPodNode[podNode.ID] = &podNodes[i]
+	db.Select("id", "lcuuid", "name").Find(&podNodes)
+	idToPodNode := make(map[int]metadbmodel.PodNode)
+	lcuuidToPodNode := make(map[string]metadbmodel.PodNode)
+	for _, podNode := range podNodes {
+		idToPodNode[podNode.ID] = podNode
+		lcuuidToPodNode[podNode.Lcuuid] = podNode
 	}
 
 	db.Find(&conns)
@@ -255,8 +272,9 @@ func (v *VTapCheck) typeCheck(db *metadb.DB) {
 		podNodeIDToVMID[conn.PodNodeID] = conn.VMID
 	}
 
-	var vms []metadbmodel.VM
-	if err := db.Where("htype in ?", []int{common.VM_HTYPE_BM_C, common.VM_HTYPE_BM_N, common.VM_HTYPE_BM_S}).Find(&vms).Error; err != nil {
+	if err := db.Select("id", "htype").Where(
+		"htype in ?", []int{common.VM_HTYPE_BM_C, common.VM_HTYPE_BM_N, common.VM_HTYPE_BM_S},
+	).Find(&vms).Error; err != nil {
 		log.Error(err, db.LogPrefixORGID)
 	}
 	vmIDToVMType := make(map[int]int)
@@ -294,8 +312,8 @@ func (v *VTapCheck) typeCheck(db *metadb.DB) {
 				continue
 			}
 		} else {
-			var podNode metadbmodel.PodNode
-			if ret := db.Where("lcuuid = ?", vtap.Lcuuid).First(&podNode); ret.Error != nil {
+			podNode, ok := lcuuidToPodNode[vtap.Lcuuid]
+			if !ok {
 				continue
 			}
 			vmID, ok := podNodeIDToVMID[podNode.ID]


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


