### PR TITLE
fix: querier null filter error

### DIFF
--- a/server/querier/engine/clickhouse/clickhouse.go
+++ b/server/querier/engine/clickhouse/clickhouse.go
@@ -2004,6 +2004,36 @@ func (e *CHEngine) parseWhere(node sqlparser.Expr, w *Where, isCheck bool) (view
 			stmt := &WhereFunction{Function: outfunc, Value: sqlparser.String(node.Right)}
 			return stmt.Trans(node, w, e)
 		}
+	case *sqlparser.IsExpr:
+		if isCheck {
+			return nil, nil
+		}
+		operator := strings.ToLower(node.Operator)
+		if operator != sqlparser.IsNullStr && operator != sqlparser.IsNotNullStr {
+			return nil, errors.New(fmt.Sprintf("parse where error: %s(%T)", sqlparser.String(node), node))
+		}
+		whereTag := chCommon.ParseAlias(node.Expr)
+		metricStruct, ok := metrics.GetMetrics(whereTag, e.DB, e.Table, e.ORGID, e.NativeField)
+		if ok && metricStruct.Type != metrics.METRICS_TYPE_TAG {
+			whereTag = metricStruct.DBField
+		}
+		stmt := GetWhere(whereTag, "NULL")
+		filterNode, err := stmt.Trans(&sqlparser.ComparisonExpr{
+			Left:     node.Expr,
+			Operator: "=",
+			Right:    &sqlparser.NullVal{},
+		}, w, e)
+		if err != nil {
+			return nil, err
+		}
+		filterExpr := filterNode.ToString()
+		filterExpr = strings.TrimPrefix(filterExpr, "(")
+		filterExpr = strings.TrimSuffix(filterExpr, ")")
+		filterExpr = strings.ReplaceAll(filterExpr, "= NULL", " IS NULL")
+		if operator == sqlparser.IsNotNullStr {
+			filterExpr = "not(" + filterExpr + ")"
+		}
+		return &view.Expr{Value: "(" + filterExpr + ")"}, nil
 	case *sqlparser.FuncExpr:
 		args := []string{}
 		for _, argExpr := range node.Exprs {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


