### PR TITLE
docs: Include the Disk Space requirement in the All-In-One Deployment

### DIFF
--- a/manifests/deepflow-docker-compose/README.md
+++ b/manifests/deepflow-docker-compose/README.md
@@ -1,5 +1,31 @@
 # DeepFlow STANDALONE mode docker-compose deployment package
 
+## System Requirements
+
+Before deploying DeepFlow using Docker Compose, ensure your system meets the following minimum requirements:
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU      | 4 cores | 8+ cores    |
+| Memory   | 8 GB    | 16+ GB      |
+| Disk     | 100 GB  | 200+ GB     |
+
+### Disk Space Details
+
+DeepFlow stores data in the following directories under `/opt/deepflow/`:
+
+- `/opt/deepflow/mysql/` - MySQL database files
+- `/opt/deepflow/clickhouse/` - ClickHouse metadata and indexes
+- `/opt/deepflow/clickhouse_storage/` - ClickHouse data storage (primary data location)
+- `/opt/deepflow/grafana/` - Grafana dashboards, plugins, and provisioning
+
+The actual disk usage depends on:
+- Data retention period
+- Traffic volume being monitored
+- Number of agents reporting data
+
+For production environments with high traffic volumes, consider allocating 500+ GB of disk space.
+
 ## Usage
 
 ```console


### PR DESCRIPTION
## Summary
This PR fixes #2332

## Changes
- Added System Requirements section to the docker-compose README
- Included a table with minimum and recommended CPU, Memory, and Disk requirements
- Added detailed disk space information including storage directories (/opt/deepflow/)
- Documented factors affecting disk usage (retention period, traffic volume, number of agents)
- Added guidance for production environments (500+ GB recommendation)