### PR TITLE
fix: fix lua unwind in some cases

### DIFF
--- a/agent/crates/trace-utils/cbindgen.toml
+++ b/agent/crates/trace-utils/cbindgen.toml
@@ -59,6 +59,7 @@ include = [
   "ProcessShardList",
   "UnwindEntryShard",
   "LuaRuntimeInfo",
+  "LuaProcessLayout",
   "PythonUnwindInfo",
   "PythonOffsets",
   "PythonUnwindTable",
@@ -108,6 +109,7 @@ PythonOffsets = "python_offsets_t"
 PythonUnwindInfo = "python_unwind_info_t"
 PythonUnwindTable = "python_unwind_table_t"
 LuaRuntimeInfo = "lua_runtime_info_t"
+LuaProcessLayout = "lua_process_layout_t"
 LuaUnwindInfo = "lua_unwind_info_t"
 LuaUnwindTable = "lua_unwind_table_t"
 LuaOfs = "lua_ofs"

--- a/agent/crates/trace-utils/src/lib.rs
+++ b/agent/crates/trace-utils/src/lib.rs
@@ -142,6 +142,21 @@ pub struct LuaRuntimeInfo {
 
 #[cfg(feature = "enterprise")]
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct LuaProcessLayout {
+    pub liblua_start: u64,
+    pub liblua_end: u64,
+    pub exe_start: u64,
+    pub exe_end: u64,
+    pub lib_path: [u8; LUA_RUNTIME_PATH_LEN],
+    pub exe_path: [u8; LUA_RUNTIME_PATH_LEN],
+    pub has_lib: u8,
+    pub has_exe: u8,
+    pub reserved: [u8; 6],
+}
+
+#[cfg(feature = "enterprise")]
+#[repr(C)]
 pub struct PythonUnwindInfo {
     pub auto_tls_key_addr: u64,
     pub version: u16,
@@ -590,6 +605,7 @@ extern "C" {
         lua_offsets_fd: i32,
         luajit_offsets_fd: i32,
     );
+    pub fn lua_get_process_layout(pid: u32, out: *mut LuaProcessLayout) -> i32;
 
     pub fn lua_unwind_table_create(
         lang_flags_fd: i32,

--- a/agent/crates/trace-utils/src/trace_utils.h
+++ b/agent/crates/trace-utils/src/trace_utils.h
@@ -135,6 +135,20 @@ typedef struct {
 } lua_runtime_info_t;
 #endif
 
+#if defined(DF_ENTERPRISE)
+typedef struct {
+    uint64_t liblua_start;
+    uint64_t liblua_end;
+    uint64_t exe_start;
+    uint64_t exe_end;
+    uint8_t lib_path[LUA_RUNTIME_PATH_LEN];
+    uint8_t exe_path[LUA_RUNTIME_PATH_LEN];
+    uint8_t has_lib;
+    uint8_t has_exe;
+    uint8_t reserved[6];
+} lua_process_layout_t;
+#endif
+
 typedef struct {
     uint32_t id;
     uint16_t entry_start;
@@ -606,6 +620,10 @@ extern bool is_v8_process(uint32_t pid);
 
 #if defined(DF_ENTERPRISE)
 extern int32_t lua_detect(uint32_t pid, lua_runtime_info_t *out);
+#endif
+
+#if defined(DF_ENTERPRISE)
+extern int32_t lua_get_process_layout(uint32_t pid, lua_process_layout_t *out);
 #endif
 
 #if defined(DF_ENTERPRISE)

--- a/agent/src/ebpf/kernel/include/lua_unwind_helper.h
+++ b/agent/src/ebpf/kernel/include/lua_unwind_helper.h
@@ -79,6 +79,7 @@ struct lua_state_cache_t {
 	__u64 states[LUA_STATE_STACK_DEPTH];
 	__u8 depth;
 	__u8 pad[7];
+	__u64 retained_L;
 };
 
 enum func_type {

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -94,6 +94,7 @@
 #define MAP_LUA_OFFSETS_NAME            "__lua_offsets_map"
 #define MAP_LUAJIT_OFFSETS_NAME         "__luajit_offsets_map"
 #define MAP_LUA_TSTATE_NAME             "__lua_tstate_map"
+#define MAP_LUA_TEXT_REGION_NAME        "__lua_text_region_map"
 
 #define MAP_CP_PROGS_JMP_KP_NAME             "__cp_progs_jmp_kp_map"
 #define PROG_OFFCPU_DWARF_UNWIND_FOR_KP      "df_KP_offcpu_dwarf_unwind"


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

### Fixes "lua unwind in special cases"
#### Steps to reproduce the bug
- profiling lua program without coroutines, calling only one lua_pcallk function
- ...
#### Changes to fix the bug
- use register-based method as fallback
- enhanced lua version detection heuristics 
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [x] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


