### PR TITLE
refactor: improve agent restart log readability

### DIFF
--- a/agent/crates/public/src/codecs/hessian2.rs
+++ b/agent/crates/public/src/codecs/hessian2.rs
@@ -90,12 +90,18 @@ impl Hessian2Decoder {
                 }
             }
             // int
-            0x80..=0xbf | 0xc0..=0xcf | 0xd0..=0xd7 | BC_INT => {
-                Self::to_hessian_value(Self::decode_i32(bytes, start), bytes.len(), HessianValue::Int)
-            }
+            0x80..=0xbf | 0xc0..=0xcf | 0xd0..=0xd7 | BC_INT => Self::to_hessian_value(
+                Self::decode_i32(bytes, start),
+                bytes.len(),
+                HessianValue::Int,
+            ),
             // long
             0xd8..=0xef | 0xf0..=0xff | 0x38..=0x3f | BC_LONG_INT | BC_LONG => {
-                Self::to_hessian_value(Self::decode_i64(bytes, start), bytes.len(), HessianValue::Long)
+                Self::to_hessian_value(
+                    Self::decode_i64(bytes, start),
+                    bytes.len(),
+                    HessianValue::Long,
+                )
             }
             // date
             BC_DATE | BC_DATE_MINUTE => Self::to_hessian_value(
@@ -139,12 +145,18 @@ impl Hessian2Decoder {
                 None => (None, bytes.len()),
             },
             // hashmap
-            BC_MAP | BC_MAP_UNTYPED => {
-                Self::to_hessian_value(self.decode_map(bytes, start), bytes.len(), HessianValue::Map)
-            }
+            BC_MAP | BC_MAP_UNTYPED => Self::to_hessian_value(
+                self.decode_map(bytes, start),
+                bytes.len(),
+                HessianValue::Map,
+            ),
             // object，只能处理为 hashmap
             BC_OBJECT_DEF | BC_OBJECT | BC_OBJECT_DIRECT..=BC_OBJECT_DIRECT_MAX => {
-                Self::to_hessian_value(self.decode_obj(bytes, start), bytes.len(), HessianValue::Map)
+                Self::to_hessian_value(
+                    self.decode_obj(bytes, start),
+                    bytes.len(),
+                    HessianValue::Map,
+                )
             }
             _ => (None, bytes.len()), // 如果不符合任何一种，表示这个 tag 没有意义，直接丢弃剩余所有数据
         }

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -17,7 +17,7 @@
 use std::{
     borrow::Cow,
     cmp::{max, min},
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt,
     hash::{Hash, Hasher},
     iter,
@@ -31,6 +31,7 @@ use std::{
 use arc_swap::{access::Map, ArcSwap};
 use base64::{prelude::BASE64_STANDARD, Engine};
 use bytesize::ByteSize;
+use chrono::Local;
 use flexi_logger::{
     writers::FileLogWriter, Age, Cleanup, Criterion, FileSpec, FlexiLoggerError, LogSpecification,
     LoggerHandle, Naming,
@@ -2656,8 +2657,8 @@ impl ConfigHandler {
             .as_ref()
             .map(|re| public::netns::find_ns_files_by_regex(&re));
         if old_netns != new_netns {
-            info!(
-                "query net namespaces changed from {:?} to {:?}, restart agent to create dispatcher for extra namespaces, deepflow-agent restart...",
+            warn!(
+                "inputs.cbpf.af_packet.extra_netns_regex namespace set changed ({:?} -> {:?}), deepflow-agent restart...",
                 old_netns, new_netns
             );
             crate::utils::clean_and_exit(public::consts::NORMAL_EXIT_WITH_RESTART);
@@ -2924,8 +2925,49 @@ impl ConfigHandler {
         let config = &mut candidate_config.user_config;
         let mut new_config: ModuleConfig = (static_config.clone(), user_config).try_into().unwrap();
         let mut callbacks: Vec<fn(&ConfigHandler, &mut AgentComponents)> = vec![];
+        let config_update_started_at = Local::now();
         let mut restart_dispatcher = false;
+        let mut dispatcher_restart_reasons = BTreeSet::<Cow<'static, str>>::new();
         let mut restart_agent = false;
+        let mut agent_restart_reasons = BTreeSet::<Cow<'static, str>>::new();
+        let changed_reason =
+            |key: &'static str, old: &dyn fmt::Debug, new: &dyn fmt::Debug| -> Cow<'static, str> {
+                Cow::Owned(format!("{key}: {old:?} -> {new:?}"))
+            };
+
+        // Batch-update config fields with consistent logging and optional restart-reason capture.
+        //
+        // For each tuple `(old_field, new_field, key)`:
+        // - compare and log when changed,
+        // - optionally append a restart reason when `$restart` is true,
+        // - write `new_field` back to `old_field`,
+        // - OR the computed restart flag into `$restart_flag`.
+        //
+        // Note: this macro is intended for direct field updates only. Keep entries with
+        // side effects/callbacks/non-trivial branching outside this macro to avoid changing behavior.
+        macro_rules! update_fields_with_restart_reason {
+            ($restart_flag:ident, $restart:expr, $reasons:expr, [$(($old:expr, $new:expr, $key:expr)),+ $(,)?]) => {{
+                $(
+                    let old_ref = &mut $old;
+                    let new_ref = &$new;
+                    if *old_ref != *new_ref {
+                        info!("Update {} from {:?} to {:?}.", $key, old_ref, new_ref);
+                        let restart_value = $restart;
+                        let reason = if restart_value {
+                            Some(changed_reason($key, old_ref, new_ref))
+                        } else {
+                            None
+                        };
+                        *old_ref = (*new_ref).clone();
+                        $restart_flag |= restart_value;
+                        if let Some(reason) = reason {
+                            $reasons.insert(reason);
+                        }
+                    }
+                )+
+            }};
+        }
+
         #[cfg(target_os = "windows")]
         let capture_mode = new_config.user_config.inputs.cbpf.common.capture_mode;
         let logger_handle = &mut self.logger_handle;
@@ -2959,38 +3001,33 @@ impl ConfigHandler {
         // inputs
         let af_packet = &mut config.inputs.cbpf.af_packet;
         let new_af_packet = &mut new_config.user_config.inputs.cbpf.af_packet;
-        if af_packet.bpf_filter_disabled != new_af_packet.bpf_filter_disabled {
-            info!(
-                "Update inputs.cbpf.af_packet.bpf_filter_disabled from {:?} to {:?}.",
-                af_packet.bpf_filter_disabled, new_af_packet.bpf_filter_disabled
-            );
-            af_packet.bpf_filter_disabled = new_af_packet.bpf_filter_disabled;
-            restart_agent = !first_run;
-        }
-        if af_packet.skip_npb_bpf != new_af_packet.skip_npb_bpf {
-            info!(
-                "Update inputs.cbpf.af_packet.skip_npb_bpf from {:?} to {:?}.",
-                af_packet.skip_npb_bpf, new_af_packet.skip_npb_bpf
-            );
-            af_packet.skip_npb_bpf = new_af_packet.skip_npb_bpf;
-            restart_agent = !first_run;
-        }
-        if af_packet.bond_interfaces != new_af_packet.bond_interfaces {
-            info!(
-                "Update inputs.cbpf.af_packet.bond_interfaces from {:?} to {:?}.",
-                af_packet.bond_interfaces, new_af_packet.bond_interfaces
-            );
-            af_packet.bond_interfaces = new_af_packet.bond_interfaces.clone();
-            restart_agent = !first_run;
-        }
-        if af_packet.extra_bpf_filter != new_af_packet.extra_bpf_filter {
-            info!(
-                "Update inputs.cbpf.af_packet.extra_bpf_filter from {:?} to {:?}.",
-                af_packet.extra_bpf_filter, new_af_packet.extra_bpf_filter
-            );
-            af_packet.extra_bpf_filter = new_af_packet.extra_bpf_filter.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    af_packet.bpf_filter_disabled,
+                    new_af_packet.bpf_filter_disabled,
+                    "inputs.cbpf.af_packet.bpf_filter_disabled"
+                ),
+                (
+                    af_packet.skip_npb_bpf,
+                    new_af_packet.skip_npb_bpf,
+                    "inputs.cbpf.af_packet.skip_npb_bpf"
+                ),
+                (
+                    af_packet.bond_interfaces,
+                    new_af_packet.bond_interfaces,
+                    "inputs.cbpf.af_packet.bond_interfaces"
+                ),
+                (
+                    af_packet.extra_bpf_filter,
+                    new_af_packet.extra_bpf_filter,
+                    "inputs.cbpf.af_packet.extra_bpf_filter"
+                )
+            ]
+        );
         if af_packet.extra_netns_regex != new_af_packet.extra_netns_regex {
             info!(
                 "Update inputs.cbpf.af_packet.extra_netns_regex from {:?} to {:?}.",
@@ -3017,18 +3054,16 @@ impl ConfigHandler {
                 callbacks.push(Self::switch_recv_engine);
             }
         }
-        if af_packet.inner_interface_capture_enabled
-            != new_af_packet.inner_interface_capture_enabled
-        {
-            info!(
-                "Update inputs.cbpf.af_packet.inner_interface_capture_enabled from {:?} to {:?}.",
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
                 af_packet.inner_interface_capture_enabled,
-                new_af_packet.inner_interface_capture_enabled
-            );
-            af_packet.inner_interface_capture_enabled =
-                new_af_packet.inner_interface_capture_enabled;
-            restart_agent = !first_run;
-        }
+                new_af_packet.inner_interface_capture_enabled,
+                "inputs.cbpf.af_packet.inner_interface_capture_enabled"
+            )]
+        );
         if af_packet.inner_interface_regex != new_af_packet.inner_interface_regex {
             info!(
                 "Update inputs.cbpf.af_packet.inner_interface_regex from {:?} to {:?}.",
@@ -3036,76 +3071,67 @@ impl ConfigHandler {
             );
             af_packet.inner_interface_regex = new_af_packet.inner_interface_regex.clone();
         }
-        if af_packet.src_interfaces != new_af_packet.src_interfaces {
-            info!(
-                "Update inputs.cbpf.af_packet.src_interfaces from {:?} to {:?}.",
-                af_packet.src_interfaces, new_af_packet.src_interfaces
-            );
-            af_packet.src_interfaces = new_af_packet.src_interfaces.clone();
-            restart_agent = !first_run;
-        }
-        if af_packet.vlan_pcp_in_physical_mirror_traffic
-            != new_af_packet.vlan_pcp_in_physical_mirror_traffic
-        {
-            info!(
-                "Update inputs.cbpf.af_packet.vlan_pcp_in_physical_mirror_traffic from {:?} to {:?}.",
-                af_packet.vlan_pcp_in_physical_mirror_traffic,
-                new_af_packet.vlan_pcp_in_physical_mirror_traffic
-            );
-            af_packet.vlan_pcp_in_physical_mirror_traffic =
-                new_af_packet.vlan_pcp_in_physical_mirror_traffic;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    af_packet.src_interfaces,
+                    new_af_packet.src_interfaces,
+                    "inputs.cbpf.af_packet.src_interfaces"
+                ),
+                (
+                    af_packet.vlan_pcp_in_physical_mirror_traffic,
+                    new_af_packet.vlan_pcp_in_physical_mirror_traffic,
+                    "inputs.cbpf.af_packet.vlan_pcp_in_physical_mirror_traffic"
+                )
+            ]
+        );
         let tunning = &mut af_packet.tunning;
         let new_tunning = &mut new_af_packet.tunning;
-        if tunning.ring_blocks_enabled != new_tunning.ring_blocks_enabled {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.ring_blocks_enabled from {:?} to {:?}.",
-                tunning.ring_blocks_enabled, new_tunning.ring_blocks_enabled
-            );
-            tunning.ring_blocks_enabled = new_tunning.ring_blocks_enabled;
-            restart_agent = !first_run;
-        }
-        if tunning.packet_fanout_count != new_tunning.packet_fanout_count {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.packet_fanout_count from {:?} to {:?}.",
-                tunning.packet_fanout_count, new_tunning.packet_fanout_count
-            );
-            tunning.packet_fanout_count = new_tunning.packet_fanout_count;
-            restart_agent = !first_run;
-        }
-        if tunning.packet_fanout_mode != new_tunning.packet_fanout_mode {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.packet_fanout_mode from {:?} to {:?}.",
-                tunning.packet_fanout_mode, new_tunning.packet_fanout_mode
-            );
-            tunning.packet_fanout_mode = new_tunning.packet_fanout_mode;
-            restart_agent = !first_run;
-        }
-        if tunning.promisc != new_tunning.promisc {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.interface_promisc_enabled from {:?} to {:?}.",
-                tunning.promisc, new_tunning.promisc
-            );
-            tunning.promisc = new_tunning.promisc;
-            restart_agent = !first_run;
-        }
-        if tunning.ring_blocks != new_tunning.ring_blocks {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.ring_blocks from {:?} to {:?}.",
-                tunning.ring_blocks, new_tunning.ring_blocks
-            );
-            tunning.ring_blocks = new_tunning.ring_blocks;
-            restart_agent = !first_run;
-        }
-        if tunning.socket_version != new_tunning.socket_version {
-            info!(
-                "Update inputs.cbpf.af_packet.tunning.socket_version from {:?} to {:?}.",
-                tunning.socket_version, new_tunning.socket_version
-            );
-            tunning.socket_version = new_tunning.socket_version;
-            restart_dispatcher = !cfg!(target_os = "windows");
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tunning.ring_blocks_enabled,
+                    new_tunning.ring_blocks_enabled,
+                    "inputs.cbpf.af_packet.tunning.ring_blocks_enabled"
+                ),
+                (
+                    tunning.packet_fanout_count,
+                    new_tunning.packet_fanout_count,
+                    "inputs.cbpf.af_packet.tunning.packet_fanout_count"
+                ),
+                (
+                    tunning.packet_fanout_mode,
+                    new_tunning.packet_fanout_mode,
+                    "inputs.cbpf.af_packet.tunning.packet_fanout_mode"
+                ),
+                (
+                    tunning.promisc,
+                    new_tunning.promisc,
+                    "inputs.cbpf.af_packet.tunning.interface_promisc_enabled"
+                ),
+                (
+                    tunning.ring_blocks,
+                    new_tunning.ring_blocks,
+                    "inputs.cbpf.af_packet.tunning.ring_blocks"
+                )
+            ]
+        );
+        update_fields_with_restart_reason!(
+            restart_dispatcher,
+            !cfg!(target_os = "windows"),
+            dispatcher_restart_reasons,
+            [(
+                tunning.socket_version,
+                new_tunning.socket_version,
+                "inputs.cbpf.af_packet.tunning.socket_version"
+            )]
+        );
 
         let packet_fanout_count = config.inputs.cbpf.af_packet.tunning.packet_fanout_count;
         let common = &mut config.inputs.cbpf.common;
@@ -3115,11 +3141,17 @@ impl ConfigHandler {
                 "Update inputs.cbpf.common.capture_mode from {:?} to {:?}.",
                 common.capture_mode, new_common.capture_mode
             );
+            let old_capture_mode = common.capture_mode;
             common.capture_mode = new_common.capture_mode;
             candidate_config.capture_mode = new_common.capture_mode;
             if let Some(c) = components.as_mut() {
                 if packet_fanout_count > 1 {
-                    info!("capture_mode changes and fanout is enabled, deepflow-agent restart...");
+                    warn!(
+                        "inputs.cbpf.common.capture_mode changed ({:?} -> {:?}) with inputs.cbpf.af_packet.tunning.packet_fanout_count={} (>1), deepflow-agent restart...",
+                        old_capture_mode,
+                        new_common.capture_mode,
+                        packet_fanout_count
+                    );
                     crate::utils::clean_and_exit(public::consts::NORMAL_EXIT_WITH_RESTART);
                     return vec![];
                 } else {
@@ -3127,7 +3159,15 @@ impl ConfigHandler {
                     c.clear_dispatcher_components();
                 }
             }
-            restart_agent = !first_run;
+            let restart_value = !first_run;
+            restart_agent |= restart_value;
+            if restart_value {
+                agent_restart_reasons.insert(changed_reason(
+                    "inputs.cbpf.common.capture_mode",
+                    &old_capture_mode,
+                    &new_common.capture_mode,
+                ));
+            }
         }
         if candidate_config.capture_mode != PacketCaptureType::Analyzer
             && !running_in_container()
@@ -3143,53 +3183,41 @@ impl ConfigHandler {
 
         let physical_mirror = &mut config.inputs.cbpf.physical_mirror;
         let new_physical_mirror = &mut new_config.user_config.inputs.cbpf.physical_mirror;
-        if physical_mirror.packet_dedup_disabled != new_physical_mirror.packet_dedup_disabled {
-            info!(
-                "Update inputs.cbpf.physical_mirror.packet_dedup_disabled from {:?} to {:?}.",
-                physical_mirror.packet_dedup_disabled, new_physical_mirror.packet_dedup_disabled
-            );
-            physical_mirror.packet_dedup_disabled = new_physical_mirror.packet_dedup_disabled;
-            restart_agent = !first_run;
-        }
-        if physical_mirror.private_cloud_gateway_traffic
-            != new_physical_mirror.private_cloud_gateway_traffic
-        {
-            info!(
-                "Update inputs.cbpf.physical_mirror.private_cloud_gateway_traffic from {:?} to {:?}.",
-                physical_mirror.private_cloud_gateway_traffic,
-                new_physical_mirror.private_cloud_gateway_traffic
-            );
-            physical_mirror.private_cloud_gateway_traffic =
-                new_physical_mirror.private_cloud_gateway_traffic;
-            restart_agent = !first_run;
-        }
-        if physical_mirror.default_capture_network_type
-            != new_physical_mirror.default_capture_network_type
-        {
-            info!(
-                "Update inputs.cbpf.physical_mirror.default_capture_network_type from {:?} to {:?}.",
-                physical_mirror.default_capture_network_type,
-                new_physical_mirror.default_capture_network_type
-            );
-            physical_mirror.default_capture_network_type =
-                new_physical_mirror.default_capture_network_type;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    physical_mirror.packet_dedup_disabled,
+                    new_physical_mirror.packet_dedup_disabled,
+                    "inputs.cbpf.physical_mirror.packet_dedup_disabled"
+                ),
+                (
+                    physical_mirror.private_cloud_gateway_traffic,
+                    new_physical_mirror.private_cloud_gateway_traffic,
+                    "inputs.cbpf.physical_mirror.private_cloud_gateway_traffic"
+                ),
+                (
+                    physical_mirror.default_capture_network_type,
+                    new_physical_mirror.default_capture_network_type,
+                    "inputs.cbpf.physical_mirror.default_capture_network_type"
+                )
+            ]
+        );
 
         let preprocess = &mut config.inputs.cbpf.preprocess;
         let new_preprocess = &mut new_config.user_config.inputs.cbpf.preprocess;
-        if preprocess.packet_segmentation_reassembly
-            != new_preprocess.packet_segmentation_reassembly
-        {
-            info!(
-                "Update inputs.cbpf.preprocess.packet_segmentation_reassembly from {:?} to {:?}.",
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
                 preprocess.packet_segmentation_reassembly,
-                new_preprocess.packet_segmentation_reassembly
-            );
-            preprocess.packet_segmentation_reassembly =
-                new_preprocess.packet_segmentation_reassembly.clone();
-            restart_agent = !first_run;
-        }
+                new_preprocess.packet_segmentation_reassembly,
+                "inputs.cbpf.preprocess.packet_segmentation_reassembly"
+            )]
+        );
         if preprocess.tunnel_decap_protocols != new_preprocess.tunnel_decap_protocols {
             info!(
                 "Update inputs.cbpf.preprocess.tunnel_decap_protocols from {:?} to {:?}.",
@@ -3197,87 +3225,78 @@ impl ConfigHandler {
             );
             preprocess.tunnel_decap_protocols = new_preprocess.tunnel_decap_protocols.clone();
         }
-        if preprocess.tunnel_trim_protocols != new_preprocess.tunnel_trim_protocols {
-            info!(
-                "Update inputs.cbpf.preprocess.tunnel_trim_protocols from {:?} to {:?}.",
-                preprocess.tunnel_trim_protocols, new_preprocess.tunnel_trim_protocols
-            );
-            preprocess.tunnel_trim_protocols = new_preprocess.tunnel_trim_protocols.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                preprocess.tunnel_trim_protocols,
+                new_preprocess.tunnel_trim_protocols,
+                "inputs.cbpf.preprocess.tunnel_trim_protocols"
+            )]
+        );
 
         let special_network = &mut config.inputs.cbpf.special_network;
         let new_special_network = &mut new_config.user_config.inputs.cbpf.special_network;
-        if special_network.dpdk.source != new_special_network.dpdk.source {
-            info!(
-                "Update inputs.cbpf.special_network.dpdk.source from {:?} to {:?}.",
-                special_network.dpdk.source, new_special_network.dpdk.source
-            );
-            special_network.dpdk.source = new_special_network.dpdk.source;
-            restart_agent = !first_run;
-        }
-        if special_network.dpdk.reorder_cache_window_size
-            != new_special_network.dpdk.reorder_cache_window_size
-        {
-            info!(
-                "Update inputs.cbpf.special_network.dpdk.reorder_cache_window_size from {:?} to {:?}.",
-                special_network.dpdk.reorder_cache_window_size,
-                new_special_network.dpdk.reorder_cache_window_size
-            );
-            special_network.dpdk.reorder_cache_window_size =
-                new_special_network.dpdk.reorder_cache_window_size;
-            restart_agent = !first_run;
-        }
-        if special_network.libpcap.enabled != new_special_network.libpcap.enabled {
-            info!(
-                "Update inputs.cbpf.special_network.libpcap.enabled from {:?} to {:?}.",
-                special_network.libpcap.enabled, new_special_network.libpcap.enabled
-            );
-            special_network.libpcap.enabled = new_special_network.libpcap.enabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    special_network.dpdk.source,
+                    new_special_network.dpdk.source,
+                    "inputs.cbpf.special_network.dpdk.source"
+                ),
+                (
+                    special_network.dpdk.reorder_cache_window_size,
+                    new_special_network.dpdk.reorder_cache_window_size,
+                    "inputs.cbpf.special_network.dpdk.reorder_cache_window_size"
+                ),
+                (
+                    special_network.libpcap.enabled,
+                    new_special_network.libpcap.enabled,
+                    "inputs.cbpf.special_network.libpcap.enabled"
+                ),
+                (
+                    special_network.vhost_user.vhost_socket_path,
+                    new_special_network.vhost_user.vhost_socket_path,
+                    "inputs.cbpf.special_network.vhost_user.vhost_socket_path"
+                )
+            ]
+        );
 
         let physical_switch = &mut special_network.physical_switch;
         let new_physical_switch = &mut new_special_network.physical_switch;
-        if physical_switch.netflow_ports != new_physical_switch.netflow_ports {
-            info!(
-                "Update inputs.cbpf.special_network.physical_switch.netflow_ports  from {:?} to {:?}.",
-                physical_switch.netflow_ports, new_physical_switch.netflow_ports
-            );
-            physical_switch.netflow_ports = new_physical_switch.netflow_ports.clone();
-            restart_agent = !first_run;
-        }
-        if physical_switch.sflow_ports != new_physical_switch.sflow_ports {
-            info!(
-                "Update inputs.cbpf.special_network.physical_switch.sflow_ports  from {:?} to {:?}.",
-                physical_switch.sflow_ports, new_physical_switch.sflow_ports
-            );
-            physical_switch.sflow_ports = new_physical_switch.sflow_ports.clone();
-            restart_agent = !first_run;
-        }
-        if special_network.vhost_user.vhost_socket_path
-            != new_special_network.vhost_user.vhost_socket_path
-        {
-            info!(
-                "Update inputs.cbpf.special_network.vhost_user.vhost_socket_path from {:?} to {:?}.",
-                special_network.vhost_user.vhost_socket_path,
-                new_special_network.vhost_user.vhost_socket_path
-            );
-            special_network.vhost_user.vhost_socket_path =
-                new_special_network.vhost_user.vhost_socket_path.clone();
-            restart_agent = !first_run;
-        }
-
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    physical_switch.netflow_ports,
+                    new_physical_switch.netflow_ports,
+                    "inputs.cbpf.special_network.physical_switch.netflow_ports"
+                ),
+                (
+                    physical_switch.sflow_ports,
+                    new_physical_switch.sflow_ports,
+                    "inputs.cbpf.special_network.physical_switch.sflow_ports"
+                )
+            ]
+        );
         let tunning = &mut config.inputs.cbpf.tunning;
         let new_tunning = &mut new_config.user_config.inputs.cbpf.tunning;
-        if tunning.dispatcher_queue_enabled != new_tunning.dispatcher_queue_enabled {
-            info!(
-                "Update inputs.cbpf.tunning.dispatcher_queue_enabled from {:?} to {:?}.",
-                tunning.dispatcher_queue_enabled, new_tunning.dispatcher_queue_enabled
-            );
-            tunning.dispatcher_queue_enabled = new_tunning.dispatcher_queue_enabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                tunning.dispatcher_queue_enabled,
+                new_tunning.dispatcher_queue_enabled,
+                "inputs.cbpf.tunning.dispatcher_queue_enabled"
+            )]
+        );
         if tunning.max_capture_packet_size != new_tunning.max_capture_packet_size {
             info!(
                 "Update inputs.cbpf.tunning.max_capture_packet_size from {:?} to {:?}.",
@@ -3293,458 +3312,401 @@ impl ConfigHandler {
             tunning.max_capture_pps = new_tunning.max_capture_pps;
             callbacks.push(Self::leaky_bucket_callback);
         }
-        if tunning.raw_packet_buffer_block_size != new_tunning.raw_packet_buffer_block_size {
-            info!(
-                "Update inputs.cbpf.tunning.raw_packet_buffer_block_size from {:?} to {:?}.",
-                tunning.raw_packet_buffer_block_size, new_tunning.raw_packet_buffer_block_size
-            );
-            tunning.raw_packet_buffer_block_size = new_tunning.raw_packet_buffer_block_size;
-            restart_agent = !first_run;
-        }
-        if tunning.raw_packet_queue_size != new_tunning.raw_packet_queue_size {
-            info!(
-                "Update inputs.cbpf.tunning.raw_packet_queue_size from {:?} to {:?}.",
-                tunning.raw_packet_queue_size, new_tunning.raw_packet_queue_size
-            );
-            tunning.raw_packet_queue_size = new_tunning.raw_packet_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tunning.raw_packet_buffer_block_size,
+                    new_tunning.raw_packet_buffer_block_size,
+                    "inputs.cbpf.tunning.raw_packet_buffer_block_size"
+                ),
+                (
+                    tunning.raw_packet_queue_size,
+                    new_tunning.raw_packet_queue_size,
+                    "inputs.cbpf.tunning.raw_packet_queue_size"
+                )
+            ]
+        );
 
         let ebpf = &mut config.inputs.ebpf;
         let new_ebpf = &mut new_config.user_config.inputs.ebpf;
-        if ebpf.disabled != new_ebpf.disabled {
-            info!(
-                "Update inputs.ebpf.disabled from {:?} to {:?}.",
-                ebpf.disabled, new_ebpf.disabled
-            );
-            ebpf.disabled = new_ebpf.disabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(ebpf.disabled, new_ebpf.disabled, "inputs.ebpf.disabled")]
+        );
 
         let io_event = &mut ebpf.file.io_event;
         let new_io_event = &mut new_ebpf.file.io_event;
-        if io_event.collect_mode != new_io_event.collect_mode {
-            info!(
-                "Update inputs.ebpf.file.io_event.collect_mode from {:?} to {:?}.",
-                io_event.collect_mode, new_io_event.collect_mode
-            );
-            io_event.collect_mode = new_io_event.collect_mode;
-            restart_agent = !first_run;
-        }
-        if io_event.minimal_duration != new_io_event.minimal_duration {
-            info!(
-                "Update inputs.ebpf.file.io_event.minimal_duration from {:?} to {:?}.",
-                io_event.minimal_duration, new_io_event.minimal_duration
-            );
-            io_event.minimal_duration = new_io_event.minimal_duration;
-            restart_agent = !first_run;
-        }
-        if io_event.enable_virtual_file_collect != new_io_event.enable_virtual_file_collect {
-            info!(
-                "Update inputs.ebpf.file.io_event.enable_virtual_file_collect from {:?} to {:?}.",
-                io_event.enable_virtual_file_collect, new_io_event.enable_virtual_file_collect
-            );
-            io_event.enable_virtual_file_collect = new_io_event.enable_virtual_file_collect;
-            restart_agent = !first_run;
-        }
-        if ebpf.java_symbol_file_refresh_defer_interval
-            != new_ebpf.java_symbol_file_refresh_defer_interval
-        {
-            info!(
-                "Update inputs.ebpf.java_symbol_file_refresh_defer_interval from {:?} to {:?}.",
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    io_event.collect_mode,
+                    new_io_event.collect_mode,
+                    "inputs.ebpf.file.io_event.collect_mode"
+                ),
+                (
+                    io_event.minimal_duration,
+                    new_io_event.minimal_duration,
+                    "inputs.ebpf.file.io_event.minimal_duration"
+                ),
+                (
+                    io_event.enable_virtual_file_collect,
+                    new_io_event.enable_virtual_file_collect,
+                    "inputs.ebpf.file.io_event.enable_virtual_file_collect"
+                )
+            ]
+        );
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
                 ebpf.java_symbol_file_refresh_defer_interval,
-                new_ebpf.java_symbol_file_refresh_defer_interval
-            );
-            ebpf.java_symbol_file_refresh_defer_interval =
-                new_ebpf.java_symbol_file_refresh_defer_interval;
-            restart_agent = !first_run;
-        }
+                new_ebpf.java_symbol_file_refresh_defer_interval,
+                "inputs.ebpf.java_symbol_file_refresh_defer_interval"
+            )]
+        );
 
         let on_cpu = &mut ebpf.profile.on_cpu;
         let new_on_cpu = &mut new_ebpf.profile.on_cpu;
-        if on_cpu.aggregate_by_cpu != new_on_cpu.aggregate_by_cpu {
-            info!(
-                "Update inputs.ebpf.profile.on_cpu.aggregate_by_cpu from {:?} to {:?}.",
-                on_cpu.aggregate_by_cpu, new_on_cpu.aggregate_by_cpu
-            );
-            on_cpu.aggregate_by_cpu = new_on_cpu.aggregate_by_cpu;
-            restart_agent = !first_run;
-        }
-        if on_cpu.disabled != new_on_cpu.disabled {
-            info!(
-                "Update inputs.ebpf.profile.on_cpu.disabled from {:?} to {:?}.",
-                on_cpu.disabled, new_on_cpu.disabled
-            );
-            on_cpu.disabled = new_on_cpu.disabled;
-            restart_agent = !first_run;
-        }
-        if on_cpu.sampling_frequency != new_on_cpu.sampling_frequency {
-            info!(
-                "Update inputs.ebpf.profile.on_cpu.sampling_frequency from {:?} to {:?}.",
-                on_cpu.sampling_frequency, new_on_cpu.sampling_frequency
-            );
-            on_cpu.sampling_frequency = new_on_cpu.sampling_frequency;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    on_cpu.aggregate_by_cpu,
+                    new_on_cpu.aggregate_by_cpu,
+                    "inputs.ebpf.profile.on_cpu.aggregate_by_cpu"
+                ),
+                (
+                    on_cpu.disabled,
+                    new_on_cpu.disabled,
+                    "inputs.ebpf.profile.on_cpu.disabled"
+                ),
+                (
+                    on_cpu.sampling_frequency,
+                    new_on_cpu.sampling_frequency,
+                    "inputs.ebpf.profile.on_cpu.sampling_frequency"
+                )
+            ]
+        );
 
         let memory = &mut ebpf.profile.memory;
         let new_memory = &mut new_ebpf.profile.memory;
-        if memory != new_memory {
-            info!(
-                "Update inputs.ebpf.profile.memory from {:?} to {:?}.",
-                memory, new_memory
-            );
-            restart_agent = (memory.disabled != new_memory.disabled
-                || memory.queue_size != new_memory.queue_size)
-                && !first_run;
-            *memory = *new_memory;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    memory.disabled,
+                    new_memory.disabled,
+                    "inputs.ebpf.profile.memory.disabled"
+                ),
+                (
+                    memory.queue_size,
+                    new_memory.queue_size,
+                    "inputs.ebpf.profile.memory.queue_size"
+                )
+            ]
+        );
+        *memory = *new_memory;
 
         let off_cpu = &mut ebpf.profile.off_cpu;
         let new_off_cpu = &mut new_ebpf.profile.off_cpu;
-        if off_cpu.aggregate_by_cpu != new_off_cpu.aggregate_by_cpu {
-            info!(
-                "Update inputs.ebpf.profile.off_cpu.aggregate_by_cpu from {:?} to {:?}.",
-                off_cpu.aggregate_by_cpu, new_off_cpu.aggregate_by_cpu
-            );
-            off_cpu.aggregate_by_cpu = new_off_cpu.aggregate_by_cpu;
-            restart_agent = !first_run;
-        }
-        if off_cpu.disabled != new_off_cpu.disabled {
-            info!(
-                "Update inputs.ebpf.profile.off_cpu.disabled from {:?} to {:?}.",
-                off_cpu.disabled, new_off_cpu.disabled
-            );
-            off_cpu.disabled = new_off_cpu.disabled;
-            restart_agent = !first_run;
-        }
-        if off_cpu.min_blocking_time != new_off_cpu.min_blocking_time {
-            info!(
-                "Update inputs.ebpf.profile.off_cpu.min_blocking_time from {:?} to {:?}.",
-                off_cpu.min_blocking_time, new_off_cpu.min_blocking_time
-            );
-            off_cpu.min_blocking_time = new_off_cpu.min_blocking_time;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    off_cpu.aggregate_by_cpu,
+                    new_off_cpu.aggregate_by_cpu,
+                    "inputs.ebpf.profile.off_cpu.aggregate_by_cpu"
+                ),
+                (
+                    off_cpu.disabled,
+                    new_off_cpu.disabled,
+                    "inputs.ebpf.profile.off_cpu.disabled"
+                ),
+                (
+                    off_cpu.min_blocking_time,
+                    new_off_cpu.min_blocking_time,
+                    "inputs.ebpf.profile.off_cpu.min_blocking_time"
+                )
+            ]
+        );
 
-        if ebpf.profile.preprocess.stack_compression
-            != new_ebpf.profile.preprocess.stack_compression
-        {
-            info!(
-                "Update inputs.ebpf.profile.preprocess.stack_compression from {:?} to {:?}.",
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
                 ebpf.profile.preprocess.stack_compression,
-                new_ebpf.profile.preprocess.stack_compression
-            );
-            ebpf.profile.preprocess.stack_compression =
-                new_ebpf.profile.preprocess.stack_compression;
-            restart_agent = !first_run;
-        }
+                new_ebpf.profile.preprocess.stack_compression,
+                "inputs.ebpf.profile.preprocess.stack_compression"
+            )]
+        );
 
         let unwinding = &mut ebpf.profile.unwinding;
         let new_unwinding = &mut new_ebpf.profile.unwinding;
-        if unwinding.dwarf_disabled != new_unwinding.dwarf_disabled {
-            info!(
-                "Update inputs.ebpf.profile.unwinding.dwarf_disabled from {:?} to {:?}.",
-                unwinding.dwarf_disabled, new_unwinding.dwarf_disabled
-            );
-            unwinding.dwarf_disabled = new_unwinding.dwarf_disabled;
-            restart_agent = !first_run;
-        }
-        if unwinding.dwarf_process_map_size != new_unwinding.dwarf_process_map_size {
-            info!(
-                "Update inputs.ebpf.profile.unwinding.dwarf_process_map_size from {:?} to {:?}.",
-                unwinding.dwarf_process_map_size, new_unwinding.dwarf_process_map_size
-            );
-            unwinding.dwarf_process_map_size = new_unwinding.dwarf_process_map_size;
-            restart_agent = !first_run;
-        }
-        if unwinding.dwarf_regex != new_unwinding.dwarf_regex {
-            info!(
-                "Update inputs.ebpf.profile.unwinding.dwarf_regex from {:?} to {:?}.",
-                unwinding.dwarf_regex, new_unwinding.dwarf_regex
-            );
-            unwinding.dwarf_regex = new_unwinding.dwarf_regex.clone();
-            restart_agent = !first_run;
-        }
-        if unwinding.dwarf_shard_map_size != new_unwinding.dwarf_shard_map_size {
-            info!(
-                "Update inputs.ebpf.profile.unwinding.dwarf_shard_map_size from {:?} to {:?}.",
-                unwinding.dwarf_shard_map_size, new_unwinding.dwarf_shard_map_size
-            );
-            unwinding.dwarf_shard_map_size = new_unwinding.dwarf_shard_map_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    unwinding.dwarf_disabled,
+                    new_unwinding.dwarf_disabled,
+                    "inputs.ebpf.profile.unwinding.dwarf_disabled"
+                ),
+                (
+                    unwinding.dwarf_process_map_size,
+                    new_unwinding.dwarf_process_map_size,
+                    "inputs.ebpf.profile.unwinding.dwarf_process_map_size"
+                ),
+                (
+                    unwinding.dwarf_regex,
+                    new_unwinding.dwarf_regex,
+                    "inputs.ebpf.profile.unwinding.dwarf_regex"
+                ),
+                (
+                    unwinding.dwarf_shard_map_size,
+                    new_unwinding.dwarf_shard_map_size,
+                    "inputs.ebpf.profile.unwinding.dwarf_shard_map_size"
+                )
+            ]
+        );
 
         let kprobe = &mut ebpf.socket.kprobe;
         let new_kprobe = &mut new_ebpf.socket.kprobe;
-        if kprobe.enable_unix_socket != new_kprobe.enable_unix_socket {
-            info!(
-                "Update inputs.ebpf.socket.kprobe.enable_unix_socket from {:?} to {:?}.",
-                kprobe.enable_unix_socket, new_kprobe.enable_unix_socket
-            );
-            kprobe.enable_unix_socket = new_kprobe.enable_unix_socket;
-            restart_agent = !first_run;
-        }
-        if kprobe.blacklist.ports != new_kprobe.blacklist.ports {
-            info!(
-                "Update inputs.ebpf.socket.kprobe.blacklist.ports from {:?} to {:?}.",
-                kprobe.blacklist.ports, new_kprobe.blacklist.ports
-            );
-            kprobe.blacklist.ports = new_kprobe.blacklist.ports.clone();
-            restart_agent = !first_run;
-        }
-        if kprobe.whitelist.ports != new_kprobe.whitelist.ports {
-            info!(
-                "Update inputs.ebpf.socket.kprobe.whitelist.ports from {:?} to {:?}.",
-                kprobe.whitelist.ports, new_kprobe.whitelist.ports
-            );
-            kprobe.whitelist.ports = new_kprobe.whitelist.ports.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    kprobe.enable_unix_socket,
+                    new_kprobe.enable_unix_socket,
+                    "inputs.ebpf.socket.kprobe.enable_unix_socket"
+                ),
+                (
+                    kprobe.blacklist.ports,
+                    new_kprobe.blacklist.ports,
+                    "inputs.ebpf.socket.kprobe.blacklist.ports"
+                ),
+                (
+                    kprobe.whitelist.ports,
+                    new_kprobe.whitelist.ports,
+                    "inputs.ebpf.socket.kprobe.whitelist.ports"
+                )
+            ]
+        );
 
         let uprobe = &mut ebpf.socket.uprobe;
         let new_uprobe = &mut new_ebpf.socket.uprobe;
-        if uprobe.tls.enabled != new_uprobe.tls.enabled {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.tls.enabled from {:?} to {:?}.",
-                uprobe.tls.enabled, new_uprobe.tls.enabled
-            );
-            uprobe.tls.enabled = new_uprobe.tls.enabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                uprobe.tls.enabled,
+                new_uprobe.tls.enabled,
+                "inputs.ebpf.socket.uprobe.tls.enabled"
+            )]
+        );
         let golang_uprobe = &mut uprobe.golang;
         let new_golang_uprobe = &mut new_uprobe.golang;
-        if golang_uprobe.enabled != new_golang_uprobe.enabled {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.golang.enabled from {:?} to {:?}.",
-                golang_uprobe.enabled, new_golang_uprobe.enabled
-            );
-            golang_uprobe.enabled = new_golang_uprobe.enabled;
-            restart_agent = !first_run;
-        }
-        if golang_uprobe.tracing_timeout != new_golang_uprobe.tracing_timeout {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.golang.tracing_timeout from {:?} to {:?}.",
-                golang_uprobe.tracing_timeout, new_golang_uprobe.tracing_timeout
-            );
-            golang_uprobe.tracing_timeout = new_golang_uprobe.tracing_timeout;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    golang_uprobe.enabled,
+                    new_golang_uprobe.enabled,
+                    "inputs.ebpf.socket.uprobe.golang.enabled"
+                ),
+                (
+                    golang_uprobe.tracing_timeout,
+                    new_golang_uprobe.tracing_timeout,
+                    "inputs.ebpf.socket.uprobe.golang.tracing_timeout"
+                )
+            ]
+        );
 
         let dpdk_uprobe = &mut uprobe.dpdk;
         let new_dpdk_uprobe = &mut new_uprobe.dpdk;
-        if dpdk_uprobe.command != new_dpdk_uprobe.command {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.dpdk.command from {:?} to {:?}.",
-                dpdk_uprobe.command, new_dpdk_uprobe.command
-            );
-            dpdk_uprobe.command = new_dpdk_uprobe.command.clone();
-            restart_agent = !first_run;
-        }
-        if dpdk_uprobe.rx_hooks != new_dpdk_uprobe.rx_hooks {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.dpdk.rx_hooks from {:?} to {:?}.",
-                dpdk_uprobe.rx_hooks, new_dpdk_uprobe.rx_hooks
-            );
-            dpdk_uprobe.rx_hooks = new_dpdk_uprobe.rx_hooks.clone();
-            restart_agent = !first_run;
-        }
-        if dpdk_uprobe.tx_hooks != new_dpdk_uprobe.tx_hooks {
-            info!(
-                "Update inputs.ebpf.socket.uprobe.dpdk.tx_hooks from {:?} to {:?}.",
-                dpdk_uprobe.tx_hooks, new_dpdk_uprobe.tx_hooks
-            );
-            dpdk_uprobe.tx_hooks = new_dpdk_uprobe.tx_hooks.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    dpdk_uprobe.command,
+                    new_dpdk_uprobe.command,
+                    "inputs.ebpf.socket.uprobe.dpdk.command"
+                ),
+                (
+                    dpdk_uprobe.rx_hooks,
+                    new_dpdk_uprobe.rx_hooks,
+                    "inputs.ebpf.socket.uprobe.dpdk.rx_hooks"
+                ),
+                (
+                    dpdk_uprobe.tx_hooks,
+                    new_dpdk_uprobe.tx_hooks,
+                    "inputs.ebpf.socket.uprobe.dpdk.tx_hooks"
+                )
+            ]
+        );
 
         let preprocess = &mut ebpf.socket.preprocess;
         let new_preprocess = &mut new_ebpf.socket.preprocess;
-        if preprocess.out_of_order_reassembly_cache_size
-            != new_preprocess.out_of_order_reassembly_cache_size
-        {
-            info!(
-                "Update inputs.ebpf.socket.preprocess.out_of_order_reassembly_cache_size from {:?} to {:?}.",
-                preprocess.out_of_order_reassembly_cache_size,
-                new_preprocess.out_of_order_reassembly_cache_size
-            );
-            preprocess.out_of_order_reassembly_cache_size =
-                new_preprocess.out_of_order_reassembly_cache_size;
-            restart_agent = !first_run;
-        }
-        if preprocess.out_of_order_reassembly_protocols
-            != new_preprocess.out_of_order_reassembly_protocols
-        {
-            info!(
-                "Update inputs.ebpf.socket.preprocess.out_of_order_reassembly_protocols from {:?} to {:?}.",
-                preprocess.out_of_order_reassembly_protocols,
-                new_preprocess.out_of_order_reassembly_protocols
-            );
-            preprocess.out_of_order_reassembly_protocols =
-                new_preprocess.out_of_order_reassembly_protocols.clone();
-            restart_agent = !first_run;
-        }
-        if preprocess.out_of_order_reassembly_timeout
-            != new_preprocess.out_of_order_reassembly_timeout
-        {
-            info!(
-                "Update inputs.ebpf.socket.preprocess.out_of_order_reassembly_timeout from {:?} to {:?}.",
-                preprocess.out_of_order_reassembly_timeout,
-                new_preprocess.out_of_order_reassembly_timeout
-            );
-            preprocess.out_of_order_reassembly_timeout =
-                new_preprocess.out_of_order_reassembly_timeout.clone();
-            restart_agent = !first_run;
-        }
-        if preprocess.segmentation_reassembly_protocols
-            != new_preprocess.segmentation_reassembly_protocols
-        {
-            info!(
-                "Update inputs.ebpf.socket.preprocess.segmentation_reassembly_protocols from {:?} to {:?}.",
-                preprocess.segmentation_reassembly_protocols,
-                new_preprocess.segmentation_reassembly_protocols
-            );
-            preprocess.segmentation_reassembly_protocols =
-                new_preprocess.segmentation_reassembly_protocols.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    preprocess.out_of_order_reassembly_cache_size,
+                    new_preprocess.out_of_order_reassembly_cache_size,
+                    "inputs.ebpf.socket.preprocess.out_of_order_reassembly_cache_size"
+                ),
+                (
+                    preprocess.out_of_order_reassembly_protocols,
+                    new_preprocess.out_of_order_reassembly_protocols,
+                    "inputs.ebpf.socket.preprocess.out_of_order_reassembly_protocols"
+                ),
+                (
+                    preprocess.out_of_order_reassembly_timeout,
+                    new_preprocess.out_of_order_reassembly_timeout,
+                    "inputs.ebpf.socket.preprocess.out_of_order_reassembly_timeout"
+                ),
+                (
+                    preprocess.segmentation_reassembly_protocols,
+                    new_preprocess.segmentation_reassembly_protocols,
+                    "inputs.ebpf.socket.preprocess.segmentation_reassembly_protocols"
+                )
+            ]
+        );
 
         let tunning = &mut ebpf.socket.tunning;
         let new_tunning = &mut new_ebpf.socket.tunning;
-        if tunning.fentry_enabled != new_tunning.fentry_enabled {
-            info!(
-                "Update inputs.ebpf.socket.tunning.fentry_enabled from {:?} to {:?}.",
-                tunning.fentry_enabled, new_tunning.fentry_enabled
-            );
-            tunning.fentry_enabled = new_tunning.fentry_enabled;
-            restart_agent = !first_run;
-        }
-        if tunning.map_prealloc_disabled != new_tunning.map_prealloc_disabled {
-            info!(
-                "Update inputs.ebpf.socket.tunning.map_prealloc_disabled from {:?} to {:?}.",
-                tunning.map_prealloc_disabled, new_tunning.map_prealloc_disabled
-            );
-            tunning.map_prealloc_disabled = new_tunning.map_prealloc_disabled;
-            restart_agent = !first_run;
-        }
-        if tunning.syscall_trace_id_disabled != new_tunning.syscall_trace_id_disabled {
-            info!(
-                "Update inputs.ebpf.socket.tunning.syscall_trace_id_disabled from {:?} to {:?}.",
-                tunning.syscall_trace_id_disabled, new_tunning.syscall_trace_id_disabled
-            );
-            tunning.syscall_trace_id_disabled = new_tunning.syscall_trace_id_disabled;
-            restart_agent = !first_run;
-        }
-        if tunning.max_capture_rate != new_tunning.max_capture_rate {
-            info!(
-                "Update inputs.ebpf.socket.tunning.max_capture_rate from {:?} to {:?}.",
-                tunning.max_capture_rate, new_tunning.max_capture_rate
-            );
-            tunning.max_capture_rate = new_tunning.max_capture_rate;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tunning.fentry_enabled,
+                    new_tunning.fentry_enabled,
+                    "inputs.ebpf.socket.tunning.fentry_enabled"
+                ),
+                (
+                    tunning.map_prealloc_disabled,
+                    new_tunning.map_prealloc_disabled,
+                    "inputs.ebpf.socket.tunning.map_prealloc_disabled"
+                ),
+                (
+                    tunning.syscall_trace_id_disabled,
+                    new_tunning.syscall_trace_id_disabled,
+                    "inputs.ebpf.socket.tunning.syscall_trace_id_disabled"
+                ),
+                (
+                    tunning.max_capture_rate,
+                    new_tunning.max_capture_rate,
+                    "inputs.ebpf.socket.tunning.max_capture_rate"
+                )
+            ]
+        );
 
         let tunning = &mut ebpf.tunning;
         let new_tunning = &mut new_ebpf.tunning;
-        if tunning.collector_queue_size != new_tunning.collector_queue_size {
-            info!(
-                "Update inputs.ebpf.tunning.collector_queue_size from {:?} to {:?}.",
-                tunning.collector_queue_size, new_tunning.collector_queue_size
-            );
-            tunning.collector_queue_size = new_tunning.collector_queue_size;
-            restart_agent = !first_run;
-        }
-        if tunning.kernel_ring_size != new_tunning.kernel_ring_size {
-            info!(
-                "Update inputs.ebpf.tunning.kernel_ring_size from {:?} to {:?}.",
-                tunning.kernel_ring_size, new_tunning.kernel_ring_size
-            );
-            tunning.kernel_ring_size = new_tunning.kernel_ring_size;
-            restart_agent = !first_run;
-        }
-        if tunning.max_socket_entries != new_tunning.max_socket_entries {
-            info!(
-                "Update inputs.ebpf.tunning.max_socket_entries from {:?} to {:?}.",
-                tunning.max_socket_entries, new_tunning.max_socket_entries
-            );
-            tunning.max_socket_entries = new_tunning.max_socket_entries;
-            restart_agent = !first_run;
-        }
-        if tunning.max_trace_entries != new_tunning.max_trace_entries {
-            info!(
-                "Update inputs.ebpf.tunning.max_trace_entries from {:?} to {:?}.",
-                tunning.max_trace_entries, new_tunning.max_trace_entries
-            );
-            tunning.max_trace_entries = new_tunning.max_trace_entries;
-            restart_agent = !first_run;
-        }
-        if tunning.perf_pages_count != new_tunning.perf_pages_count {
-            info!(
-                "Update inputs.ebpf.tunning.perf_pages_count from {:?} to {:?}.",
-                tunning.perf_pages_count, new_tunning.perf_pages_count
-            );
-            tunning.perf_pages_count = new_tunning.perf_pages_count;
-            restart_agent = !first_run;
-        }
-        if tunning.socket_map_reclaim_threshold != new_tunning.socket_map_reclaim_threshold {
-            info!(
-                "Update inputs.ebpf.tunning.socket_map_reclaim_threshold from {:?} to {:?}.",
-                tunning.socket_map_reclaim_threshold, new_tunning.socket_map_reclaim_threshold
-            );
-            tunning.socket_map_reclaim_threshold = new_tunning.socket_map_reclaim_threshold;
-            restart_agent = !first_run;
-        }
-        if tunning.userspace_worker_threads != new_tunning.userspace_worker_threads {
-            info!(
-                "Update inputs.ebpf.tunning.userspace_worker_threads from {:?} to {:?}.",
-                tunning.userspace_worker_threads, new_tunning.userspace_worker_threads
-            );
-            tunning.userspace_worker_threads = new_tunning.userspace_worker_threads;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tunning.collector_queue_size,
+                    new_tunning.collector_queue_size,
+                    "inputs.ebpf.tunning.collector_queue_size"
+                ),
+                (
+                    tunning.kernel_ring_size,
+                    new_tunning.kernel_ring_size,
+                    "inputs.ebpf.tunning.kernel_ring_size"
+                ),
+                (
+                    tunning.max_socket_entries,
+                    new_tunning.max_socket_entries,
+                    "inputs.ebpf.tunning.max_socket_entries"
+                ),
+                (
+                    tunning.max_trace_entries,
+                    new_tunning.max_trace_entries,
+                    "inputs.ebpf.tunning.max_trace_entries"
+                ),
+                (
+                    tunning.perf_pages_count,
+                    new_tunning.perf_pages_count,
+                    "inputs.ebpf.tunning.perf_pages_count"
+                ),
+                (
+                    tunning.socket_map_reclaim_threshold,
+                    new_tunning.socket_map_reclaim_threshold,
+                    "inputs.ebpf.tunning.socket_map_reclaim_threshold"
+                ),
+                (
+                    tunning.userspace_worker_threads,
+                    new_tunning.userspace_worker_threads,
+                    "inputs.ebpf.tunning.userspace_worker_threads"
+                )
+            ]
+        );
 
         let integration = &mut config.inputs.integration;
         let new_integration = &mut new_config.user_config.inputs.integration;
-        if integration.enabled != new_integration.enabled {
-            info!(
-                "Update inputs.integration.enabled from {:?} to {:?}.",
-                integration.enabled, new_integration.enabled
-            );
-            integration.enabled = new_integration.enabled;
-            restart_agent = !first_run;
-        }
-        if integration.compression != new_integration.compression {
-            info!(
-                "Update inputs.integration.compression from {:?} to {:?}.",
-                integration.compression, new_integration.compression
-            );
-            integration.compression = new_integration.compression.clone();
-            restart_agent = !first_run;
-        }
-        if integration.feature_control != new_integration.feature_control {
-            info!(
-                "Update inputs.integration.feature_control from {:?} to {:?}.",
-                integration.feature_control, new_integration.feature_control
-            );
-            integration.feature_control = new_integration.feature_control;
-            restart_agent = !first_run;
-        }
-        if integration.listen_port != new_integration.listen_port {
-            info!(
-                "Update inputs.integration.listen_port from {:?} to {:?}.",
-                integration.listen_port, new_integration.listen_port
-            );
-            integration.listen_port = new_integration.listen_port;
-            restart_agent = !first_run;
-        }
-        if integration.prometheus_extra_labels != new_integration.prometheus_extra_labels {
-            info!(
-                "Update inputs.integration.prometheus_extra_labels from {:?} to {:?}.",
-                integration.prometheus_extra_labels, new_integration.prometheus_extra_labels
-            );
-            integration.prometheus_extra_labels = new_integration.prometheus_extra_labels.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    integration.enabled,
+                    new_integration.enabled,
+                    "inputs.integration.enabled"
+                ),
+                (
+                    integration.compression,
+                    new_integration.compression,
+                    "inputs.integration.compression"
+                ),
+                (
+                    integration.feature_control,
+                    new_integration.feature_control,
+                    "inputs.integration.feature_control"
+                ),
+                (
+                    integration.listen_port,
+                    new_integration.listen_port,
+                    "inputs.integration.listen_port"
+                ),
+                (
+                    integration.prometheus_extra_labels,
+                    new_integration.prometheus_extra_labels,
+                    "inputs.integration.prometheus_extra_labels"
+                )
+            ]
+        );
 
         let resources = &mut config.inputs.resources;
         let new_resources = &mut new_config.user_config.inputs.resources;
@@ -3758,77 +3720,63 @@ impl ConfigHandler {
 
         let kubernetes = &mut resources.kubernetes;
         let new_kubernetes = &mut new_resources.kubernetes;
-        if kubernetes.api_list_max_interval != new_kubernetes.api_list_max_interval {
-            info!(
-                "Update inputs.resources.kubernetes.api_list_max_interval from {:?} to {:?}.",
-                kubernetes.api_list_max_interval, new_kubernetes.api_list_max_interval
-            );
-            kubernetes.api_list_max_interval = new_kubernetes.api_list_max_interval;
-            restart_agent = !first_run;
-        }
-        if kubernetes.api_list_page_size != new_kubernetes.api_list_page_size {
-            info!(
-                "Update inputs.resources.kubernetes.api_list_page_size from {:?} to {:?}.",
-                kubernetes.api_list_page_size, new_kubernetes.api_list_page_size
-            );
-            kubernetes.api_list_page_size = new_kubernetes.api_list_page_size;
-            restart_agent = !first_run;
-        }
-        if kubernetes.api_resources != new_kubernetes.api_resources {
-            info!(
-                "Update inputs.resources.kubernetes.api_resources from {:?} to {:?}.",
-                kubernetes.api_resources, new_kubernetes.api_resources
-            );
-            kubernetes.api_resources = new_kubernetes.api_resources.clone();
-            restart_agent = !first_run;
-        }
-        if kubernetes.ingress_flavour != new_kubernetes.ingress_flavour {
-            info!(
-                "Update inputs.resources.kubernetes.ingress_flavour from {:?} to {:?}.",
-                kubernetes.ingress_flavour, new_kubernetes.ingress_flavour
-            );
-            kubernetes.ingress_flavour = new_kubernetes.ingress_flavour.clone();
-            restart_agent = !first_run;
-        }
-        if kubernetes.kubernetes_namespace != new_kubernetes.kubernetes_namespace {
-            info!(
-                "Update inputs.resources.kubernetes.kubernetes_namespace from {:?} to {:?}.",
-                kubernetes.kubernetes_namespace, new_kubernetes.kubernetes_namespace
-            );
-            kubernetes.kubernetes_namespace = new_kubernetes.kubernetes_namespace.clone();
-            restart_agent = !first_run;
-        }
-        if kubernetes.pod_mac_collection_method != new_kubernetes.pod_mac_collection_method {
-            info!(
-                "Update inputs.resources.kubernetes.pod_mac_collection_method from {:?} to {:?}.",
-                kubernetes.pod_mac_collection_method, new_kubernetes.pod_mac_collection_method
-            );
-            kubernetes.pod_mac_collection_method = new_kubernetes.pod_mac_collection_method;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    kubernetes.api_list_max_interval,
+                    new_kubernetes.api_list_max_interval,
+                    "inputs.resources.kubernetes.api_list_max_interval"
+                ),
+                (
+                    kubernetes.api_list_page_size,
+                    new_kubernetes.api_list_page_size,
+                    "inputs.resources.kubernetes.api_list_page_size"
+                ),
+                (
+                    kubernetes.api_resources,
+                    new_kubernetes.api_resources,
+                    "inputs.resources.kubernetes.api_resources"
+                ),
+                (
+                    kubernetes.ingress_flavour,
+                    new_kubernetes.ingress_flavour,
+                    "inputs.resources.kubernetes.ingress_flavour"
+                ),
+                (
+                    kubernetes.kubernetes_namespace,
+                    new_kubernetes.kubernetes_namespace,
+                    "inputs.resources.kubernetes.kubernetes_namespace"
+                ),
+                (
+                    kubernetes.pod_mac_collection_method,
+                    new_kubernetes.pod_mac_collection_method,
+                    "inputs.resources.kubernetes.pod_mac_collection_method"
+                )
+            ]
+        );
 
         let private_cloud = &mut resources.private_cloud;
         let new_private_cloud = &mut new_resources.private_cloud;
-        if private_cloud.hypervisor_resource_enabled
-            != new_private_cloud.hypervisor_resource_enabled
-        {
-            info!(
-                "Update inputs.resources.private_cloud.hypervisor_resource_enabled from {:?} to {:?}.",
-                private_cloud.hypervisor_resource_enabled,
-                new_private_cloud.hypervisor_resource_enabled
-            );
-            private_cloud.hypervisor_resource_enabled =
-                new_private_cloud.hypervisor_resource_enabled;
-            restart_agent = !first_run;
-        }
-        if private_cloud.vm_mac_mapping_script != new_private_cloud.vm_mac_mapping_script {
-            info!(
-                "Update inputs.resources.private_cloud.vm_mac_mapping_script from {:?} to {:?}.",
-                private_cloud.vm_mac_mapping_script, new_private_cloud.vm_mac_mapping_script
-            );
-            private_cloud.vm_mac_mapping_script = new_private_cloud.vm_mac_mapping_script.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    private_cloud.hypervisor_resource_enabled,
+                    new_private_cloud.hypervisor_resource_enabled,
+                    "inputs.resources.private_cloud.hypervisor_resource_enabled"
+                ),
+                (
+                    private_cloud.vm_mac_mapping_script,
+                    new_private_cloud.vm_mac_mapping_script,
+                    "inputs.resources.private_cloud.vm_mac_mapping_script"
+                )
+            ]
+        );
         if private_cloud.vm_mac_source != new_private_cloud.vm_mac_source {
             info!(
                 "Update inputs.resources.private_cloud.vm_mac_source from {:?} to {:?}.",
@@ -3846,14 +3794,12 @@ impl ConfigHandler {
 
         let proc = &mut config.inputs.proc;
         let new_proc = &mut new_config.user_config.inputs.proc;
-        if proc.enabled != new_proc.enabled {
-            info!(
-                "Update inputs.proc.enabled from {:?} to {:?}.",
-                proc.enabled, new_proc.enabled
-            );
-            proc.enabled = new_proc.enabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(proc.enabled, new_proc.enabled, "inputs.proc.enabled")]
+        );
         if proc.min_lifetime != new_proc.min_lifetime {
             info!(
                 "Update inputs.proc.min_lifetime from {:?} to {:?}.",
@@ -3886,14 +3832,16 @@ impl ConfigHandler {
             proc.process_matcher = new_proc.process_matcher.clone();
             process_matcher_update = true;
         }
-        if proc.symbol_table != new_proc.symbol_table {
-            info!(
-                "Update inputs.proc.symbol_table from {:?} to {:?}.",
-                proc.symbol_table, new_proc.symbol_table
-            );
-            proc.symbol_table = new_proc.symbol_table;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                proc.symbol_table,
+                new_proc.symbol_table,
+                "inputs.proc.symbol_table"
+            )]
+        );
         if proc.socket_info_sync_interval != new_proc.socket_info_sync_interval {
             info!(
                 "Update inputs.proc.socket_info_sync_interval from {:?} to {:?}.",
@@ -3949,14 +3897,16 @@ impl ConfigHandler {
         // global
         let alerts = &mut config.global.alerts;
         let new_alerts = &mut new_config.user_config.global.alerts;
-        if alerts.check_core_file_disabled != new_alerts.check_core_file_disabled {
-            info!(
-                "Update global.alerts.check_core_file_disabled from {:?} to {:?}.",
-                alerts.check_core_file_disabled, new_alerts.check_core_file_disabled
-            );
-            alerts.check_core_file_disabled = new_alerts.check_core_file_disabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                alerts.check_core_file_disabled,
+                new_alerts.check_core_file_disabled,
+                "global.alerts.check_core_file_disabled"
+            )]
+        );
         if alerts.process_threshold != new_alerts.process_threshold {
             info!(
                 "Update global.alerts.process_threshold from {:?} to {:?}.",
@@ -4316,22 +4266,15 @@ impl ConfigHandler {
             );
             ntp.enabled = new_ntp.enabled;
         }
-        if ntp.max_drift != new_ntp.max_drift {
-            info!(
-                "Update global.ntp.max_drift from {:?} to {:?}.",
-                ntp.max_drift, new_ntp.max_drift
-            );
-            ntp.max_drift = new_ntp.max_drift;
-            restart_agent = !first_run;
-        }
-        if ntp.min_drift != new_ntp.min_drift {
-            info!(
-                "Update global.ntp.min_drift from {:?} to {:?}.",
-                ntp.min_drift, new_ntp.min_drift
-            );
-            ntp.min_drift = new_ntp.min_drift;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (ntp.max_drift, new_ntp.max_drift, "global.ntp.max_drift"),
+                (ntp.min_drift, new_ntp.min_drift, "global.ntp.min_drift")
+            ]
+        );
 
         let self_monitoring = &mut config.global.self_monitoring;
         let new_self_monitoring = &mut new_config.user_config.global.self_monitoring;
@@ -4344,14 +4287,16 @@ impl ConfigHandler {
             );
             debug.enabled = debug.enabled;
         }
-        if debug.local_udp_port != new_debug.local_udp_port {
-            info!(
-                "Update global.self_monitoring.debug.local_udp_port from {:?} to {:?}.",
-                debug.local_udp_port, new_debug.local_udp_port
-            );
-            debug.local_udp_port = debug.local_udp_port;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                debug.local_udp_port,
+                new_debug.local_udp_port,
+                "global.self_monitoring.debug.local_udp_port"
+            )]
+        );
 
         if self_monitoring.hostname != new_self_monitoring.hostname {
             info!(
@@ -4403,33 +4348,36 @@ impl ConfigHandler {
                 new_log.log_level = log.log_level.clone();
             }
         }
-        if self_monitoring.profile.enabled != new_self_monitoring.profile.enabled {
-            info!(
-                "Update global.self_monitoring.profile.enabled from {:?} to {:?}.",
-                self_monitoring.profile.enabled, new_self_monitoring.profile.enabled
-            );
-            self_monitoring.profile.enabled = new_self_monitoring.profile.enabled;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                self_monitoring.profile.enabled,
+                new_self_monitoring.profile.enabled,
+                "global.self_monitoring.profile.enabled"
+            )]
+        );
 
         let standalone_mode = &mut config.global.standalone_mode;
         let new_standalone_mode = &mut new_config.user_config.global.standalone_mode;
-        if standalone_mode.data_file_dir != new_standalone_mode.data_file_dir {
-            info!(
-                "Update global.standalone_mode.data_file_dir from {:?} to {:?}.",
-                standalone_mode.data_file_dir, new_standalone_mode.data_file_dir
-            );
-            standalone_mode.data_file_dir = new_standalone_mode.data_file_dir.clone();
-            restart_agent = !first_run;
-        }
-        if standalone_mode.max_data_file_size != new_standalone_mode.max_data_file_size {
-            info!(
-                "Update global.standalone_mode.max_data_file_size from {:?} to {:?}.",
-                standalone_mode.max_data_file_size, new_standalone_mode.max_data_file_size
-            );
-            standalone_mode.max_data_file_size = new_standalone_mode.max_data_file_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    standalone_mode.data_file_dir,
+                    new_standalone_mode.data_file_dir,
+                    "global.standalone_mode.data_file_dir"
+                ),
+                (
+                    standalone_mode.max_data_file_size,
+                    new_standalone_mode.max_data_file_size,
+                    "global.standalone_mode.max_data_file_size"
+                )
+            ]
+        );
 
         let tunning = &mut config.global.tunning;
         let new_tunning = &mut new_config.user_config.global.tunning;
@@ -4445,12 +4393,21 @@ impl ConfigHandler {
                 "Update global.tunning.swap_disabled from {:?} to {:?}.",
                 tunning.swap_disabled, new_tunning.swap_disabled
             );
+            let reason = changed_reason(
+                "global.tunning.swap_disabled",
+                &tunning.swap_disabled,
+                &new_tunning.swap_disabled,
+            );
             tunning.swap_disabled = new_tunning.swap_disabled;
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if tunning.swap_disabled {
                 Self::set_swap_disabled();
             } else {
-                restart_agent = !first_run;
+                let restart_value = !first_run;
+                restart_agent |= restart_value;
+                if restart_value {
+                    agent_restart_reasons.insert(reason);
+                }
             }
         }
         if tunning.cpu_affinity != new_tunning.cpu_affinity {
@@ -4458,13 +4415,22 @@ impl ConfigHandler {
                 "Update global.tunning.cpu_affinity from {:?} to {:?}.",
                 tunning.cpu_affinity, new_tunning.cpu_affinity
             );
+            let reason = changed_reason(
+                "global.tunning.cpu_affinity",
+                &tunning.cpu_affinity,
+                &new_tunning.cpu_affinity,
+            );
             tunning.cpu_affinity = new_tunning.cpu_affinity.clone();
             #[cfg(any(target_os = "linux", target_os = "android"))]
             {
                 Self::set_cpu_affinity(&tunning.cpu_affinity, &mut cpu_set);
                 new_config.dispatcher.cpu_set = cpu_set;
             }
-            restart_agent = !first_run;
+            let restart_value = !first_run;
+            restart_agent |= restart_value;
+            if restart_value {
+                agent_restart_reasons.insert(reason);
+            }
         }
         if tunning.process_scheduling_priority != new_tunning.process_scheduling_priority {
             info!(
@@ -4506,14 +4472,16 @@ impl ConfigHandler {
         // dev
         let dev = &mut config.dev;
         let new_dev = &mut new_config.user_config.dev;
-        if dev.feature_flags != new_dev.feature_flags {
-            info!(
-                "Update dev.feature_flags from {:?} to {:?}.",
-                dev.feature_flags, new_dev.feature_flags
-            );
-            dev.feature_flags = new_dev.feature_flags.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                dev.feature_flags,
+                new_dev.feature_flags,
+                "dev.feature_flags"
+            )]
+        );
 
         // output
         let outputs = &mut config.outputs;
@@ -4527,14 +4495,16 @@ impl ConfigHandler {
             );
             socket.multiple_sockets_to_ingester = new_socket.multiple_sockets_to_ingester;
         }
-        if socket.raw_udp_qos_bypass != new_socket.raw_udp_qos_bypass {
-            info!(
-                "Update outputs.socket.raw_udp_qos_bypass from {:?} to {:?}.",
-                socket.raw_udp_qos_bypass, new_socket.raw_udp_qos_bypass
-            );
-            socket.raw_udp_qos_bypass = new_socket.raw_udp_qos_bypass;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                socket.raw_udp_qos_bypass,
+                new_socket.raw_udp_qos_bypass,
+                "outputs.socket.raw_udp_qos_bypass"
+            )]
+        );
         if socket.data_socket_type != new_socket.data_socket_type {
             info!(
                 "Update outputs.socket.data_socket_type from {:?} to {:?}.",
@@ -4617,14 +4587,16 @@ impl ConfigHandler {
 
         let tunning = &mut flow_log.tunning;
         let new_tunning = &mut new_flow_log.tunning;
-        if tunning.collector_queue_size != new_tunning.collector_queue_size {
-            info!(
-                "Update outputs.flow_log.tunning.collector_queue_size from {:?} to {:?}.",
-                tunning.collector_queue_size, new_tunning.collector_queue_size
-            );
-            tunning.collector_queue_size = new_tunning.collector_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                tunning.collector_queue_size,
+                new_tunning.collector_queue_size,
+                "outputs.flow_log.tunning.collector_queue_size"
+            )]
+        );
 
         let flow_metrics = &mut outputs.flow_metrics;
         let new_flow_metrics = &mut new_outputs.flow_metrics;
@@ -4644,14 +4616,30 @@ impl ConfigHandler {
             );
             filters.apm_metrics = new_filters.apm_metrics;
         }
-        if filters.inactive_ip_aggregation != new_filters.inactive_ip_aggregation {
+        if filters.npm_metrics != new_filters.npm_metrics {
             info!(
-                "Update outputs.flow_metrics.filters.inactive_ip_aggregation from {:?} to {:?}.",
-                filters.inactive_ip_aggregation, new_filters.inactive_ip_aggregation
+                "Update outputs.flow_metrics.filters.npm_metrics from {:?} to {:?}.",
+                filters.npm_metrics, new_filters.npm_metrics
             );
-            filters.inactive_ip_aggregation = new_filters.inactive_ip_aggregation;
-            restart_dispatcher = true;
+            filters.npm_metrics = new_filters.npm_metrics;
         }
+        update_fields_with_restart_reason!(
+            restart_dispatcher,
+            true,
+            dispatcher_restart_reasons,
+            [
+                (
+                    filters.inactive_ip_aggregation,
+                    new_filters.inactive_ip_aggregation,
+                    "outputs.flow_metrics.filters.inactive_ip_aggregation"
+                ),
+                (
+                    filters.npm_metrics_concurrent,
+                    new_filters.npm_metrics_concurrent,
+                    "outputs.flow_metrics.filters.npm_metrics_concurrent"
+                )
+            ]
+        );
         if filters.inactive_server_port_aggregation != new_filters.inactive_server_port_aggregation
         {
             info!(
@@ -4660,21 +4648,6 @@ impl ConfigHandler {
                 new_filters.inactive_server_port_aggregation
             );
             filters.inactive_server_port_aggregation = new_filters.inactive_server_port_aggregation;
-        }
-        if filters.npm_metrics != new_filters.npm_metrics {
-            info!(
-                "Update outputs.flow_metrics.filters.npm_metrics from {:?} to {:?}.",
-                filters.npm_metrics, new_filters.npm_metrics
-            );
-            filters.npm_metrics = new_filters.npm_metrics;
-        }
-        if filters.npm_metrics_concurrent != new_filters.npm_metrics_concurrent {
-            info!(
-                "Update outputs.flow_metrics.filters.npm_metrics_concurrent from {:?} to {:?}.",
-                filters.npm_metrics_concurrent, new_filters.npm_metrics_concurrent
-            );
-            filters.npm_metrics_concurrent = new_filters.npm_metrics_concurrent;
-            restart_dispatcher = true;
         }
         if filters.second_metrics != new_filters.second_metrics {
             info!(
@@ -4685,25 +4658,19 @@ impl ConfigHandler {
         }
         let tunning = &mut outputs.flow_metrics.tunning;
         let new_tunning = &mut new_outputs.flow_metrics.tunning;
-        if tunning.sender_queue_size != new_tunning.sender_queue_size {
-            info!(
-                "Update outputs.flow_metrics.tunning.sender_queue_size from {:?} to {:?}.",
-                tunning.sender_queue_size, new_tunning.sender_queue_size
-            );
-            tunning.sender_queue_size = new_tunning.sender_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                tunning.sender_queue_size,
+                new_tunning.sender_queue_size,
+                "outputs.flow_metrics.tunning.sender_queue_size"
+            )]
+        );
 
         let npb = &mut outputs.npb;
         let new_npb = &mut new_outputs.npb;
-        if npb.overlay_vlan_header_trimming != new_npb.overlay_vlan_header_trimming {
-            info!(
-                "Update outputs.npb.overlay_vlan_header_trimming from {:?} to {:?}.",
-                npb.overlay_vlan_header_trimming, new_npb.overlay_vlan_header_trimming
-            );
-            npb.overlay_vlan_header_trimming = new_npb.overlay_vlan_header_trimming;
-            restart_agent = !first_run;
-        }
         if npb.traffic_global_dedup != new_npb.traffic_global_dedup {
             info!(
                 "Update outputs.npb.traffic_global_dedup from {:?} to {:?}.",
@@ -4711,14 +4678,23 @@ impl ConfigHandler {
             );
             npb.traffic_global_dedup = new_npb.traffic_global_dedup;
         }
-        if npb.custom_vxlan_flags != new_npb.custom_vxlan_flags {
-            info!(
-                "Update outputs.npb.custom_vxlan_flags from {:?} to {:?}.",
-                npb.custom_vxlan_flags, new_npb.custom_vxlan_flags
-            );
-            npb.custom_vxlan_flags = new_npb.custom_vxlan_flags;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    npb.overlay_vlan_header_trimming,
+                    new_npb.overlay_vlan_header_trimming,
+                    "outputs.npb.overlay_vlan_header_trimming"
+                ),
+                (
+                    npb.custom_vxlan_flags,
+                    new_npb.custom_vxlan_flags,
+                    "outputs.npb.custom_vxlan_flags"
+                )
+            ]
+        );
         if npb.extra_vlan_header != new_npb.extra_vlan_header {
             info!(
                 "Update outputs.npb.extra_vlan_header from {:?} to {:?}.",
@@ -4752,22 +4728,26 @@ impl ConfigHandler {
             );
             npb.raw_udp_vlan_tag = new_npb.raw_udp_vlan_tag;
         }
-        if npb.target_port != new_npb.target_port {
-            info!(
-                "Update outputs.npb.target_port from {:?} to {:?}.",
-                npb.target_port, new_npb.target_port
-            );
-            npb.target_port = new_npb.target_port;
-            restart_agent = !first_run;
-        }
-        if outputs.compression != new_outputs.compression {
-            info!(
-                "Update outputs.compression from {:?} to {:?}.",
-                outputs.compression, new_outputs.compression
-            );
-            outputs.compression = new_outputs.compression.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                npb.target_port,
+                new_npb.target_port,
+                "outputs.npb.target_port"
+            )]
+        );
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                outputs.compression,
+                new_outputs.compression,
+                "outputs.compression"
+            )]
+        );
 
         // plugins
         let plugins = &mut config.plugins;
@@ -4801,169 +4781,152 @@ impl ConfigHandler {
         let new_packet = &mut new_processors.packet;
         let pcap = &mut packet.pcap_stream;
         let new_pcap = &mut new_packet.pcap_stream;
-        if pcap.buffer_size_per_flow != new_pcap.buffer_size_per_flow {
-            info!(
-                "Update processors.packet.pcap_stream.buffer_size_per_flow from {:?} to {:?}.",
-                pcap.buffer_size_per_flow, new_pcap.buffer_size_per_flow
-            );
-            pcap.buffer_size_per_flow = new_pcap.buffer_size_per_flow;
-            restart_agent = !first_run;
-        }
-        if pcap.flush_interval != new_pcap.flush_interval {
-            info!(
-                "Update processors.packet.pcap_stream.flush_interval from {:?} to {:?}.",
-                pcap.flush_interval, new_pcap.flush_interval
-            );
-            pcap.flush_interval = new_pcap.flush_interval;
-            restart_agent = !first_run;
-        }
-        if pcap.receiver_queue_size != new_pcap.receiver_queue_size {
-            info!(
-                "Update processors.packet.pcap_stream.receiver_queue_size from {:?} to {:?}.",
-                pcap.receiver_queue_size, new_pcap.receiver_queue_size
-            );
-            pcap.receiver_queue_size = new_pcap.receiver_queue_size;
-            restart_agent = !first_run;
-        }
-        if pcap.total_buffer_size != new_pcap.total_buffer_size {
-            info!(
-                "Update processors.packet.pcap_stream.total_buffer_size from {:?} to {:?}.",
-                pcap.total_buffer_size, new_pcap.total_buffer_size
-            );
-            pcap.total_buffer_size = new_pcap.total_buffer_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    pcap.buffer_size_per_flow,
+                    new_pcap.buffer_size_per_flow,
+                    "processors.packet.pcap_stream.buffer_size_per_flow"
+                ),
+                (
+                    pcap.flush_interval,
+                    new_pcap.flush_interval,
+                    "processors.packet.pcap_stream.flush_interval"
+                ),
+                (
+                    pcap.receiver_queue_size,
+                    new_pcap.receiver_queue_size,
+                    "processors.packet.pcap_stream.receiver_queue_size"
+                ),
+                (
+                    pcap.total_buffer_size,
+                    new_pcap.total_buffer_size,
+                    "processors.packet.pcap_stream.total_buffer_size"
+                )
+            ]
+        );
 
         let policy = &mut packet.policy;
         let new_policy = &mut new_packet.policy;
-        if policy.fast_path_disabled != new_policy.fast_path_disabled {
-            info!(
-                "Update processors.packet.policy.fast_path_disabled from {:?} to {:?}.",
-                policy.fast_path_disabled, new_policy.fast_path_disabled
-            );
-            policy.fast_path_disabled = new_policy.fast_path_disabled;
-            restart_agent = !first_run;
-        }
-        if policy.fast_path_map_size != new_policy.fast_path_map_size {
-            info!(
-                "Update processors.packet.policy.fast_path_map_size from {:?} to {:?}.",
-                policy.fast_path_map_size, new_policy.fast_path_map_size
-            );
-            policy.fast_path_map_size = new_policy.fast_path_map_size;
-            restart_agent = !first_run;
-        }
-        if policy.forward_table_capacity != new_policy.forward_table_capacity {
-            info!(
-                "Update processors.packet.policy.forward_table_capacity from {:?} to {:?}.",
-                policy.forward_table_capacity, new_policy.forward_table_capacity
-            );
-            policy.forward_table_capacity = new_policy.forward_table_capacity;
-            restart_agent = !first_run;
-        }
-        if policy.max_first_path_level != new_policy.max_first_path_level {
-            info!(
-                "Update processors.packet.policy.max_first_path_level from {:?} to {:?}.",
-                policy.max_first_path_level, new_policy.max_first_path_level
-            );
-            policy.max_first_path_level = new_policy.max_first_path_level;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    policy.fast_path_disabled,
+                    new_policy.fast_path_disabled,
+                    "processors.packet.policy.fast_path_disabled"
+                ),
+                (
+                    policy.fast_path_map_size,
+                    new_policy.fast_path_map_size,
+                    "processors.packet.policy.fast_path_map_size"
+                ),
+                (
+                    policy.forward_table_capacity,
+                    new_policy.forward_table_capacity,
+                    "processors.packet.policy.forward_table_capacity"
+                ),
+                (
+                    policy.max_first_path_level,
+                    new_policy.max_first_path_level,
+                    "processors.packet.policy.max_first_path_level"
+                )
+            ]
+        );
 
         let tcp_header = &mut packet.tcp_header;
         let new_tcp_header = &mut new_packet.tcp_header;
-        if tcp_header.block_size != new_tcp_header.block_size {
-            info!(
-                "Update processors.packet.tcp_header.block_size from {:?} to {:?}.",
-                tcp_header.block_size, new_tcp_header.block_size
-            );
-            tcp_header.block_size = new_tcp_header.block_size;
-            restart_agent = !first_run;
-        }
-        if tcp_header.header_fields_flag != new_tcp_header.header_fields_flag {
-            info!(
-                "Update processors.packet.tcp_header.header_fields_flag from {:?} to {:?}.",
-                tcp_header.header_fields_flag, new_tcp_header.header_fields_flag
-            );
-            tcp_header.header_fields_flag = new_tcp_header.header_fields_flag;
-            restart_agent = !first_run;
-        }
-        if tcp_header.sender_queue_size != new_tcp_header.sender_queue_size {
-            info!(
-                "Update processors.packet.tcp_header.sender_queue_size from {:?} to {:?}.",
-                tcp_header.sender_queue_size, new_tcp_header.sender_queue_size
-            );
-            tcp_header.sender_queue_size = new_tcp_header.sender_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tcp_header.block_size,
+                    new_tcp_header.block_size,
+                    "processors.packet.tcp_header.block_size"
+                ),
+                (
+                    tcp_header.header_fields_flag,
+                    new_tcp_header.header_fields_flag,
+                    "processors.packet.tcp_header.header_fields_flag"
+                ),
+                (
+                    tcp_header.sender_queue_size,
+                    new_tcp_header.sender_queue_size,
+                    "processors.packet.tcp_header.sender_queue_size"
+                )
+            ]
+        );
 
         let toa = &mut packet.toa;
         let new_toa = &mut new_packet.toa;
-        if toa.cache_size != new_toa.cache_size {
-            info!(
-                "Update processors.packet.toa.cache_size from {:?} to {:?}.",
-                toa.cache_size, new_toa.cache_size
-            );
-            toa.cache_size = new_toa.cache_size;
-            restart_agent = !first_run;
-        }
-        if toa.sender_queue_size != new_toa.sender_queue_size {
-            info!(
-                "Update processors.packet.toa.sender_queue_size from {:?} to {:?}.",
-                toa.sender_queue_size, new_toa.sender_queue_size
-            );
-            toa.sender_queue_size = new_toa.sender_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    toa.cache_size,
+                    new_toa.cache_size,
+                    "processors.packet.toa.cache_size"
+                ),
+                (
+                    toa.sender_queue_size,
+                    new_toa.sender_queue_size,
+                    "processors.packet.toa.sender_queue_size"
+                )
+            ]
+        );
 
         let flow_log = &mut processors.flow_log;
         let new_flow_log = &mut new_processors.flow_log;
         let conntrack = &mut flow_log.conntrack;
         let new_conntrack = &mut new_flow_log.conntrack;
-        if conntrack.flow_flush_interval != new_conntrack.flow_flush_interval {
-            info!(
-                "Update processors.flow_log.conntrack.flow_flush_interval from {:?} to {:?}.",
-                conntrack.flow_flush_interval, new_conntrack.flow_flush_interval
-            );
-            conntrack.flow_flush_interval = new_conntrack.flow_flush_interval;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
+                conntrack.flow_flush_interval,
+                new_conntrack.flow_flush_interval,
+                "processors.flow_log.conntrack.flow_flush_interval"
+            )]
+        );
         let flow_generation = &mut conntrack.flow_generation;
         let new_flow_generation = &mut new_conntrack.flow_generation;
-        if flow_generation.cloud_traffic_ignore_mac != new_flow_generation.cloud_traffic_ignore_mac
-        {
-            info!(
-                "Update processors.flow_log.conntrack.flow_generation.cloud_traffic_ignore_mac from {:?} to {:?}.",
-                flow_generation.cloud_traffic_ignore_mac,
-                new_flow_generation.cloud_traffic_ignore_mac
-            );
-            flow_generation.cloud_traffic_ignore_mac = new_flow_generation.cloud_traffic_ignore_mac;
-            restart_agent = !first_run;
-        }
-        if flow_generation.idc_traffic_ignore_vlan != new_flow_generation.idc_traffic_ignore_vlan {
-            info!(
-                "Update processors.flow_log.conntrack.flow_generation.idc_traffic_ignore_vlan from {:?} to {:?}.",
-                flow_generation.idc_traffic_ignore_vlan,
-                new_flow_generation.idc_traffic_ignore_vlan
-            );
-            flow_generation.idc_traffic_ignore_vlan = new_flow_generation.idc_traffic_ignore_vlan;
-            restart_agent = !first_run;
-        }
-        if flow_generation.ignore_l2_end != new_flow_generation.ignore_l2_end {
-            info!(
-                "Update processors.flow_log.conntrack.flow_generation.ignore_l2_end from {:?} to {:?}.",
-                flow_generation.ignore_l2_end, new_flow_generation.ignore_l2_end
-            );
-            flow_generation.ignore_l2_end = new_flow_generation.ignore_l2_end;
-            restart_agent = !first_run;
-        }
-        if flow_generation.server_ports != new_flow_generation.server_ports {
-            info!(
-                "Update processors.flow_log.conntrack.flow_generation.server_ports from {:?} to {:?}.",
-                flow_generation.server_ports, new_flow_generation.server_ports
-            );
-            flow_generation.server_ports = new_flow_generation.server_ports.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    flow_generation.cloud_traffic_ignore_mac,
+                    new_flow_generation.cloud_traffic_ignore_mac,
+                    "processors.flow_log.conntrack.flow_generation.cloud_traffic_ignore_mac"
+                ),
+                (
+                    flow_generation.idc_traffic_ignore_vlan,
+                    new_flow_generation.idc_traffic_ignore_vlan,
+                    "processors.flow_log.conntrack.flow_generation.idc_traffic_ignore_vlan"
+                ),
+                (
+                    flow_generation.ignore_l2_end,
+                    new_flow_generation.ignore_l2_end,
+                    "processors.flow_log.conntrack.flow_generation.ignore_l2_end"
+                ),
+                (
+                    flow_generation.server_ports,
+                    new_flow_generation.server_ports,
+                    "processors.flow_log.conntrack.flow_generation.server_ports"
+                )
+            ]
+        );
 
         let timeouts = &mut conntrack.timeouts;
         let new_timeouts = &mut new_conntrack.timeouts;
@@ -4998,134 +4961,110 @@ impl ConfigHandler {
 
         let time_window = &mut flow_log.time_window;
         let new_time_window = &mut new_flow_log.time_window;
-        if time_window.extra_tolerable_flow_delay != new_time_window.extra_tolerable_flow_delay {
-            info!(
-                "Update processors.flow_log.time_window.extra_tolerable_flow_delay from {:?} to {:?}.",
-                time_window.extra_tolerable_flow_delay, new_time_window.extra_tolerable_flow_delay
-            );
-            time_window.extra_tolerable_flow_delay = new_time_window.extra_tolerable_flow_delay;
-            restart_agent = !first_run;
-        }
-        if time_window.max_tolerable_packet_delay != new_time_window.max_tolerable_packet_delay {
-            info!(
-                "Update processors.flow_log.time_window.max_tolerable_packet_delay from {:?} to {:?}.",
-                time_window.max_tolerable_packet_delay, new_time_window.max_tolerable_packet_delay
-            );
-            time_window.max_tolerable_packet_delay = new_time_window.max_tolerable_packet_delay;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    time_window.extra_tolerable_flow_delay,
+                    new_time_window.extra_tolerable_flow_delay,
+                    "processors.flow_log.time_window.extra_tolerable_flow_delay"
+                ),
+                (
+                    time_window.max_tolerable_packet_delay,
+                    new_time_window.max_tolerable_packet_delay,
+                    "processors.flow_log.time_window.max_tolerable_packet_delay"
+                )
+            ]
+        );
 
         let tunning = &mut flow_log.tunning;
         let new_tunning = &mut new_flow_log.tunning;
-        if tunning.rrt_cache_capacity != new_tunning.rrt_cache_capacity {
-            info!(
-                "Update processors.flow_log.tunning.rrt_cache_capacity from {:?} to {:?}.",
-                tunning.rrt_cache_capacity, new_tunning.rrt_cache_capacity
-            );
-            tunning.rrt_cache_capacity = new_tunning.rrt_cache_capacity;
-            restart_agent = !first_run;
-        }
-        if tunning.concurrent_flow_limit != new_tunning.concurrent_flow_limit {
-            info!(
-                "Update processors.flow_log.tunning.concurrent_flow_limit from {:?} to {:?}.",
-                tunning.concurrent_flow_limit, new_tunning.concurrent_flow_limit
-            );
-            tunning.concurrent_flow_limit = new_tunning.concurrent_flow_limit;
-            restart_agent = !first_run;
-        }
-        if tunning.flow_aggregator_queue_size != new_tunning.flow_aggregator_queue_size {
-            info!(
-                "Update processors.flow_log.tunning.flow_aggregator_queue_size from {:?} to {:?}.",
-                tunning.flow_aggregator_queue_size, new_tunning.flow_aggregator_queue_size
-            );
-            tunning.flow_aggregator_queue_size = new_tunning.flow_aggregator_queue_size;
-            restart_agent = !first_run;
-        }
-        if tunning.flow_generator_queue_size != new_tunning.flow_generator_queue_size {
-            info!(
-                "Update processors.flow_log.tunning.flow_generator_queue_size from {:?} to {:?}.",
-                tunning.flow_generator_queue_size, new_tunning.flow_generator_queue_size
-            );
-            tunning.flow_generator_queue_size = new_tunning.flow_generator_queue_size;
-            restart_agent = !first_run;
-        }
-        if tunning.flow_map_hash_slots != new_tunning.flow_map_hash_slots {
-            info!(
-                "Update processors.flow_log.tunning.flow_map_hash_slots from {:?} to {:?}.",
-                tunning.flow_map_hash_slots, new_tunning.flow_map_hash_slots
-            );
-            tunning.flow_map_hash_slots = new_tunning.flow_map_hash_slots;
-            restart_agent = !first_run;
-        }
-        if tunning.max_batched_buffer_size != new_tunning.max_batched_buffer_size {
-            info!(
-                "Update processors.flow_log.tunning.max_batched_buffer_size from {:?} to {:?}.",
-                tunning.max_batched_buffer_size, new_tunning.max_batched_buffer_size
-            );
-            tunning.max_batched_buffer_size = new_tunning.max_batched_buffer_size;
-            restart_agent = !first_run;
-        }
-        if tunning.memory_pool_size != new_tunning.memory_pool_size {
-            info!(
-                "Update processors.flow_log.tunning.memory_pool_size from {:?} to {:?}.",
-                tunning.memory_pool_size, new_tunning.memory_pool_size
-            );
-            tunning.memory_pool_size = new_tunning.memory_pool_size;
-            restart_agent = !first_run;
-        }
-        if tunning.quadruple_generator_queue_size != new_tunning.quadruple_generator_queue_size {
-            info!(
-                "Update processors.flow_log.tunning.quadruple_generator_queue_size from {:?} to {:?}.",
-                tunning.quadruple_generator_queue_size, new_tunning.quadruple_generator_queue_size
-            );
-            tunning.quadruple_generator_queue_size = new_tunning.quadruple_generator_queue_size;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tunning.rrt_cache_capacity,
+                    new_tunning.rrt_cache_capacity,
+                    "processors.flow_log.tunning.rrt_cache_capacity"
+                ),
+                (
+                    tunning.concurrent_flow_limit,
+                    new_tunning.concurrent_flow_limit,
+                    "processors.flow_log.tunning.concurrent_flow_limit"
+                ),
+                (
+                    tunning.flow_aggregator_queue_size,
+                    new_tunning.flow_aggregator_queue_size,
+                    "processors.flow_log.tunning.flow_aggregator_queue_size"
+                ),
+                (
+                    tunning.flow_generator_queue_size,
+                    new_tunning.flow_generator_queue_size,
+                    "processors.flow_log.tunning.flow_generator_queue_size"
+                ),
+                (
+                    tunning.flow_map_hash_slots,
+                    new_tunning.flow_map_hash_slots,
+                    "processors.flow_log.tunning.flow_map_hash_slots"
+                ),
+                (
+                    tunning.max_batched_buffer_size,
+                    new_tunning.max_batched_buffer_size,
+                    "processors.flow_log.tunning.max_batched_buffer_size"
+                ),
+                (
+                    tunning.memory_pool_size,
+                    new_tunning.memory_pool_size,
+                    "processors.flow_log.tunning.memory_pool_size"
+                ),
+                (
+                    tunning.quadruple_generator_queue_size,
+                    new_tunning.quadruple_generator_queue_size,
+                    "processors.flow_log.tunning.quadruple_generator_queue_size"
+                )
+            ]
+        );
 
         let request_log = &mut processors.request_log;
         let new_request_log = &mut new_processors.request_log;
         let app = &mut request_log.application_protocol_inference;
         let new_app = &mut new_request_log.application_protocol_inference;
-        if app.enabled_protocols != new_app.enabled_protocols {
-            info!(
-                "Update processors.request_log.application_protocol_inference.enabled_protocols from {:?} to {:?}.",
-                app.enabled_protocols, new_app.enabled_protocols
-            );
-            app.enabled_protocols = new_app.enabled_protocols.clone();
-            restart_agent = !first_run;
-        }
-        if app.inference_max_retries != new_app.inference_max_retries {
-            info!(
-                "Update processors.request_log.application_protocol_inference.inference_max_retries from {:?} to {:?}.",
-                app.inference_max_retries, new_app.inference_max_retries
-            );
-            app.inference_max_retries = new_app.inference_max_retries;
-            restart_agent = !first_run;
-        }
-        if app.inference_result_ttl != new_app.inference_result_ttl {
-            info!(
-                "Update processors.request_log.application_protocol_inference.inference_result_ttl from {:?} to {:?}.",
-                app.inference_result_ttl, new_app.inference_result_ttl
-            );
-            app.inference_result_ttl = new_app.inference_result_ttl;
-            restart_agent = !first_run;
-        }
-        if app.inference_whitelist != new_app.inference_whitelist {
-            info!(
-                "Update processors.request_log.application_protocol_inference.inference_whitelist from {:?} to {:?}.",
-                app.inference_whitelist, new_app.inference_whitelist
-            );
-            app.inference_whitelist = new_app.inference_whitelist.clone();
-            restart_agent = !first_run;
-        }
-        if app.protocol_special_config != new_app.protocol_special_config {
-            info!(
-                "Update processors.request_log.application_protocol_inference.protocol_special_config from {:?} to {:?}.",
-                app.protocol_special_config, new_app.protocol_special_config
-            );
-            app.protocol_special_config = new_app.protocol_special_config.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    app.enabled_protocols,
+                    new_app.enabled_protocols,
+                    "processors.request_log.application_protocol_inference.enabled_protocols"
+                ),
+                (
+                    app.inference_max_retries,
+                    new_app.inference_max_retries,
+                    "processors.request_log.application_protocol_inference.inference_max_retries"
+                ),
+                (
+                    app.inference_result_ttl,
+                    new_app.inference_result_ttl,
+                    "processors.request_log.application_protocol_inference.inference_result_ttl"
+                ),
+                (
+                    app.inference_whitelist,
+                    new_app.inference_whitelist,
+                    "processors.request_log.application_protocol_inference.inference_whitelist"
+                ),
+                (
+                    app.protocol_special_config,
+                    new_app.protocol_special_config,
+                    "processors.request_log.application_protocol_inference.protocol_special_config"
+                )
+            ]
+        );
         #[cfg(feature = "enterprise")]
         if app.custom_protocols != new_app.custom_protocols {
             info!(
@@ -5136,22 +5075,23 @@ impl ConfigHandler {
         }
         let filters = &mut request_log.filters;
         let new_filters = &mut new_request_log.filters;
-        if filters.port_number_prefilters != new_filters.port_number_prefilters {
-            info!(
-                "Update processors.request_log.filters.port_number_prefilters from {:?} to {:?}.",
-                filters.port_number_prefilters, new_filters.port_number_prefilters
-            );
-            filters.port_number_prefilters = new_filters.port_number_prefilters.clone();
-            restart_agent = !first_run;
-        }
-        if filters.tag_filters != new_filters.tag_filters {
-            info!(
-                "Update processors.request_log.filters.tag_filters from {:?} to {:?}.",
-                filters.tag_filters, new_filters.tag_filters
-            );
-            filters.tag_filters = new_filters.tag_filters.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    filters.port_number_prefilters,
+                    new_filters.port_number_prefilters,
+                    "processors.request_log.filters.port_number_prefilters"
+                ),
+                (
+                    filters.tag_filters,
+                    new_filters.tag_filters,
+                    "processors.request_log.filters.tag_filters"
+                )
+            ]
+        );
         if filters.unconcerned_dns_nxdomain_response_suffixes
             != new_filters.unconcerned_dns_nxdomain_response_suffixes
         {
@@ -5166,22 +5106,23 @@ impl ConfigHandler {
         }
         let timeouts = &mut request_log.timeouts;
         let new_timeouts = &mut new_request_log.timeouts;
-        if timeouts.tcp_request_timeout != new_timeouts.tcp_request_timeout {
-            info!(
-                "Update processors.request_log.timeouts.tcp_request_timeout from {:?} to {:?}.",
-                timeouts.tcp_request_timeout, new_timeouts.tcp_request_timeout
-            );
-            timeouts.tcp_request_timeout = new_timeouts.tcp_request_timeout;
-            restart_agent = !first_run;
-        }
-        if timeouts.udp_request_timeout != new_timeouts.udp_request_timeout {
-            info!(
-                "Update processors.request_log.timeouts.udp_request_timeout from {:?} to {:?}.",
-                timeouts.udp_request_timeout, new_timeouts.udp_request_timeout
-            );
-            timeouts.udp_request_timeout = new_timeouts.udp_request_timeout;
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    timeouts.tcp_request_timeout,
+                    new_timeouts.tcp_request_timeout,
+                    "processors.request_log.timeouts.tcp_request_timeout"
+                ),
+                (
+                    timeouts.udp_request_timeout,
+                    new_timeouts.udp_request_timeout,
+                    "processors.request_log.timeouts.udp_request_timeout"
+                )
+            ]
+        );
         if timeouts.session_aggregate != new_timeouts.session_aggregate {
             info!(
                 "Update processors.request_log.timeouts.session_aggregate from {:?} to {:?}.",
@@ -5192,30 +5133,28 @@ impl ConfigHandler {
 
         let tag_extraction = &mut request_log.tag_extraction;
         let new_tag_extraction = &mut new_request_log.tag_extraction;
-        if tag_extraction.custom_fields != new_tag_extraction.custom_fields {
-            info!(
-                "Update processors.request_log.tag_extraction.custom_fields from {:?} to {:?}.",
-                tag_extraction.custom_fields, new_tag_extraction.custom_fields
-            );
-            tag_extraction.custom_fields = new_tag_extraction.custom_fields.clone();
-            restart_agent = !first_run;
-        }
-        if tag_extraction.http_endpoint != new_tag_extraction.http_endpoint {
-            info!(
-                "Update processors.request_log.tag_extraction.http_endpoint from {:?} to {:?}.",
-                tag_extraction.http_endpoint, new_tag_extraction.http_endpoint
-            );
-            tag_extraction.http_endpoint = new_tag_extraction.http_endpoint.clone();
-            restart_agent = !first_run;
-        }
-        if tag_extraction.obfuscate_protocols != new_tag_extraction.obfuscate_protocols {
-            info!(
-                "Update processors.request_log.tag_extraction.obfuscate_protocols from {:?} to {:?}.",
-                tag_extraction.obfuscate_protocols, new_tag_extraction.obfuscate_protocols
-            );
-            tag_extraction.obfuscate_protocols = new_tag_extraction.obfuscate_protocols.clone();
-            restart_agent = !first_run;
-        }
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [
+                (
+                    tag_extraction.custom_fields,
+                    new_tag_extraction.custom_fields,
+                    "processors.request_log.tag_extraction.custom_fields"
+                ),
+                (
+                    tag_extraction.http_endpoint,
+                    new_tag_extraction.http_endpoint,
+                    "processors.request_log.tag_extraction.http_endpoint"
+                ),
+                (
+                    tag_extraction.obfuscate_protocols,
+                    new_tag_extraction.obfuscate_protocols,
+                    "processors.request_log.tag_extraction.obfuscate_protocols"
+                )
+            ]
+        );
         if tag_extraction.tracing_tag != new_tag_extraction.tracing_tag {
             info!(
                 "Update processors.request_log.tag_extraction.tracing_tag from {:?} to {:?}.",
@@ -5234,18 +5173,16 @@ impl ConfigHandler {
 
         let tunning = &mut request_log.tunning;
         let new_tunning = &mut new_request_log.tunning;
-        if tunning.consistent_timestamp_in_l7_metrics
-            != new_tunning.consistent_timestamp_in_l7_metrics
-        {
-            info!(
-                "Update processors.request_log.tunning.consistent_timestamp_in_l7_metrics from {:?} to {:?}.",
+        update_fields_with_restart_reason!(
+            restart_agent,
+            !first_run,
+            agent_restart_reasons,
+            [(
                 tunning.consistent_timestamp_in_l7_metrics,
-                new_tunning.consistent_timestamp_in_l7_metrics
-            );
-            tunning.consistent_timestamp_in_l7_metrics =
-                new_tunning.consistent_timestamp_in_l7_metrics;
-            restart_agent = !first_run;
-        }
+                new_tunning.consistent_timestamp_in_l7_metrics,
+                "processors.request_log.tunning.consistent_timestamp_in_l7_metrics"
+            )]
+        );
         if tunning.payload_truncation != new_tunning.payload_truncation {
             info!(
                 "Update processors.request_log.tunning.payload_truncation from {:?} to {:?}.",
@@ -5276,6 +5213,7 @@ impl ConfigHandler {
         }
 
         candidate_config.enabled = new_config.enabled;
+        let old_capture_mode = candidate_config.capture_mode;
         candidate_config.capture_mode = new_config.capture_mode;
         if candidate_config.dispatcher != new_config.dispatcher {
             #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -5303,6 +5241,12 @@ impl ConfigHandler {
                     != candidate_config.get_flow_capacity(candidate_config.dispatcher.max_memory)
             {
                 restart_dispatcher = true;
+                dispatcher_restart_reasons.insert(Cow::Owned(format!(
+                    "capture_mode: {old_capture_mode:?} -> {:?}; dispatcher.max_memory: {:?} -> {:?}",
+                    new_config.capture_mode,
+                    candidate_config.dispatcher.max_memory,
+                    new_config.dispatcher.max_memory,
+                )));
             }
 
             debug!(
@@ -5414,6 +5358,11 @@ impl ConfigHandler {
         if candidate_config.flow != new_config.flow {
             if candidate_config.flow.collector_enabled != new_config.flow.collector_enabled {
                 restart_dispatcher = true;
+                dispatcher_restart_reasons.insert(changed_reason(
+                    "flow.collector_enabled",
+                    &candidate_config.flow.collector_enabled,
+                    &new_config.flow.collector_enabled,
+                ));
             }
             debug!(
                 "flow_generator config change from {:#?} to {:#?}",
@@ -5437,9 +5386,17 @@ impl ConfigHandler {
                 "collector config change from {:#?} to {:#?}",
                 candidate_config.collector, new_config.collector
             );
-            restart_dispatcher = candidate_config.collector.agent_id
+            let restart_value = candidate_config.collector.agent_id
                 != new_config.collector.agent_id
                 && new_config.collector.enabled;
+            restart_dispatcher |= restart_value;
+            if restart_value {
+                dispatcher_restart_reasons.insert(changed_reason(
+                    "collector.agent_id",
+                    &candidate_config.collector.agent_id,
+                    &new_config.collector.agent_id,
+                ));
+            }
             candidate_config.collector = new_config.collector.clone();
         }
 
@@ -5481,18 +5438,33 @@ impl ConfigHandler {
             {
                 if candidate_config.sender.enabled != new_config.sender.enabled {
                     restart_dispatcher = true;
+                    dispatcher_restart_reasons.insert(changed_reason(
+                        "sender.enabled",
+                        &candidate_config.sender.enabled,
+                        &new_config.sender.enabled,
+                    ));
                 }
             }
 
             if candidate_config.sender.npb_socket_type != new_config.sender.npb_socket_type {
                 if candidate_config.capture_mode != PacketCaptureType::Analyzer {
                     restart_dispatcher = true;
+                    dispatcher_restart_reasons.insert(changed_reason(
+                        "sender.npb_socket_type",
+                        &candidate_config.sender.npb_socket_type,
+                        &new_config.sender.npb_socket_type,
+                    ));
                 }
             }
 
             if candidate_config.sender.npb_dedup_enabled != new_config.sender.npb_dedup_enabled {
                 if candidate_config.capture_mode != PacketCaptureType::Analyzer {
                     restart_dispatcher = true;
+                    dispatcher_restart_reasons.insert(changed_reason(
+                        "sender.npb_dedup_enabled",
+                        &candidate_config.sender.npb_dedup_enabled,
+                        &new_config.sender.npb_dedup_enabled,
+                    ));
                 }
             }
 
@@ -5507,6 +5479,11 @@ impl ConfigHandler {
             if candidate_config.handler.npb_dedup_enabled != new_config.handler.npb_dedup_enabled {
                 if candidate_config.capture_mode != PacketCaptureType::Analyzer {
                     restart_dispatcher = true;
+                    dispatcher_restart_reasons.insert(changed_reason(
+                        "handler.npb_dedup_enabled",
+                        &candidate_config.handler.npb_dedup_enabled,
+                        &new_config.handler.npb_dedup_enabled,
+                    ));
                 }
             }
             debug!(
@@ -5595,8 +5572,13 @@ impl ConfigHandler {
                 "npb config change from {:#?} to {:#?}",
                 candidate_config.npb, new_config.npb
             );
-            candidate_config.npb = new_config.npb.clone();
             restart_dispatcher = true;
+            dispatcher_restart_reasons.insert(changed_reason(
+                "npb",
+                &candidate_config.npb,
+                &new_config.npb,
+            ));
+            candidate_config.npb = new_config.npb.clone();
             if components.is_some() {
                 callbacks.push(Self::set_npb);
             }
@@ -5609,7 +5591,7 @@ impl ConfigHandler {
 
         if new_config != *candidate_config {
             error!(
-                "Some configurations have not been, updated deepflow-agent restart... please check the code."
+                "on_config safety fallback found unapplied config diff, deepflow-agent restart..."
             );
             error!(
                 "Configurations from {:#?} to {:#?}",
@@ -5632,17 +5614,53 @@ impl ConfigHandler {
                 .source
                 == DpdkSource::Ebpf
         {
-            restart_agent = !first_run;
+            let restart_value = !first_run;
+            restart_agent |= restart_value;
+            if restart_value {
+                agent_restart_reasons.extend(dispatcher_restart_reasons.iter().cloned());
+                agent_restart_reasons.insert(Cow::Owned(format!(
+                    "dispatcher restart escalated to agent restart because inputs.cbpf.special_network.dpdk.source={:?}",
+                    new_config
+                        .user_config
+                        .inputs
+                        .cbpf
+                        .special_network
+                        .dpdk
+                        .source
+                )));
+            }
         }
 
         if restart_agent {
-            warn!("Change configuration and restart agent...");
+            let reasons = agent_restart_reasons
+                .iter()
+                .enumerate()
+                .map(|(i, reason)| format!("\n  {}. {}", i + 1, reason))
+                .collect::<Vec<_>>()
+                .join("");
+            warn!(
+                "restart agent due to {} reason(s) at {}:{}\ndeepflow-agent restart...",
+                agent_restart_reasons.len(),
+                config_update_started_at.to_rfc3339(),
+                reasons
+            );
             crate::utils::clean_and_exit(public::consts::NORMAL_EXIT_WITH_RESTART);
             return vec![];
         }
 
         if restart_dispatcher {
-            warn!("Change configuration and restart dispatcher...");
+            let reasons = dispatcher_restart_reasons
+                .iter()
+                .enumerate()
+                .map(|(i, reason)| format!("\n  {}. {}", i + 1, reason))
+                .collect::<Vec<_>>()
+                .join("");
+            warn!(
+                "restart dispatcher due to {} reason(s) at {}:{}\nrestarting dispatcher threads...",
+                dispatcher_restart_reasons.len(),
+                config_update_started_at.to_rfc3339(),
+                reasons
+            );
             callbacks.push(Self::set_restart_dispatcher);
         }
 

--- a/agent/src/ebpf_dispatcher/memory_profile.rs
+++ b/agent/src/ebpf_dispatcher/memory_profile.rs
@@ -619,7 +619,7 @@ impl MemoryProfiler {
             return;
         }
         if self.inner_recv.is_none() || self.thread_handle.is_some() {
-            warn!("memory profiler is in invalid state, terminating agent");
+            warn!("memory profiler is in invalid state, deepflow-agent restart...");
             crate::utils::clean_and_exit(1);
         }
 

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -628,7 +628,10 @@ impl Trident {
         let handle = match main_loop {
             Ok(h) => Some(h),
             Err(e) => {
-                error!("Failed to create main-loop thread: {}", e);
+                error!(
+                    "Failed to create main-loop thread: {}, deepflow-agent restart...",
+                    e
+                );
                 crate::utils::clean_and_exit(1);
                 None
             }
@@ -642,6 +645,7 @@ impl Trident {
         let action = kernel_version_check();
         if action.contains(ActionFlags::TERMINATE) {
             exception_handler.set(Exception::KernelVersionCircuitBreaker);
+            error!("kernel check indicates TERMINATE action, deepflow-agent restart...");
             crate::utils::clean_and_exit(1);
         } else if action.contains(ActionFlags::MELTDOWN) {
             exception_handler.set(Exception::KernelVersionCircuitBreaker);


### PR DESCRIPTION
### This PR is for:
- Agent

### Backport `refactor: add detailed log on agent restart`
#### Checklist
- [x] Kept hot-update config behavior unchanged (no added/removed config items).
- [x] Added config-update start timestamp and included it in restart logs.
- [x] Made restart reasons easier to read with clearer separation.
- [x] Kept dispatcher/agent restart reason aggregation semantics unchanged.
#### Backport to branches
- v6.6