### PR TITLE
fix: set kick thread nice before tracer init

### DIFF
--- a/agent/src/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher.rs
@@ -943,6 +943,18 @@ impl EbpfCollector {
             }
         }
 
+        if let Err(e) = config.ebpf.tunning.validate() {
+            warn!(
+                "skip setting kick thread nice value to {}: {}",
+                config.ebpf.tunning.kick_kern_nice, e
+            );
+        } else if ebpf::set_kick_kern_nice(config.ebpf.tunning.kick_kern_nice) != 0 {
+            warn!(
+                "failed to set kick thread nice value to {}",
+                config.ebpf.tunning.kick_kern_nice
+            );
+        }
+
         if ebpf::bpf_tracer_init(null_mut(), true) != 0 {
             info!("ebpf bpf_tracer_init error.");
             return Err(Error::EbpfInitError);
@@ -1018,18 +1030,6 @@ impl EbpfCollector {
         }
 
         ebpf::set_bpf_map_prealloc(!config.ebpf.socket.tunning.map_prealloc_disabled);
-
-        if let Err(e) = config.ebpf.tunning.validate() {
-            warn!(
-                "skip setting kick thread nice value to {}: {}",
-                config.ebpf.tunning.kick_kern_nice, e
-            );
-        } else if ebpf::set_kick_kern_nice(config.ebpf.tunning.kick_kern_nice) != 0 {
-            warn!(
-                "failed to set kick thread nice value to {}",
-                config.ebpf.tunning.kick_kern_nice
-            );
-        }
 
         if config.ebpf.socket.tunning.fentry_enabled {
             ebpf::enable_fentry();


### PR DESCRIPTION
Apply kick thread nice settings before bpf_tracer_init so kick threads start with the configured nice value.



### This PR is for:


- Agent

#### Affected branches
- main
- v7.1
- v7.0
- v6.6
