### PR TITLE
fix: correct pt_regs offset for kernel unwind

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -155,7 +155,8 @@ SOCKET_TRACE_ELFS := user/socket_trace_bpf_common.c \
 	user/socket_trace_bpf_kprobe.c
 
 PERF_PROFILER_ELFS := user/perf_profiler_bpf_common.c \
-	user/perf_profiler_bpf_5_2_plus.c
+	user/perf_profiler_bpf_5_2_plus.c \
+	user/perf_profiler_bpf_5_15_plus.c
 
 ELFFILES := $(SOCKET_TRACE_ELFS) $(PERF_PROFILER_ELFS) $(AF_PACKET_FANOUT_ELFS) $(TCP_OPTION_TRACING_ELFS)
 
@@ -206,6 +207,10 @@ user/perf_profiler_bpf_common.c: tools/bintobuffer kernel/perf_profiler.bpf.c
 user/perf_profiler_bpf_5_2_plus.c: tools/bintobuffer kernel/perf_profiler.bpf.c
 	$(call check_clang)
 	$(call compile_perf_profiler_elf,5_2_plus,LINUX_VER_5_2_PLUS=1)
+
+user/perf_profiler_bpf_5_15_plus.c: tools/bintobuffer kernel/perf_profiler.bpf.c
+	$(call check_clang)
+	$(call compile_perf_profiler_elf,5_15_plus,LINUX_VER_5_15_PLUS=1)
 
 $(STATIC_OBJDIR) $(SHARED_OBJDIR):
 	$(call msg,MKDIR,$@)

--- a/agent/src/ebpf/kernel/Makefile
+++ b/agent/src/ebpf/kernel/Makefile
@@ -42,6 +42,8 @@ ARCH := $(shell uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's
 
 ifeq ($(LINUX_VER_3_10_0),1)
 	EXTRA_EBPF_CLAGS = -DLINUX_VER_3_10_0
+else ifeq ($(LINUX_VER_5_15_PLUS),1)
+	EXTRA_EBPF_CLAGS = -DLINUX_VER_5_2_PLUS -DLINUX_VER_5_15_PLUS
 else ifeq ($(LINUX_VER_5_2_PLUS),1)
 	EXTRA_EBPF_CLAGS = -DLINUX_VER_5_2_PLUS
 else ifeq ($(LINUX_VER_KYLIN),1)
@@ -97,4 +99,3 @@ clean:
 	@rm $(TAEGET_KERN_ELF) $(TARGET) ${TAEGET_KERN_ELF:.elf=.ll} *.S *.objdump -rf
 
 .PHONY: all clean
-

--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -32,6 +32,17 @@
 #include <bcc/compat/linux/bpf.h>
 #include "utils.h"
 
+struct task_struct;
+
+#ifndef BPF_FUNC_task_pt_regs
+// Helper ID for bpf_task_pt_regs (introduced in Linux 5.15, GPL-only).
+#define BPF_FUNC_task_pt_regs 175
+#endif
+#ifndef BPF_FUNC_get_current_task_btf
+// Helper ID for bpf_get_current_task_btf (introduced in Linux 5.11).
+#define BPF_FUNC_get_current_task_btf 158
+#endif
+
 /*
  * bpf helpers
  */
@@ -77,6 +88,12 @@ static long
     (void *)16;
 static __u64 __attribute__ ((__unused__)) (*bpf_get_current_task) (void) =
     (void *)35;
+static struct task_struct
+    __attribute__ ((__unused__)) * (*bpf_get_current_task_btf) (void) =
+    (void *)BPF_FUNC_get_current_task_btf;
+static struct pt_regs
+    __attribute__ ((__unused__)) * (*bpf_task_pt_regs) (struct task_struct *task) =
+    (void *)BPF_FUNC_task_pt_regs;
 static long
     __attribute__ ((__unused__)) (*bpf_perf_event_output) (void *ctx, void *map,
 							   __u64 flags,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

One or more of:
- Agent

### Fixes incorrect pt_regs offset in kernel unwind on Linux 5.15+ (c4cf55ee1)
#### Steps to reproduce the bug
  - Run the continuous profiler on a Linux 5.15+ kernel with DWARF/unwind enabled
  - Observe invalid or incorrect user-mode registers/stacks during kernel unwind (e.g., invalid FP or
    broken stacks)
#### Changes to fix the bug
  - Add a 5.15+ perf-profiler BPF build variant and select it at runtime based on kernel version
  - Define helper IDs and wrappers for bpf_get_current_task_btf and bpf_task_pt_regs
  - Use bpf_task_pt_regs (with BTF-typed task pointer) to read user pt_regs on 5.15+ and keep the old
    path as fallback
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
- [x] Verified eBPF program runs successfully on linux 5.4.x.
- [x] Verified eBPF program runs successfully on linux 5.15.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


