### PR TITLE
fix: guard mount info cache initialization failure

### DIFF
--- a/agent/src/ebpf/user/mount.c
+++ b/agent/src/ebpf/user/mount.c
@@ -216,6 +216,9 @@ int mount_info_cache_init(const char *name)
 
 struct mount_info *mount_info_cache_lookup(pid_t pid, u64 mntns_id)
 {
+	if (!enable_mount_info_cache())
+		return MOUNT_INFO_INVAL;
+
 	if (mntns_id == 0 && pid > 0) {
 		if (get_mount_ns_id(pid, &mntns_id))
 			return MOUNT_INFO_INVAL;
@@ -552,6 +555,9 @@ static int check_mount_kvp_cb(mount_info_hash_kv * kvp, void *ctx)
 
 void collect_mount_info_stats(bool output_log)
 {
+	if (!enable_mount_info_cache())
+		return;
+
 	u64 elems_count = 0;
 	mount_info_hash_t *h = &mount_info_hash;
 	mount_info_hash_foreach_key_value_pair(h,
@@ -592,6 +598,9 @@ void check_and_cleanup_mount_info(pid_t pid, u64 mntns_id)
 // Periodically check whether the host node's mount information has changed.
 void check_root_mount_info(bool output_log)
 {
+	if (!enable_mount_info_cache())
+		return;
+
 	u32 new_hash = 0;
 	hash_mountinfo_file(1, &new_hash);
 	if (new_hash != 0 && new_hash != host_root_mountinfo_hash) {

--- a/agent/src/ebpf/user/proc.c
+++ b/agent/src/ebpf/user/proc.c
@@ -762,7 +762,10 @@ void *get_symbol_cache(pid_t pid, bool new_cache)
 int create_and_init_proc_info_caches(void)
 {
 	// Initialize the mount information cache.
-	mount_info_cache_init("mount-info-cache");
+	if (mount_info_cache_init("mount-info-cache")) {
+		ebpf_warning("mount_info_cache_init() failed.\n");
+		return ETR_NOMEM;
+	}
 
 	/*
 	 * Building a 'proc_event_ring' for handling process events.

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -3094,7 +3094,8 @@ int running_socket_tracer(tracer_callback_t handle,
 	socket_tracer_set_probes(tps);
 	golang_trace_init();
 	openssl_trace_init();
-	create_and_init_proc_info_caches();
+	if ((ret = create_and_init_proc_info_caches()))
+		return ret;
 
 	struct bpf_tracer *tracer =
 	    setup_bpf_tracer(SK_TRACER_NAME, bpf_load_buffer_name,


### PR DESCRIPTION
Prevent proc-events from accessing an uninitialized mount info bihash when mount_info_cache_init() fails. Propagate the initialization error from create_and_init_proc_info_caches() and add runtime guards before mount info cache lookup/stat/root-check paths.

### This PR is for:
- Agent

### Affected branches
- main

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


