### PR TITLE
feat(server): add Dameng L7 protocol metadata

### DIFF
--- a/server/libs/datatype/flow.go
+++ b/server/libs/datatype/flow.go
@@ -164,6 +164,7 @@ const (
 	L7_PROTOCOL_MYSQL       L7Protocol = 60
 	L7_PROTOCOL_POSTGRE     L7Protocol = 61
 	L7_PROTOCOL_ORACLE      L7Protocol = 62
+	L7_PROTOCOL_DAMENG      L7Protocol = 63
 	L7_PROTOCOL_REDIS       L7Protocol = 80
 	L7_PROTOCOL_MONGODB     L7Protocol = 81
 	L7_PROTOCOL_MEMCACHED   L7Protocol = 82
@@ -693,6 +694,12 @@ func (p L7Protocol) String(isTLS bool) string {
 		} else {
 			return "Oracle"
 		}
+	case L7_PROTOCOL_DAMENG:
+		if isTLS {
+			return "Dameng_TLS"
+		} else {
+			return "Dameng"
+		}
 	case L7_PROTOCOL_ISO8583:
 		if isTLS {
 			return "ISO-8583_TLS"
@@ -815,6 +822,7 @@ var L7ProtocolStringMap = map[string]L7Protocol{
 	strings.ToLower(L7_PROTOCOL_MYSQL.String(false)):       L7_PROTOCOL_MYSQL,
 	strings.ToLower(L7_PROTOCOL_POSTGRE.String(false)):     L7_PROTOCOL_POSTGRE,
 	strings.ToLower(L7_PROTOCOL_ORACLE.String(false)):      L7_PROTOCOL_ORACLE,
+	strings.ToLower(L7_PROTOCOL_DAMENG.String(false)):      L7_PROTOCOL_DAMENG,
 	strings.ToLower(L7_PROTOCOL_ISO8583.String(false)):     L7_PROTOCOL_ISO8583,
 	strings.ToLower(L7_PROTOCOL_NET_SIGN.String(false)):    L7_PROTOCOL_NET_SIGN,
 	strings.ToLower(L7_PROTOCOL_TRIPLE.String(false)):      L7_PROTOCOL_TRIPLE,

--- a/server/querier/db_descriptions/clickhouse/tag/enum/l7_protocol
+++ b/server/querier/db_descriptions/clickhouse/tag/enum/l7_protocol
@@ -15,6 +15,7 @@
 60      , MySQL           ,
 61      , PostgreSQL      ,
 62      , Oracle          ,
+63      , Dameng          ,
 80      , Redis           ,
 81      , MongoDB         ,
 82      , Memcached       ,


### PR DESCRIPTION
## Summary
- register Dameng in server-side L7 protocol enum mapping
- add Dameng tag description for ClickHouse querier metadata

## Test plan
- [x] Build passes for changed files locally
- [x] Verified only server-related files are included in this PR