### PR TITLE
Fix: the compilation error in the Enterprise Edition

### DIFF
--- a/agent/src/flow_generator/protocol_logs/mq/web_sphere_mq.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/web_sphere_mq.rs
@@ -402,7 +402,7 @@ impl L7ProtocolParserInterface for WebSphereMqLog {
         false
     }
 
-    fn perf_stats(&mut self) -> Option<L7PerfStats> {
+    fn perf_stats(&mut self) -> Vec<L7PerfStats> {
         std::mem::take(&mut self.perf_stats)
     }
 }

--- a/agent/src/flow_generator/protocol_logs/rpc/iso8583.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/iso8583.rs
@@ -367,7 +367,7 @@ impl L7ProtocolParserInterface for Iso8583Log {
                         info.rrt = rrt_us;
                         perf_stat.rrt_count += 1;
                         perf_stat.rrt_sum += rrt_us;
-                        perf_stat.rrt_max = perf_stats.rrt_max.max(rrt_us as u32);
+                        perf_stat.rrt_max = perf_stat.rrt_max.max(rrt_us as u32);
                     }
                 }
                 self.perf_stats.push(perf_stat);


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


