### PR TITLE
feat: remove hook points when I/O event collection is disabled

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -305,6 +305,10 @@ static void config_probes_for_kfunc(struct tracer_probes_conf *tps)
 	// Periodic trigger for timeout checks on cached data
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");
 
+	// If file I/O event collection is not enabled, hook installation will be skipped
+	if (io_event_collect_mode == IO_EVENT_COLLECT_DISABLE)
+		return;
+
         // file R/W probes
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pread64");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv");
@@ -385,7 +389,11 @@ static void config_probes_for_kprobe_and_tracepoint(struct tracer_probes_conf
 
 	// Periodic trigger for timeout checks on cached data
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_getppid");
-	
+
+	// If file I/O event collection is not enabled, hook installation will be skipped
+	if (io_event_collect_mode == IO_EVENT_COLLECT_DISABLE)
+		return;
+
         // file R/W probes
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_pread64");
 	tps_set_symbol(tps, "tracepoint/syscalls/sys_enter_preadv");
@@ -432,10 +440,12 @@ static void config_probes_for_kprobe(struct tracer_probes_conf *tps)
 	probes_set_symbol(tps, "__sys_sendmmsg");
 	probes_set_symbol(tps, "__sys_recvmsg");
 	probes_set_symbol(tps, "__sys_recvmmsg");
-	probes_set_symbol(tps, "ksys_pread64");
-	probes_set_symbol(tps, "do_preadv");
-	probes_set_symbol(tps, "ksys_pwrite64");
-	probes_set_symbol(tps, "do_pwritev");
+	if (io_event_collect_mode != IO_EVENT_COLLECT_DISABLE) {
+		probes_set_symbol(tps, "ksys_pread64");
+		probes_set_symbol(tps, "do_preadv");
+		probes_set_symbol(tps, "ksys_pwrite64");
+		probes_set_symbol(tps, "do_pwritev");
+	}
 
 	if (k_version == KERNEL_VERSION(3, 10, 0)) {
 		/*
@@ -2371,6 +2381,8 @@ int set_io_event_collect_mode(uint32_t mode)
 {
 	io_event_collect_mode = mode;
 
+	ebpf_info("Set io_event_collect_mode %d\n", io_event_collect_mode);
+
 	struct bpf_tracer *tracer = find_bpf_tracer(SK_TRACER_NAME);
 	if (tracer == NULL) {
 		return 0;
@@ -2396,7 +2408,6 @@ int set_io_event_collect_mode(uint32_t mode)
 		return ETR_UPDATE_MAP_FAILD;
 	}
 
-	ebpf_info("Set io_event_collect_mode %d\n", io_event_collect_mode);
 	return 0;
 }
 

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -22,6 +22,10 @@
 #define CACHE_LINE_SIZE 64
 #endif
 
+#define IO_EVENT_COLLECT_DISABLE	0  // Disable collection: no file I/O events are captured
+#define IO_EVENT_COLLECT_LIFECYCLE	1  // Lifecycle mode: collect file I/O events only during process lifetime
+#define IO_EVENT_COLLECT_ALL		2  // Full mode: collect all file I/O events
+
 #define SYSCALL_FORK_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_fork"
 #define SYSCALL_CLONE_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_exit_clone"
 #define SYSCALL_PRWV2_TP_PATH "/sys/kernel/debug/tracing/events/syscalls/sys_enter_preadv2"


### PR DESCRIPTION
Skip installing related hook points when file I/O event collection is disabled to reduce unnecessary overhead and improve runtime performance.

Ensure hooks are only active when needed.


#### Affected branches
- main
- v7.1
- v7.0
- v6.6