### PR TITLE
fix: incorrect endpoint

### DIFF
--- a/agent/src/common/l7_protocol_info.rs
+++ b/agent/src/common/l7_protocol_info.rs
@@ -18,7 +18,7 @@ use std::cell::RefMut;
 
 use super::flow::PacketDirection;
 use enum_dispatch::enum_dispatch;
-use log::{debug, error, warn};
+use log::{debug, error};
 use serde::Serialize;
 
 use crate::{
@@ -224,15 +224,16 @@ where
 
     /*
         calculate rrt
-        if have previous log cache:
+        if session
+            return stats
+        if request
+            update rrt cache
+            return stats
+        if response
             if previous is req and current is resp and current time > previous time
                 rrt = current time - previous time
-            if previous is resp and current is req and current time < previous time, likely ebfp disorder
-                rrt =  previous time - current time
-
-            otherwise can not calculate rrt, cache current log rrt
-
-        if have no previous log cache, cache the current log rrt
+            remove rrt cache
+            return stats
     */
     fn perf_stats(&self, param: &ParseParam) -> Option<L7PerfStats> {
         if param.time == 0 {
@@ -284,14 +285,16 @@ where
             //
             // If the first log is a response, its perf stats will not be counted here.
             // We need to know whether its corresponding request is on blacklist before accounting.
-            let ret = if cur_info.msg_type == LogMessageType::Request && !cur_info.on_blacklist {
-                timeout_counter.in_cache[index] += 1;
-                Some(L7PerfStats::from(&cur_info))
+            return if !cur_info.on_blacklist {
+                let stats = L7PerfStats::from(&cur_info);
+                if cur_info.msg_type == LogMessageType::Request {
+                    timeout_counter.in_cache[index] += 1;
+                    rtt_cache.put(key, cur_info);
+                }
+                Some(stats)
             } else {
                 None
             };
-            rtt_cache.put(key, cur_info);
-            return ret;
         };
 
         let mut keep_prev = false;
@@ -344,84 +347,24 @@ where
             }
 
             result
-        } else if prev_info.is_response_of(&cur_info) {
-            // cur_info is request, prev_info is response
-            // request not accounted before
-            let result = if !cur_info.on_blacklist {
-                let mut perf_stats = L7PerfStats::from(&cur_info);
-
-                if !prev_info.on_blacklist {
-                    let rrt = prev_info.time - cur_info.time;
-                    if rrt > param.rrt_timeout as u64 {
-                        warn!("l7 log info disorder with long time rrt {}", rrt);
-                        match prev_info.multi_merge_info.as_ref() {
-                            Some(info) if info.merged => (),
-                            _ => timeout_counter.timeout[index] += 1,
-                        }
-                    }
-
-                    perf_stats.sequential_merge(&L7PerfStats::from(&*prev_info));
-                    perf_stats.update_rrt(rrt);
-                }
-
-                Some(perf_stats)
-            } else {
-                None
-            };
-
-            if !keep_prev {
-                rtt_cache.pop(&key);
-            }
-
-            result
         } else if !self.need_merge() {
             debug!(
                 "can not calculate rrt, flow_id: {}, previous log type: {:?}, previous time: {}, current log type: {:?}, current time: {}",
                 param.flow_id, prev_info.msg_type, prev_info.time, cur_info.msg_type, cur_info.time,
             );
 
-            if prev_info.time > cur_info.time {
-                if !cur_info.on_blacklist && cur_info.msg_type == LogMessageType::Request {
-                    timeout_counter.timeout[index] += 1;
+            if !keep_prev {
+                rtt_cache.pop(&key);
+            }
+
+            if !cur_info.on_blacklist {
+                let stats = L7PerfStats::from(&cur_info);
+                if cur_info.msg_type == LogMessageType::Request {
+                    rtt_cache.put(key, cur_info);
                 }
-                if !prev_info.on_blacklist && prev_info.msg_type == LogMessageType::Request {
-                    timeout_counter.in_cache[index] += 1;
-                }
-                if !cur_info.on_blacklist {
-                    Some(L7PerfStats::from(&cur_info))
-                } else {
-                    None
-                }
+                Some(stats)
             } else {
-                if !prev_info.on_blacklist && prev_info.msg_type == LogMessageType::Request {
-                    timeout_counter.timeout[index] += 1;
-                }
-                if !cur_info.on_blacklist && cur_info.msg_type == LogMessageType::Request {
-                    timeout_counter.in_cache[index] += 1;
-                }
-                let cur_is_req = cur_info.msg_type == LogMessageType::Request;
-                let cur_on_blacklist = cur_info.on_blacklist;
-                let prev_info = rtt_cache.put(key, cur_info).unwrap();
-                // Requests are counted (req=1) eagerly when they first enter the cache,
-                // so re-emitting a displaced Request here would double-count it.
-                // Responses were cached with None on arrival and must be counted here.
-                let mut result =
-                    if !prev_info.on_blacklist && prev_info.msg_type == LogMessageType::Response {
-                        L7PerfStats::from(&prev_info)
-                    } else {
-                        L7PerfStats::default()
-                    };
-                // A new Request entering the cache via this path (replacing a previous entry)
-                // was never counted by the first-entry path, so emit req=1 now so that
-                // "request accounted before" holds when its response arrives via is_request_of.
-                if !cur_on_blacklist && cur_is_req {
-                    result.inc_req();
-                }
-                if result == L7PerfStats::default() {
-                    None
-                } else {
-                    Some(result)
-                }
+                None
             }
         } else {
             if !prev_info.on_blacklist

--- a/agent/src/common/l7_protocol_log.rs
+++ b/agent/src/common/l7_protocol_log.rs
@@ -353,13 +353,13 @@ impl LogCache {
     pub fn is_request_of(&self, other: &Self) -> bool {
         self.msg_type == LogMessageType::Request
             && other.msg_type == LogMessageType::Response
-            && self.time < other.time
+            && self.time <= other.time
     }
 
     pub fn is_response_of(&self, other: &Self) -> bool {
         self.msg_type == LogMessageType::Response
             && other.msg_type == LogMessageType::Request
-            && self.time > other.time
+            && self.time >= other.time
     }
 }
 

--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -1288,6 +1288,7 @@ impl<'a> MetaPacket<'a> {
             header_type: self.header_type,
             l2_l3_opt_size: self.l2_l3_opt_size,
             l4_opt_size: self.l4_opt_size,
+            flow_id: self.flow_id,
             ..Default::default()
         })
     }

--- a/agent/src/flow_generator/protocol_logs/fastcgi.rs
+++ b/agent/src/flow_generator/protocol_logs/fastcgi.rs
@@ -563,7 +563,7 @@ impl L7ProtocolParserInterface for FastCGILog {
 
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/http.rs
+++ b/agent/src/flow_generator/protocol_logs/http.rs
@@ -1326,7 +1326,7 @@ impl HttpLog {
 
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, info.is_reversed) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/mq/amqp.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/amqp.rs
@@ -1125,7 +1125,7 @@ impl L7ProtocolParserInterface for AmqpLog {
                 }
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                         if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                             info.endpoint = Some(endpoint.to_string());
                         }

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -903,7 +903,7 @@ impl L7ProtocolParserInterface for KafkaLog {
 
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
@@ -316,7 +316,7 @@ impl L7ProtocolParserInterface for MqttLog {
 
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                         if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                             info.endpoint = Some(endpoint.to_string());
                         }

--- a/agent/src/flow_generator/protocol_logs/mq/nats.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/nats.rs
@@ -959,7 +959,7 @@ impl L7ProtocolParserInterface for NatsLog {
 
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                         if let Some(endpoint) =
                             info.load_endpoint_from_cache(param, info.is_reversed)
                         {

--- a/agent/src/flow_generator/protocol_logs/mq/openwire.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/openwire.rs
@@ -1920,7 +1920,7 @@ impl L7ProtocolParserInterface for OpenWireLog {
 
             if param.parse_perf {
                 let mut perf_stat = L7PerfStats::default();
-                if info.msg_type == LogMessageType::Response {
+                if info.msg_type == LogMessageType::Response && info.topic.is_none() {
                     if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                         info.topic = Some(endpoint.to_string());
                     }

--- a/agent/src/flow_generator/protocol_logs/mq/pulsar.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/pulsar.rs
@@ -910,7 +910,7 @@ impl L7ProtocolParserInterface for PulsarLog {
 
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.topic.is_none() {
                         if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                             info.topic = Some(endpoint.to_string());
                         }

--- a/agent/src/flow_generator/protocol_logs/mq/rocketmq.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/rocketmq.rs
@@ -303,7 +303,7 @@ impl L7ProtocolParserInterface for RocketmqLog {
         self.perf_stats.clear();
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/plugin/custom_protocol_policy.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/custom_protocol_policy.rs
@@ -190,9 +190,9 @@ impl L7ProtocolParserInterface for CustomPolicyLog {
 
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response && info.req.endpoint.is_empty() {
+            if info.msg_type == LogMessageType::Response && info.resp.endpoint.is_empty() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
-                    info.req.endpoint = endpoint.to_string();
+                    info.resp.endpoint = endpoint.to_string();
                 }
             }
             if let Some(stats) = info.perf_stats(param) {

--- a/agent/src/flow_generator/protocol_logs/plugin/shared_obj.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/shared_obj.rs
@@ -173,11 +173,13 @@ impl L7ProtocolParserInterface for SoLog {
 
                                 if param.parse_perf {
                                     let mut perf_stat = L7PerfStats::default();
-                                    if info.msg_type == LogMessageType::Response {
+                                    if info.msg_type == LogMessageType::Response
+                                        && info.resp.endpoint.is_empty()
+                                    {
                                         if let Some(endpoint) =
                                             info.load_endpoint_from_cache(param, info.is_reversed())
                                         {
-                                            info.req.endpoint = endpoint.to_string();
+                                            info.resp.endpoint = endpoint.to_string();
                                         }
                                     }
                                     if let Some(stats) = info.perf_stats(param) {

--- a/agent/src/flow_generator/protocol_logs/plugin/wasm.rs
+++ b/agent/src/flow_generator/protocol_logs/plugin/wasm.rs
@@ -67,11 +67,11 @@ impl L7ProtocolParserInterface for WasmLog {
 
                     if param.parse_perf {
                         let mut perf_stat = L7PerfStats::default();
-                        if i.msg_type == LogMessageType::Response {
+                        if i.msg_type == LogMessageType::Response && i.resp.endpoint.is_empty() {
                             if let Some(endpoint) =
                                 i.load_endpoint_from_cache(param, i.is_reversed())
                             {
-                                i.req.endpoint = endpoint.to_string();
+                                i.resp.endpoint = endpoint.to_string();
                             }
                         }
                         if let Some(stats) = i.perf_stats(param) {

--- a/agent/src/flow_generator/protocol_logs/rpc/brpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/brpc.rs
@@ -310,7 +310,7 @@ impl L7ProtocolParserInterface for BrpcLog {
 
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                         if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                             info.endpoint = Some(endpoint.to_string());
                         }

--- a/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/dubbo.rs
@@ -582,7 +582,7 @@ impl L7ProtocolParserInterface for DubboLog {
 
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, info.is_reversed) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -359,7 +359,7 @@ impl L7ProtocolParserInterface for SofaRpcLog {
 
                 if param.parse_perf {
                     let mut perf_stat = L7PerfStats::default();
-                    if info.msg_type == LogMessageType::Response {
+                    if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                         if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                             info.endpoint = Some(endpoint.to_string());
                         }

--- a/agent/src/flow_generator/protocol_logs/rpc/tars.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/tars.rs
@@ -469,7 +469,7 @@ impl L7ProtocolParserInterface for TarsLog {
         self.perf_stats.clear();
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                     info.endpoint = Some(endpoint.to_string());
                 }

--- a/agent/src/flow_generator/protocol_logs/sql/mysql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/mysql.rs
@@ -815,7 +815,7 @@ impl L7ProtocolParserInterface for MysqlLog {
         self.perf_stats.clear();
         if param.parse_perf {
             let mut perf_stat = L7PerfStats::default();
-            if info.msg_type == LogMessageType::Response {
+            if info.msg_type == LogMessageType::Response && info.endpoint.is_none() {
                 if let Some(endpoint) = info.load_endpoint_from_cache(param, false) {
                     info.endpoint = Some(endpoint);
                 }

--- a/agent/src/plugin/mod.rs
+++ b/agent/src/plugin/mod.rs
@@ -647,7 +647,13 @@ impl L7ProtocolInfoInterface for CustomInfo {
     }
 
     fn get_endpoint(&self) -> Option<String> {
-        return Some(self.req.endpoint.clone());
+        if !self.req.endpoint.is_empty() {
+            return Some(self.req.endpoint.clone());
+        }
+        if !self.resp.endpoint.is_empty() {
+            return Some(self.resp.endpoint.clone());
+        }
+        return None;
     }
 
     fn get_biz_type(&self) -> u8 {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


###  fix: incorrect endpoint
#### Steps to reproduce the bug
#### Changes to fix the bug
- perf_stats函数不再支持乱序的场景，不在缓存响应的指标
- is_request_of/is_response_of 时间放宽，避免请求响应时间戳ns 转 ms时时间变为相同导致无法聚合-
- to_owned_segment添加flow id的赋值，避免tcp重组的指标在函数perf_stats里生成错误的key
- 对于响应能解析出来endpoint的不会再查询endpoint
#### Affected branches
- main
- 7.1
- 6.6
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


