### PR TITLE
fix: missing lifetime specifier

### DIFF
--- a/agent/crates/enterprise-utils/src/lib.rs
+++ b/agent/crates/enterprise-utils/src/lib.rs
@@ -32,6 +32,8 @@ pub mod l7 {
         }
 
         pub mod custom_field_policy {
+            use std::marker::PhantomData;
+
             pub mod enums {
                 use std::sync::Arc;
 
@@ -89,8 +91,11 @@ pub mod l7 {
             }
 
             #[derive(Clone, Copy, Debug)]
-            pub struct PolicySlice;
-            impl PolicySlice {
+            pub struct PolicySlice<'a> {
+                _marker: PhantomData<&'a ()>,
+            }
+
+            impl<'a> PolicySlice<'a> {
                 pub fn apply(
                     &self,
                     _: &mut Store,
@@ -339,6 +344,7 @@ pub mod l7 {
 
     pub mod mq {
         pub mod web_sphere_mq {
+            use public::l7_protocol::LogMessageType;
 
             #[derive(Default)]
             pub struct WebSphereMqParser {
@@ -349,7 +355,7 @@ pub mod l7 {
             }
 
             impl WebSphereMqParser {
-                pub fn check_payload(&mut self, _: &[u8], _: bool) -> bool {
+                pub fn check_payload(&mut self, _: &[u8], _: bool) -> Option<LogMessageType> {
                     unimplemented!()
                 }
 

--- a/agent/src/flow_generator/protocol_logs/mq/webspheremq.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/webspheremq.rs
@@ -325,11 +325,7 @@ const RESPONSE_CODE_OK_SUFFIX: &str = "0000";
 impl L7ProtocolParserInterface for WebSphereMqLog {
     fn check_payload(&mut self, payload: &[u8], param: &ParseParam) -> Option<LogMessageType> {
         let has_wasm = param.wasm_vm.borrow().is_some();
-        if self.parser.check_payload(payload, has_wasm) {
-            Some(LogMessageType::Request)
-        } else {
-            None
-        }
+        self.parser.check_payload(payload, has_wasm)
     }
 
     fn parse_payload(&mut self, payload: &[u8], param: &ParseParam) -> Result<L7ParseResult> {

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -516,7 +516,7 @@ pub struct DubboLog {
 #[cfg(feature = "enterprise")]
 struct CustomFieldContext<'a> {
     direction: PacketDirection,
-    policies: Option<PolicySlice>,
+    policies: Option<PolicySlice<'a>>,
     store: &'a mut Store,
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


