### PR TITLE
fix(eBPF): Flush symbol cache after replay to avoid unsent data

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -102,7 +102,7 @@ OBJS := user/elf.o \
 	user/profile/java/collect_symbol_files.o
 
 JAVA_TOOL := deepflow-jattach
-JAVA_AGENT_VERSION := 2
+JAVA_AGENT_VERSION := 3
 JAVA_AGENT_GNU_SO := df_java_agent_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_MUSL_SO := df_java_agent_musl_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_SO := $(JAVA_AGENT_GNU_SO) $(JAVA_AGENT_MUSL_SO)

--- a/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
+++ b/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
@@ -323,11 +323,6 @@ void df_send_symbol(enum event_type type, const void *code_addr,
 	send_bytes = meta->len + sizeof(*meta);
 	pthread_mutex_lock(&g_df_lock);
 	if (replay_finish) {
-		if (g_cached_bytes > 0) {
-			send_msg(perf_map_socket_fd, g_symbol_buffer,
-				 g_cached_bytes);
-			g_cached_bytes = 0;
-		}
 		send_msg(perf_map_socket_fd, symbol_str, send_bytes);
 	} else {
 		int buff_remain_bytes =
@@ -545,7 +540,16 @@ enable_replay:
 	if (g_jvmti == NULL)
 		g_jvmti = jvmti;
 	_(replay_callbacks(jvmti));
+	pthread_mutex_lock(&g_df_lock);
+	if (g_cached_bytes > 0) {
+		if (perf_map_socket_fd >= 0) {
+			send_msg(perf_map_socket_fd, g_symbol_buffer,
+				 g_cached_bytes);
+		}
+		g_cached_bytes = 0;
+	}
 	replay_finish = true;
+	pthread_mutex_unlock(&g_df_lock);
 	df_log
 	    ("- JVMTI symbolization agent startup sequence complete. Replay count %d\n",
 	     replay_count);


### PR DESCRIPTION
During replay, keep symbols cached in g_symbol_buffer. After replay_callbacks(jvmti) completes, immediately flush g_cached_bytes under g_df_lock protection. Once flush is done, set replay_finish = true.
df_send_symbol() now only sends the current symbol when replay_finish == true, and no longer flushes replay cache automatically.

This prevents cached data from being left unsent if no new symbol events occur after replay completes.

Conflicts:
	agent/src/ebpf/Makefile
### This PR is for:
- Agent
### Affected branches
- main
- v7.1
- v7.0
- v6.6
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


