### PR TITLE
feat(agent): add Kubernetes readiness and liveness probes

### DIFF
--- a/agent/docker/deepflow-agent-ds.yaml
+++ b/agent/docker/deepflow-agent-ds.yaml
@@ -24,6 +24,22 @@ spec:
           imagePullPolicy: Never
           securityContext:
             privileged: true
+          readinessProbe:
+            httpGet:
+              path: /v1/ready/
+              port: 38086
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /v1/health/
+              port: 38086
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: sys-kernel-debug
               mountPath: /sys/kernel/debug

--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -637,6 +637,18 @@ async fn handler(
                 .body(doc_bytes.as_slice().into())
                 .unwrap())
         }
+        // Health check endpoint for liveness probe
+        (&Method::GET, "/v1/health/") => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(r#"{"status":"healthy"}"#.into())
+            .unwrap()),
+        // Readiness probe endpoint - returns 200 when the server is ready to accept traffic
+        (&Method::GET, "/v1/ready/") => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header("Content-Type", "application/json")
+            .body(r#"{"status":"ready"}"#.into())
+            .unwrap()),
         // OpenTelemetry trace integration
         (&Method::POST, "/api/v1/otel/trace") => {
             if external_trace_integration_disabled {


### PR DESCRIPTION
## Summary
This PR fixes #2311

Adds Kubernetes readiness and liveness probes to the deepflow-agent, following standard K8s patterns.

## Changes
- Add `/v1/ready/` endpoint to integration collector for readiness probe
- Add `/v1/health/` endpoint to integration collector for liveness probe
- Configure readiness and liveness probes in DaemonSet YAML on port 38086

## Implementation Details
- **Readiness probe**: `/v1/ready/` returns 200 with `{"status":"ready"}` when the integration collector HTTP server is ready to accept traffic
- **Liveness probe**: `/v1/health/` returns 200 with `{"status":"healthy"}` when the server is running
- Both probes use the integration collector's HTTP server on port 38086 (the default external agent HTTP proxy port)

## Probe Configuration
```yaml
readinessProbe:
  httpGet:
    path: /v1/ready/
    port: 38086
  initialDelaySeconds: 5
  periodSeconds: 10
  timeoutSeconds: 5
  failureThreshold: 3

livenessProbe:
  httpGet:
    path: /v1/health/
    port: 38086
  initialDelaySeconds: 15
  periodSeconds: 20
  timeoutSeconds: 5
  failureThreshold: 3
```

## Test plan
- [ ] Deploy the agent as a DaemonSet and verify probes work correctly
- [ ] Verify readiness probe passes when agent is ready
- [ ] Verify liveness probe passes when agent is healthy
- [ ] Verify pod restarts if liveness probe fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)