### PR TITLE
fix: trisolaris push wrong pod_group biz service data

### DIFF
--- a/server/controller/trisolaris/dbcache/db_data.go
+++ b/server/controller/trisolaris/dbcache/db_data.go
@@ -519,7 +519,7 @@ func (d *DBDataCache) GetDataCacheFromDB(db *gorm.DB) {
 		log.Error(d.Log(err.Error()))
 	}
 	podGroups, err := dbmgr.DBMgr[models.PodGroup](db).GetFields([]string{
-		"id", "name", "type", "uid", "network_mode",
+		"id", "name", "type", "uid", "network_mode", "pod_cluster_id", "pod_namespace_id",
 	})
 	if err == nil {
 		d.podGroups = podGroups


### PR DESCRIPTION

### This PR is for:

- Server

#### Affected branches
- main
- v6.6