### PR TITLE
fix: windows/android querier keeps appending raw ip addr

### DIFF
--- a/agent/src/platform/querier/android.rs
+++ b/agent/src/platform/querier/android.rs
@@ -33,7 +33,7 @@ pub struct Querier {
     digest: u64,
 
     raw_hostname: Option<String>,
-    raw_ip_addrs: Vec<String>,
+    raw_ip_addr: String,
 
     process_data: Vec<ProcessData>,
 }
@@ -46,7 +46,7 @@ impl Querier {
             digest: Default::default(),
 
             raw_hostname: Default::default(),
-            raw_ip_addrs: Default::default(),
+            raw_ip_addr: Default::default(),
 
             process_data: Default::default(),
         }
@@ -74,7 +74,7 @@ impl Querier {
             platform_enabled: Some(config.enabled),
             raw_hostname: self.raw_hostname.clone(),
             raw_ip_netns: vec!["default".into()],
-            raw_ip_addrs: self.raw_ip_addrs.clone(),
+            raw_ip_addrs: vec![self.raw_ip_addr.clone()],
             ..Default::default()
         };
 
@@ -122,7 +122,7 @@ impl Querier {
                 hasher.write(line.as_bytes());
             }
         }
-        self.raw_ip_addrs.push(raw_host_ip_addr.unwrap_or_default());
+        self.raw_ip_addr = raw_host_ip_addr.unwrap_or_default();
         debug!("updated ip addresses");
         trace!("digest={:016x}", hasher.finish());
     }

--- a/agent/src/platform/querier/windows.rs
+++ b/agent/src/platform/querier/windows.rs
@@ -32,7 +32,7 @@ pub struct Querier {
     digest: u64,
 
     raw_hostname: Option<String>,
-    raw_ip_addrs: Vec<String>,
+    raw_ip_addr: String,
 }
 
 impl Querier {
@@ -43,7 +43,7 @@ impl Querier {
             digest: Default::default(),
 
             raw_hostname: Default::default(),
-            raw_ip_addrs: Default::default(),
+            raw_ip_addr: Default::default(),
         }
     }
 
@@ -67,7 +67,7 @@ impl Querier {
             platform_enabled: Some(config.enabled),
             raw_hostname: self.raw_hostname.clone(),
             raw_ip_netns: vec!["default".into()],
-            raw_ip_addrs: self.raw_ip_addrs.clone(),
+            raw_ip_addrs: vec![self.raw_ip_addr.clone()],
             ..Default::default()
         };
 
@@ -108,7 +108,7 @@ impl Querier {
                 hasher.write(line.as_bytes());
             }
         }
-        self.raw_ip_addrs.push(raw_host_ip_addr.unwrap_or_default());
+        self.raw_ip_addr = raw_host_ip_addr.unwrap_or_default();
         debug!("updated ip addresses");
         trace!("digest={:016x}", hasher.finish());
     }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


