### PR TITLE
feat: Update message to add new remote exec command

### DIFF
--- a/message/agent.proto
+++ b/message/agent.proto
@@ -814,7 +814,7 @@ message LinuxNamespace {
     optional string cmd = 5;
 }
 
-message CommandResult {
+message DataChunk {
     optional int32 errno = 1;
     optional bytes content = 2;
     // will only be populated in the last segment
@@ -828,6 +828,13 @@ enum ExecutionType {
     LIST_COMMAND = 0;
     LIST_NAMESPACE = 1;
     RUN_COMMAND = 2;
+    // Sending pcap to agent for biz protocol inferencing and biz decoding.
+    // Large pcap should be split into chunks in multiple `RemoteExecRequest`s (in `command_data`).
+    // Application protocol and server port can be specified in `params` with the following keys:
+    // - l7_protocol
+    // - server_port
+    // If protocol and server port are set, agent will not try to infer them.
+    DRY_REPLAY_PCAP = 3;
 }
 
 message Parameter {
@@ -845,6 +852,8 @@ message RemoteExecRequest {
     optional uint32 batch_len = 6 [default = 1048576]; // batch len of command execution results, min 1024
     optional string command_ident = 7;
 
+    optional DataChunk command_data = 10;
+
     optional uint32 command_id = 3; // deprecated, use `command_ident` instead
 }
 
@@ -857,5 +866,5 @@ message RemoteExecResponse {
 
     repeated RemoteCommand commands = 4;
     repeated LinuxNamespace linux_namespaces = 5;
-    optional CommandResult command_result = 6;
+    optional DataChunk command_result = 6;
 }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Message

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


