### PR TITLE
Fix: solve ebpf load problem for df_T_enter_close and df_T_io_event

### DIFF
--- a/agent/src/ebpf/kernel/files_rw.bpf.c
+++ b/agent/src/ebpf/kernel/files_rw.bpf.c
@@ -25,6 +25,16 @@
 #define FILE_TYPE_REGULAR   0    /* Regular VFS-backed file */
 #define FILE_TYPE_VIRTUAL   1    /* Non-VFS / virtual / special file */
 
+#ifdef EXTENDED_AI_AGENT_FILE_IO
+#if defined(LINUX_VER_KFUNC) || defined(LINUX_VER_5_2_PLUS)
+/*
+ * The common BPF object is still limited to 4096 instructions on 4.x kernels.
+ * Keep the extra AI Agent io_event logic only in variants with a larger budget.
+ */
+#define EXTENDED_AI_AGENT_FILE_IO_FULL 1
+#endif
+#endif
+
 static __inline int check_file_type(void *file, struct member_fields_offset *offset)
 {
 	if (!file || !offset)
@@ -334,12 +344,12 @@ static __inline int trace_io_event_common(void *ctx,
 		return -1;
 	}
 
-#ifdef EXTENDED_AI_AGENT_FILE_IO
+#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL
 	int __ai_agent = is_ai_agent_process(pid_tgid);
 #endif
 
 	if (tracer_ctx->io_event_collect_mode == 0) {
-#ifdef EXTENDED_AI_AGENT_FILE_IO
+#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL
 		if (!__ai_agent)
 #endif
 		return -1;
@@ -353,7 +363,7 @@ static __inline int trace_io_event_common(void *ctx,
 	}
 
 	if (trace_id == 0 && tracer_ctx->io_event_collect_mode == 1) {
-#ifdef EXTENDED_AI_AGENT_FILE_IO
+#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL
 		if (!__ai_agent)
 #endif
 		return -1;
@@ -381,7 +391,7 @@ static __inline int trace_io_event_common(void *ctx,
 	}
 
 	if (latency < tracer_ctx->io_event_minimal_duration) {
-#ifdef EXTENDED_AI_AGENT_FILE_IO
+#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL
 		if (!__ai_agent)
 #endif
 		return -1;
@@ -395,7 +405,7 @@ static __inline int trace_io_event_common(void *ctx,
 	buffer->bytes_count = data_args->bytes_count;
 	buffer->latency = latency;
 	buffer->operation = direction;
-#ifdef EXTENDED_AI_AGENT_FILE_IO
+#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL
 	buffer->access_permission =
 	    ai_agent_get_access_permission(data_args->fd, offset);
 #else

--- a/agent/src/ebpf/kernel/socket_trace.bpf.c
+++ b/agent/src/ebpf/kernel/socket_trace.bpf.c
@@ -2930,12 +2930,22 @@ static __inline void __push_close_event(__u64 pid_tgid, __u64 uid, __u64 seq,
 
 	__sync_fetch_and_add(&tracer_ctx->push_buffer_refcnt, 1);
 	struct __socket_data *v = (struct __socket_data *)&v_buff->data[0];
-	if (v_buff->len > (sizeof(v_buff->data) - sizeof(*v))) {
+	/*
+	 * Linux 4.19 verifier cannot always infer the range of v_buff->len
+	 * when it is used directly in map-value pointer arithmetic.
+	 */
+	__u32 buf_len = v_buff->len;
+	if (buf_len > (sizeof(v_buff->data) - sizeof(*v))) {
+		__sync_fetch_and_add(&tracer_ctx->push_buffer_refcnt, -1);
+		return;
+	}
+	buf_len &= (sizeof(*v_buff) - 1);
+	if (buf_len > (sizeof(v_buff->data) - sizeof(*v))) {
 		__sync_fetch_and_add(&tracer_ctx->push_buffer_refcnt, -1);
 		return;
 	}
 
-	v = (struct __socket_data *)(v_buff->data + v_buff->len);
+	v = (struct __socket_data *)(v_buff->data + buf_len);
 	__builtin_memset(v, 0, offsetof(typeof(struct __socket_data), data));
 	v->socket_id = uid;
 	v->tgid = (__u32) (pid_tgid >> 32);
@@ -3014,14 +3024,25 @@ KFUNC_PROG(__arm64_sys_close, const struct pt_regs *regs)
 		return 0;
 	}
 
-	if (socket_info_ptr->uid) {
+	/*
+	 * Snapshot map-value fields before deletion. This avoids reading
+	 * socket_info_ptr after socket_info_map deletion and keeps Linux 4.19
+	 * verifier range tracking stable after the close-event helper is inlined.
+	 */
+	__u64 close_uid = socket_info_ptr->uid;
+	__u64 close_seq = socket_info_ptr->seq;
+	__u16 close_l7_proto = socket_info_ptr->l7_proto;
+	enum process_data_extra_source close_source = source;
+
+	if (close_uid) {
 		__sync_fetch_and_add(&socket_info_ptr->seq, 1);
-		source = socket_info_ptr->data_source;
+		close_seq = socket_info_ptr->seq;
+		close_source = socket_info_ptr->data_source;
 	}
 
 	delete_socket_info(conn_key, socket_info_ptr);
-	__push_close_event(id, socket_info_ptr->uid, socket_info_ptr->seq,
-			   socket_info_ptr->l7_proto, fd, source,
+	__push_close_event(id, close_uid, close_seq,
+			   close_l7_proto, fd, close_source,
 			   offset, (void *)ctx);
 	return 0;
 }

--- a/agent/src/ebpf/test/test_ai_agent_source_contracts.py
+++ b/agent/src/ebpf/test/test_ai_agent_source_contracts.py
@@ -6,6 +6,7 @@ import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 SOCKET_TRACE = ROOT / "kernel" / "socket_trace.bpf.c"
+FILES_RW = ROOT / "kernel" / "files_rw.bpf.c"
 SOCKET_C = ROOT / "user" / "socket.c"
 
 
@@ -16,6 +17,7 @@ def require(condition: bool, message: str) -> None:
 
 
 socket_trace_text = SOCKET_TRACE.read_text()
+files_rw_text = FILES_RW.read_text()
 socket_c_text = SOCKET_C.read_text()
 
 reasm_idx = socket_trace_text.find("socket_info_ptr->reasm_bytes = 0;")
@@ -45,6 +47,73 @@ data_submit_text = socket_trace_text[data_submit_start:push_close_start]
 require(
     "__u64 pid_tgid = bpf_get_current_pid_tgid();" in data_submit_text,
     "__data_submit must define pid_tgid before EXTENDED_AI_AGENT_FILE_IO branch uses it",
+)
+
+push_close_end = socket_trace_text.find("\n}\n\n#ifdef SUPPORTS_KPROBE_ONLY", push_close_start)
+require(push_close_end != -1, "missing __push_close_event end")
+push_close_text = socket_trace_text[push_close_start:push_close_end]
+
+require(
+    "__u32 buf_len = v_buff->len;" in push_close_text,
+    "__push_close_event must copy v_buff->len into a local bounded variable for old verifier",
+)
+require(
+    "Linux 4.19 verifier cannot always infer the range of v_buff->len" in push_close_text,
+    "__push_close_event must document why the local bounded length is required",
+)
+require(
+    "buf_len &= (sizeof(*v_buff) - 1);" in push_close_text,
+    "__push_close_event must mask local buffer length before map_value pointer arithmetic",
+)
+require(
+    "(struct __socket_data *)(v_buff->data + buf_len)" in push_close_text,
+    "__push_close_event must use bounded buf_len for map_value pointer arithmetic",
+)
+
+enter_close_start = socket_trace_text.find("TP_SYSCALL_PROG(enter_close)")
+require(enter_close_start != -1, "missing enter_close definition")
+enter_close_end = socket_trace_text.find("\n}\n\n//int __sys_socket", enter_close_start)
+require(enter_close_end != -1, "missing enter_close end")
+enter_close_text = socket_trace_text[enter_close_start:enter_close_end]
+
+delete_idx = enter_close_text.find("delete_socket_info(conn_key, socket_info_ptr);")
+push_idx = enter_close_text.find("__push_close_event(")
+require(delete_idx != -1, "enter_close must delete socket_info")
+require(push_idx != -1, "enter_close must push close event")
+require(delete_idx < push_idx, "enter_close should delete socket_info before pushing close event")
+for field in ("uid", "seq", "l7_proto", "source"):
+    require(
+        f"close_{field}" in enter_close_text,
+        f"enter_close must snapshot close_{field} before deleting socket_info",
+    )
+require(
+    "delete_socket_info(conn_key, socket_info_ptr);\n\t__push_close_event(id, close_uid, close_seq,"
+    in enter_close_text,
+    "enter_close must push close events with verifier-friendly local snapshots",
+)
+
+trace_io_start = files_rw_text.find("trace_io_event_common(")
+require(trace_io_start != -1, "missing trace_io_event_common definition")
+trace_io_end = files_rw_text.find("\n}\n\n/*\n * File read/write-related", trace_io_start)
+require(trace_io_end != -1, "missing trace_io_event_common end")
+trace_io_text = files_rw_text[trace_io_start:trace_io_end]
+
+require(
+    "EXTENDED_AI_AGENT_FILE_IO_FULL" in files_rw_text,
+    "AI Agent file I/O extensions must have a 5.2+/kfunc-only guard for old 4096-insn kernels",
+)
+require(
+    "#ifdef EXTENDED_AI_AGENT_FILE_IO\n" not in trace_io_text,
+    "trace_io_event_common must not compile AI Agent file I/O extensions into common BPF",
+)
+require(
+    "#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL\n\tint __ai_agent" in trace_io_text,
+    "AI Agent io_event bypass must be guarded by EXTENDED_AI_AGENT_FILE_IO_FULL",
+)
+require(
+    "#ifdef EXTENDED_AI_AGENT_FILE_IO_FULL\n\tbuffer->access_permission =\n"
+    "\t    ai_agent_get_access_permission" in trace_io_text,
+    "AI Agent access_permission extraction must be guarded by EXTENDED_AI_AGENT_FILE_IO_FULL",
 )
 
 print("[OK]")


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

### Fixes eBPF load failures on 4.x kernels for AI Agent governance
#### Steps to reproduce the bug
  - Build an enterprise deepflow-agent with AI Agent governance enabled.
  - Deploy the agent to a Linux 4.19 kernel environment.
  - Start the socket tracer and load the common socket-trace eBPF object.
  - The eBPF loader may fail on df_T_enter_close with verifier range errors such as "math between map_value pointer and register with unbounded min
  value is not allowed".
  - The eBPF loader may also fail on df_TP_io_event because the common BPF program exceeds the 4.x kernel 4096-instruction limit, for example "Program
  too large (4304 insns), at most 4096 insns".
#### Changes to fix the bug
  - Copy v_buff->len into a local bounded variable before using it in __push_close_event map-value pointer arithmetic.
  - Add an explicit mask and bounds check for the local close-event buffer length so older verifiers can infer a safe range.
  - Add comments explaining why the close-event local bounded length is required for Linux 4.19 verifier compatibility.
  - Restrict the extra AI Agent io_event logic to LINUX_VER_5_2_PLUS and LINUX_VER_KFUNC BPF variants through EXTENDED_AI_AGENT_FILE_IO_FULL.
  - Keep the common 4.x BPF variant under the 4096-instruction limit while preserving the original io_event path.
  - Add source-level regression contracts to prevent reintroducing the old verifier-unfriendly close-event pointer arithmetic and the common-BPF AI
  Agent io_event instruction growth.
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [x] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
- [x] Verified eBPF program runs successfully on linux 4.18.x (RockyLinux 8.10).
- [x] Verified eBPF program runs successfully on linux 5.4.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


