### PR TITLE
fix: a lot of missing L7 stats without flow (#11622)

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -65,6 +65,7 @@ pub struct CollectorCounter {
     out: AtomicU64,
     drop_before_window: AtomicU64,
     drop_inactive: AtomicU64,
+    drop_by_queue: AtomicU64,
     no_endpoint: AtomicU64,
     stash_len: AtomicU64,
     stash_capacity: AtomicU64,
@@ -99,6 +100,11 @@ impl RefCountable for CollectorCounter {
                 "drop-inactive",
                 CounterType::Counted,
                 CounterValue::Unsigned(self.drop_inactive.swap(0, Ordering::Relaxed)),
+            ),
+            (
+                "drop-by-queue",
+                CounterType::Counted,
+                CounterValue::Unsigned(self.drop_by_queue.swap(0, Ordering::Relaxed)),
             ),
             (
                 "no-endpoint",
@@ -804,6 +810,9 @@ impl Stash {
         if self.closed_docs.len() >= QUEUE_BATCH_SIZE {
             if let Err(e) = self.sender.send_all(&mut self.closed_docs) {
                 warn!("queue failed to send Document data, because {:?}", e);
+                self.counter
+                    .drop_by_queue
+                    .fetch_add(self.closed_docs.len() as u64, Ordering::Relaxed);
                 self.closed_docs.clear();
             }
         }
@@ -835,6 +844,9 @@ impl Stash {
                         "{} queue failed to send data, because {:?}",
                         self.context.name, e
                     );
+                    self.counter
+                        .drop_by_queue
+                        .fetch_add(batch.len() as u64, Ordering::Relaxed);
                     return;
                 }
             }
@@ -848,6 +860,9 @@ impl Stash {
                     "{} queue failed to send data, because {:?}",
                     self.context.name, e
                 );
+                self.counter
+                    .drop_by_queue
+                    .fetch_add(batch.len() as u64, Ordering::Relaxed);
             }
         }
 
@@ -1252,7 +1267,7 @@ impl Collector {
         let thread = thread::Builder::new()
             .name("collector".to_owned())
             .spawn(move || {
-                let mut stash = Stash::new(ctx, sender, counter);
+                let mut stash = Stash::new(ctx, sender, counter.clone());
                 let mut batch = Vec::with_capacity(QUEUE_BATCH_SIZE);
                 while running.load(Ordering::Relaxed) {
                     let config = config.load();
@@ -1264,6 +1279,9 @@ impl Collector {
                             }
                             if let Err(e) = stash.sender.send_all(&mut stash.closed_docs) {
                                 warn!("queue failed to send l4 Document data, because {:?}", e);
+                                counter
+                                    .drop_by_queue
+                                    .fetch_add(stash.closed_docs.len() as u64, Ordering::Relaxed);
                                 stash.closed_docs.clear();
                             }
                             stash.calc_stash_counters();
@@ -1277,6 +1295,9 @@ impl Collector {
                             );
                             if let Err(e) = stash.sender.send_all(&mut stash.closed_docs) {
                                 warn!("queue failed to send l4 Document data, because {:?}", e);
+                                counter
+                                    .drop_by_queue
+                                    .fetch_add(stash.closed_docs.len() as u64, Ordering::Relaxed);
                                 stash.closed_docs.clear();
                             }
                         }
@@ -1384,7 +1405,7 @@ impl L7Collector {
         let thread = thread::Builder::new()
             .name("l7_collector".to_owned())
             .spawn(move || {
-                let mut stash = Stash::new(ctx, sender, counter);
+                let mut stash = Stash::new(ctx, sender, counter.clone());
                 let mut l7_batch = Vec::with_capacity(QUEUE_BATCH_SIZE);
                 while running.load(Ordering::Relaxed) {
                     let config = config.load();
@@ -1396,6 +1417,9 @@ impl L7Collector {
                             }
                             if let Err(e) = stash.sender.send_all(&mut stash.closed_docs) {
                                 warn!("queue failed to send l7 Document data, because {:?}", e);
+                                counter
+                                    .drop_by_queue
+                                    .fetch_add(stash.closed_docs.len() as u64, Ordering::Relaxed);
                                 stash.closed_docs.clear();
                             }
                             stash.calc_stash_counters();
@@ -1409,6 +1433,9 @@ impl L7Collector {
                             );
                             if let Err(e) = stash.sender.send_all(&mut stash.closed_docs) {
                                 warn!("queue failed to send l7 Document data, because {:?}", e);
+                                counter
+                                    .drop_by_queue
+                                    .fetch_add(stash.closed_docs.len() as u64, Ordering::Relaxed);
                                 stash.closed_docs.clear();
                             }
                         }

--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -27,10 +27,7 @@ use log::{debug, info, warn};
 use thread::JoinHandle;
 
 use super::{
-    check_active,
-    consts::*,
-    reset_delay_seconds, round_to_minute,
-    types::{AppMeterWithFlow, MiniFlow},
+    check_active, consts::*, reset_delay_seconds, round_to_minute, types::AppMeterWithFlow,
     MetricsType, QgStats,
 };
 
@@ -56,37 +53,26 @@ pub struct QgCounter {
     pub flow_delay: AtomicI64,
 
     pub drop_before_window: AtomicU64,
+    pub drop_by_queue: AtomicU64,
 
     pub stash_total_len: AtomicU64,
     pub stash_total_capacity: AtomicU64,
 }
 
-struct AppMeterWithL7Protocol {
-    app_meter: AppMeter,
-    endpoint: Option<String>,
-    endpoint_hash: u32,
-    // request-reponse time span
-    time_span: u32,
-    l7_protocol: L7Protocol,
-    biz_type: u8,
-    time_in_second: Duration,
-    is_reversed: bool,
-}
+impl AppMeterWithFlow {}
 
 struct QuadrupleStash {
-    l7_stats: HashMap<u64, Vec<AppMeterWithL7Protocol>>,
-    meters: Vec<Box<AppMeterWithFlow>>,
+    meters: HashMap<u64, Vec<Box<AppMeterWithFlow>>>,
 }
 
 impl QuadrupleStash {
     pub fn new() -> Self {
         Self {
-            l7_stats: HashMap::new(),
-            meters: vec![],
+            meters: HashMap::new(),
         }
     }
+
     pub fn clear(&mut self) {
-        self.l7_stats.clear();
         self.meters.clear();
     }
 }
@@ -130,6 +116,11 @@ impl RefCountable for QgCounter {
                 "drop-before-window",
                 CounterType::Counted,
                 CounterValue::Unsigned(self.drop_before_window.swap(0, Ordering::Relaxed)),
+            ),
+            (
+                "drop-by-queue",
+                CounterType::Counted,
+                CounterValue::Unsigned(self.drop_by_queue.swap(0, Ordering::Relaxed)),
             ),
             (
                 "stash-total-len",
@@ -195,21 +186,30 @@ impl SubQuadGen {
     fn flush_stats(&mut self, stash_index: usize) {
         self.stashs.push_back(QuadrupleStash::new());
         let mut stash = self.stashs.swap_remove_back(stash_index).unwrap();
-        stash.l7_stats.clear();
 
         self.batch_buffer.clear();
-        while stash.meters.len() >= QUEUE_BATCH_SIZE {
-            self.batch_buffer
-                .extend(stash.meters.drain(..QUEUE_BATCH_SIZE));
-            if let Err(e) = self.l7_output.send_all(&mut self.batch_buffer) {
-                debug!("l7 qg push l7 stats to queue failed: {}", e);
-                self.batch_buffer.clear();
+        for (_, mut flow_meters) in stash.meters.drain() {
+            while flow_meters.len() >= QUEUE_BATCH_SIZE {
+                self.batch_buffer
+                    .extend(flow_meters.drain(..QUEUE_BATCH_SIZE));
+                if let Err(e) = self.l7_output.send_all(&mut self.batch_buffer) {
+                    debug!("l7 qg push l7 stats to queue failed: {}", e);
+                    self.counter
+                        .drop_by_queue
+                        .fetch_add(self.batch_buffer.len() as u64, Ordering::Relaxed);
+                    self.batch_buffer.clear();
+                }
             }
-        }
-        // send the remaining data (not drained) in stash.meters
-        if let Err(e) = self.l7_output.send_all(&mut stash.meters) {
-            debug!("l7 qg push l7 stats to queue failed: {}", e);
-            stash.meters.clear();
+
+            if flow_meters.len() > 0 {
+                if let Err(e) = self.l7_output.send_all(&mut flow_meters) {
+                    debug!("l7 qg push l7 stats to queue failed: {}", e);
+                    self.counter
+                        .drop_by_queue
+                        .fetch_add(flow_meters.len() as u64, Ordering::Relaxed);
+                    flow_meters.clear();
+                }
+            }
         }
     }
 
@@ -223,8 +223,8 @@ impl SubQuadGen {
         let mut len = 0;
         let mut cap = 0;
         for s in self.stashs.iter() {
-            len += s.l7_stats.len();
-            cap += s.l7_stats.capacity();
+            len += s.meters.len();
+            cap += s.meters.capacity();
         }
         self.counter
             .stash_total_len
@@ -235,6 +235,7 @@ impl SubQuadGen {
     }
 
     fn push_closed_app_meter(
+        counter: &Arc<QgCounter>,
         closed_app_meters: &mut Vec<Box<AppMeterWithFlow>>,
         l7_output: &mut DebugSender<Box<AppMeterWithFlow>>,
         boxed_app_meter: Box<AppMeterWithFlow>,
@@ -246,8 +247,36 @@ impl SubQuadGen {
                     "l7_quadruple_generator push AppMeterWithFlows to queue failed, because {:?}",
                     e
                 );
+                counter
+                    .drop_by_queue
+                    .fetch_add(closed_app_meters.len() as u64, Ordering::Relaxed);
                 closed_app_meters.clear();
             }
+        }
+    }
+
+    fn generate_app_meter_with_flow(
+        l7_stats: &L7Stats,
+        app_meter: &AppMeter,
+        time_in_second: Duration,
+        time_span: u32,
+        endpoint_hash: u32,
+        is_active_host0: bool,
+        is_active_host1: bool,
+    ) -> AppMeterWithFlow {
+        let flow = &l7_stats.mini_flow;
+        AppMeterWithFlow {
+            app_meter: *app_meter,
+            l7_protocol: l7_stats.l7_protocol,
+            endpoint: l7_stats.endpoint.clone(),
+            endpoint_hash,
+            biz_type: l7_stats.biz_type,
+            time_span,
+            time_in_second: time_in_second.into(),
+            is_reversed: l7_stats.is_reversed,
+            is_active_host0,
+            is_active_host1,
+            flow: flow.clone(),
         }
     }
 
@@ -272,9 +301,19 @@ impl SubQuadGen {
             (time_in_second.as_secs() - l7_stats.time_span as u64) / self.slot_interval;
         let time_span = (current_span - request_span) as u32;
         let stash = &mut self.stashs[slot];
-        let value = stash.l7_stats.get_mut(&l7_stats.flow_id);
+        let value = stash.meters.get_mut(&l7_stats.flow_id);
+        let close_type = l7_stats.mini_flow.close_type;
 
         if let Some(meters) = value {
+            let flow = l7_stats.mini_flow.clone();
+            let (is_active_host0, is_active_host1) =
+                check_active(time_in_second.as_secs(), possible_host, &flow);
+            for meter in meters.iter_mut() {
+                meter.flow = flow.clone();
+                meter.is_active_host0 = is_active_host0;
+                meter.is_active_host1 = is_active_host1;
+            }
+
             if let Some(meter) = meters.iter_mut().find(|m| {
                 m.endpoint == l7_stats.endpoint
                     && m.biz_type == l7_stats.biz_type
@@ -284,100 +323,60 @@ impl SubQuadGen {
             }) {
                 meter.app_meter.sequential_merge(app_meter);
             } else {
-                let meter = AppMeterWithL7Protocol {
-                    app_meter: *app_meter,
-                    l7_protocol: l7_stats.l7_protocol,
-                    endpoint: l7_stats.endpoint.clone(),
-                    endpoint_hash,
-                    biz_type: l7_stats.biz_type,
-                    time_span,
+                let boxed_app_meter = Box::new(Self::generate_app_meter_with_flow(
+                    l7_stats,
+                    app_meter,
                     time_in_second,
-                    is_reversed: l7_stats.is_reversed,
-                };
-                meters.push(meter);
+                    time_span,
+                    endpoint_hash,
+                    is_active_host0,
+                    is_active_host1,
+                ));
+                meters.push(boxed_app_meter);
             }
 
-            // If l7_stats.flow.is_some(), set the flow of all meter belonging to this flow
-            if let Some(tagged_flow) = &l7_stats.flow {
-                let close_type = tagged_flow.flow.close_type;
-                let flow = MiniFlow::from(&tagged_flow.flow);
-                let (is_active_host0, is_active_host1) =
-                    check_active(time_in_second.as_secs(), possible_host, &flow);
+            if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
                 for meter in meters.drain(..) {
                     // meter.app_meter is empty, there is no need to save
                     if meter.app_meter.is_empty() {
                         continue;
                     }
-                    let boxed_app_meter = Box::new(AppMeterWithFlow {
-                        app_meter: meter.app_meter,
-                        flow: flow.clone(),
-                        l7_protocol: meter.l7_protocol,
-                        endpoint_hash: meter.endpoint_hash,
-                        endpoint: meter.endpoint,
-                        is_active_host0,
-                        is_active_host1,
-                        time_in_second: meter.time_in_second.into(),
-                        biz_type: meter.biz_type,
-                        is_reversed: meter.is_reversed,
-                        time_span,
-                    });
 
-                    if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
-                        Self::push_closed_app_meter(
-                            &mut self.closed_app_meters,
-                            &mut self.l7_output,
-                            boxed_app_meter,
-                        );
-                    } else {
-                        stash.meters.push(boxed_app_meter);
-                    }
+                    Self::push_closed_app_meter(
+                        &self.counter,
+                        &mut self.closed_app_meters,
+                        &mut self.l7_output,
+                        meter,
+                    );
                 }
+                let _ = stash.meters.remove(&l7_stats.flow_id);
             }
         } else {
             // app_meter is empty, there is no need to save
             if app_meter.is_empty() {
                 return;
             }
-            // If l7_stats.flow.is_some(), set the flow of all meter belonging to this flow
-            if let Some(tagged_flow) = &l7_stats.flow {
-                let close_type = tagged_flow.flow.close_type;
-                let flow = MiniFlow::from(&tagged_flow.flow);
-                let (is_active_host0, is_active_host1) =
-                    check_active(time_in_second.as_secs(), possible_host, &flow);
-                let boxed_app_meter = Box::new(AppMeterWithFlow {
-                    app_meter: *app_meter,
-                    flow,
-                    l7_protocol: l7_stats.l7_protocol,
-                    endpoint_hash,
-                    endpoint: l7_stats.endpoint.clone(),
-                    is_active_host0,
-                    is_active_host1,
-                    time_in_second: l7_stats.time_in_second.into(),
-                    biz_type: l7_stats.biz_type,
-                    time_span,
-                    is_reversed: l7_stats.is_reversed,
-                });
-                if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
-                    Self::push_closed_app_meter(
-                        &mut self.closed_app_meters,
-                        &mut self.l7_output,
-                        boxed_app_meter,
-                    );
-                } else {
-                    stash.meters.push(boxed_app_meter);
-                }
+            let flow = l7_stats.mini_flow.clone();
+            let (is_active_host0, is_active_host1) =
+                check_active(time_in_second.as_secs(), possible_host, &flow);
+            let boxed_app_meter = Box::new(Self::generate_app_meter_with_flow(
+                l7_stats,
+                app_meter,
+                time_in_second,
+                time_span,
+                endpoint_hash,
+                is_active_host0,
+                is_active_host1,
+            ));
+            if close_type != CloseType::Unknown && close_type != CloseType::ForcedReport {
+                Self::push_closed_app_meter(
+                    &self.counter,
+                    &mut self.closed_app_meters,
+                    &mut self.l7_output,
+                    boxed_app_meter,
+                );
             } else {
-                let meter = AppMeterWithL7Protocol {
-                    app_meter: *app_meter,
-                    l7_protocol: l7_stats.l7_protocol,
-                    endpoint: l7_stats.endpoint.clone(),
-                    endpoint_hash,
-                    biz_type: l7_stats.biz_type,
-                    time_span,
-                    time_in_second,
-                    is_reversed: l7_stats.is_reversed,
-                };
-                let _ = stash.l7_stats.insert(l7_stats.flow_id, vec![meter]);
+                stash.meters.insert(l7_stats.flow_id, vec![boxed_app_meter]);
             }
         }
     }
@@ -671,14 +670,8 @@ impl L7QuadrupleGenerator {
     }
 
     fn generate_app_meter(l7_stats: &L7Stats) -> AppMeter {
-        let (close_type, direction_score) = if let Some(tagged_flow) = &l7_stats.flow {
-            (
-                tagged_flow.flow.close_type,
-                tagged_flow.flow.direction_score,
-            )
-        } else {
-            (CloseType::ForcedReport, 0)
-        };
+        let close_type = l7_stats.mini_flow.close_type;
+        let direction_score = l7_stats.mini_flow.direction_score;
         let stats = &l7_stats.stats;
         match (l7_stats.l7_protocol, l7_stats.signal_source) {
             (
@@ -732,12 +725,18 @@ impl L7QuadrupleGenerator {
                         if let Some(q) = self.second_quad_gen.as_mut() {
                             if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
                                 warn!("second_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                                q.counter
+                                    .drop_by_queue
+                                    .fetch_add(q.closed_app_meters.len() as u64, Ordering::Relaxed);
                                 q.closed_app_meters.clear();
                             }
                         }
                         if let Some(q) = self.minute_quad_gen.as_mut() {
                             if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
                                 warn!("minute_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                                q.counter
+                                    .drop_by_queue
+                                    .fetch_add(q.closed_app_meters.len() as u64, Ordering::Relaxed);
                                 q.closed_app_meters.clear();
                             }
                         }
@@ -760,12 +759,19 @@ impl L7QuadrupleGenerator {
                     if let Some(q) = self.second_quad_gen.as_mut() {
                         if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
                             warn!("second_quad_gen queue failed to send l7 Document data, because {:?}", e);
+
+                            q.counter
+                                .drop_by_queue
+                                .fetch_add(q.closed_app_meters.len() as u64, Ordering::Relaxed);
                             q.closed_app_meters.clear();
                         }
                     }
                     if let Some(q) = self.minute_quad_gen.as_mut() {
                         if let Err(e) = q.l7_output.send_all(&mut q.closed_app_meters) {
                             warn!("minute_quad_gen queue failed to send l7 Document data, because {:?}", e);
+                            q.counter
+                                .drop_by_queue
+                                .fetch_add(q.closed_app_meters.len() as u64, Ordering::Relaxed);
                             q.closed_app_meters.clear();
                         }
                     }

--- a/agent/src/collector/types.rs
+++ b/agent/src/collector/types.rs
@@ -31,7 +31,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MiniFlow {
     pub flow_key: FlowKey,
     pub eth_type: EthernetType,
@@ -44,6 +44,7 @@ pub struct MiniFlow {
     pub otel_service: Option<String>,
     pub otel_instance: Option<String>,
     pub pod_id: u32,
+    pub direction_score: u8,
 }
 
 impl From<&Flow> for MiniFlow {
@@ -63,6 +64,7 @@ impl From<&Flow> for MiniFlow {
             otel_service: flow.otel_service.clone(),
             otel_instance: flow.otel_instance.clone(),
             pod_id: flow.pod_id,
+            direction_score: flow.direction_score,
         }
     }
 }
@@ -78,6 +80,22 @@ pub struct PeerInfo {
     pub gpid: u32,
     pub nat_real_ip: IpAddr,
     pub nat_real_port: u16,
+}
+
+impl Default for PeerInfo {
+    fn default() -> Self {
+        Self {
+            l3_epc_id: 0,
+            is_active_host: false,
+            is_device: false,
+            is_vip_interface: false,
+            has_packets: false,
+
+            gpid: 0,
+            nat_real_ip: IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            nat_real_port: 0,
+        }
+    }
 }
 
 impl From<&FlowMetricsPeer> for PeerInfo {

--- a/agent/src/common/flow.rs
+++ b/agent/src/common/flow.rs
@@ -18,7 +18,6 @@ use std::{
     fmt,
     mem::swap,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
-    sync::Arc,
     time::Duration,
 };
 
@@ -29,22 +28,21 @@ use super::{
     decapsulate::TunnelType,
     enums::{CaptureNetworkType, EthernetType, IpProtocol, TcpFlags},
     tap_port::TapPort,
-    TaggedFlow,
 };
 
 use crate::{
-    common::{endpoint::EPC_INTERNET, timestamp_to_micros, Timestamp},
-    metric::document::Direction,
-};
-use crate::{
+    collector::types::MiniFlow,
     flow_generator::protocol_logs::to_string_format,
     flow_generator::FlowState,
     metric::document::TapSide,
     utils::environment::{is_tt_pod, is_tt_workload},
 };
+use crate::{
+    common::{endpoint::EPC_INTERNET, timestamp_to_micros, Timestamp},
+    metric::document::Direction,
+};
 use public::utils::net::MacAddr;
 use public::{
-    buffer::BatchedBox,
     packet::SECONDS_IN_MINUTE,
     proto::{agent::AgentType, flow_log},
 };
@@ -542,7 +540,7 @@ impl From<FlowPerfStats> for flow_log::FlowPerfStats {
 #[derive(Clone, Debug, Default)]
 pub struct L7Stats {
     pub stats: L7PerfStats,
-    pub flow: Option<Arc<BatchedBox<TaggedFlow>>>,
+    pub mini_flow: MiniFlow,
     pub endpoint: Option<String>,
     pub flow_id: u64,
     pub l7_protocol: L7Protocol,

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -53,6 +53,7 @@ use super::{
 };
 
 use crate::{
+    collector::types::MiniFlow,
     common::{
         ebpf::EbpfType,
         endpoint::{EndpointData, EndpointDataPov, EndpointInfo, EPC_DEEPFLOW, EPC_INTERNET},
@@ -153,13 +154,16 @@ struct BufferedSender<T: std::fmt::Debug> {
 
     limit: usize,
     buffer: Vec<T>,
+
+    stats_counter: Arc<FlowMapCounter>,
 }
 
 impl<T: std::fmt::Debug> BufferedSender<T> {
-    fn new(queue: DebugSender<T>, limit: usize) -> Self {
+    fn new(queue: DebugSender<T>, limit: usize, stats_counter: Arc<FlowMapCounter>) -> Self {
         Self {
             queue,
             limit,
+            stats_counter,
             buffer: Vec::with_capacity(limit),
         }
     }
@@ -181,6 +185,9 @@ impl<T: std::fmt::Debug> BufferedSender<T> {
                 std::any::type_name::<T>(),
                 e
             );
+            self.stats_counter
+                .drop_by_queue
+                .fetch_add(self.buffer.len() as u64, Ordering::Relaxed);
             self.buffer.clear();
         }
     }
@@ -332,13 +339,24 @@ impl FlowMap {
                 );
                 allocator
             },
-            tflow_output: output_queue.map(|q| BufferedSender::new(q, QUEUE_BATCH_SIZE)),
-            l7_stats_output: BufferedSender::new(l7_stats_output_queue, QUEUE_BATCH_SIZE),
-            l7_log_output: BufferedSender::new(app_proto_log_queue, QUEUE_BATCH_SIZE),
+            tflow_output: output_queue
+                .map(|q| BufferedSender::new(q, QUEUE_BATCH_SIZE, stats_counter.clone())),
+            l7_stats_output: BufferedSender::new(
+                l7_stats_output_queue,
+                QUEUE_BATCH_SIZE,
+                stats_counter.clone(),
+            ),
+            l7_log_output: BufferedSender::new(
+                app_proto_log_queue,
+                QUEUE_BATCH_SIZE,
+                stats_counter.clone(),
+            ),
             pseq_output: match packet_sequence_queue {
-                Some(q) if packet_sequence_enabled => {
-                    Some(BufferedSender::new(q, QUEUE_BATCH_SIZE))
-                }
+                Some(q) if packet_sequence_enabled => Some(BufferedSender::new(
+                    q,
+                    QUEUE_BATCH_SIZE,
+                    stats_counter.clone(),
+                )),
                 _ => None,
             },
             last_queue_flush: Duration::ZERO,
@@ -1649,13 +1667,16 @@ impl FlowMap {
         consistent_timestamp_in_l7_metrics: bool,
         time_in_micros: u64,
     ) {
-        let flow = &mut node.tagged_flow.flow;
-        let Some(mut perf_stats) = flow.flow_perf_stats.take() else {
+        if node.tagged_flow.flow.flow_perf_stats.is_none() {
             return;
-        };
-        perf_stats.l7.sequential_merge(&l7_stat);
-        flow.flow_perf_stats = Some(perf_stats);
+        }
+        node.tagged_flow
+            .flow
+            .flow_perf_stats
+            .as_mut()
+            .map(|perf_stats| perf_stats.l7.sequential_merge(&l7_stat));
 
+        let flow = &node.tagged_flow.flow;
         let app_proto_head = l7_info.app_proto_head().unwrap();
         let time_span = if consistent_timestamp_in_l7_metrics
             && app_proto_head.msg_type == LogMessageType::Response
@@ -1677,7 +1698,7 @@ impl FlowMap {
         l7_stats.l7_protocol = l7_protocol;
         l7_stats.time_span = time_span as u32;
         l7_stats.biz_type = l7_info.get_biz_type();
-        l7_stats.flow = None;
+        l7_stats.mini_flow = MiniFlow::from(flow);
 
         self.l7_stats_output
             .send(self.l7_stats_allocator.allocate_one_with(l7_stats));
@@ -2040,7 +2061,7 @@ impl FlowMap {
                     signal_source: flow.signal_source,
                     time_in_second: self.start_time,
                     l7_protocol: flow_perf.l7_protocol,
-                    flow: Some(tagged_flow.clone()),
+                    mini_flow: MiniFlow::from(flow),
                     is_reversed: false,
                     ..Default::default()
                 };
@@ -2060,7 +2081,7 @@ impl FlowMap {
                     signal_source: flow.signal_source,
                     time_in_second: self.start_time,
                     l7_protocol: flow_perf.l7_protocol,
-                    flow: Some(tagged_flow.clone()),
+                    mini_flow: MiniFlow::from(flow),
                     is_reversed: true,
                     ..Default::default()
                 };
@@ -2568,6 +2589,7 @@ pub struct FlowMapCounter {
     closed: AtomicU64,                   // the number of closed flow
     drop_by_window: AtomicU64,           // times of flush which drop by window
     drop_by_capacity: AtomicU64,         // packet counter which drop by capacity
+    drop_by_queue: AtomicU64,            // packet counter which drop by queue
     packet_delay: AtomicI64,             // inject_meta_packet delay compared to ntp corrected system time
     flush_delay: AtomicI64,              // inject_flush_ticker delay compared to ntp corrected system time
     flow_delay: AtomicI64,               // output flow `flow_stat_time` delay compared to ntp corrected system time
@@ -2586,6 +2608,7 @@ impl FlowMapCounter {
             closed: AtomicU64::new(0),
             drop_by_window: AtomicU64::new(0),
             drop_by_capacity: AtomicU64::new(0),
+            drop_by_queue: AtomicU64::new(0),
             packet_delay: AtomicI64::new(0),
             flush_delay: AtomicI64::new(0),
             flow_delay: AtomicI64::new(0),
@@ -2624,6 +2647,11 @@ impl RefCountable for FlowMapCounter {
                 "drop_by_capacity",
                 CounterType::Gauged,
                 CounterValue::Unsigned(self.drop_by_capacity.swap(0, Ordering::Relaxed)),
+            ),
+            (
+                "drop_by_queue",
+                CounterType::Gauged,
+                CounterValue::Unsigned(self.drop_by_queue.swap(0, Ordering::Relaxed)),
             ),
             (
                 "packet_delay",

--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -48,6 +48,7 @@ use tokio::{
 use zstd::bulk::compress;
 
 use crate::{
+    collector::types::MiniFlow,
     common::{
         flow::{Flow, FlowPerfStats, L7PerfStats, L7Stats, SignalSource},
         lookup_key::LookupKey,
@@ -559,10 +560,9 @@ fn fill_l7_stats(
     let flow_stat_time = flow.flow_stat_time;
     let mut tagged_flow = TaggedFlow::default();
     tagged_flow.flow = flow;
-    let mut allocator = Allocator::new(1);
     L7Stats {
         stats,
-        flow: Some(Arc::new(allocator.allocate_one_with(tagged_flow))),
+        mini_flow: MiniFlow::from(&tagged_flow.flow),
         endpoint: last_endpoint,
         flow_id,
         l7_protocol,


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


