### PR TITLE
fix(eBPF): add kprobe fallback for AI governance hooks

### DIFF
--- a/agent/src/ebpf/kernel/uprobe_base.bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base.bpf.c
@@ -689,6 +689,11 @@ static inline int kernel_clone_exit(bool is_kprobe, bool maybe_thread,
 	else
 		data.pid = pid;
 	data.maybe_thread = maybe_thread;
+#ifdef EXTENDED_AI_AGENT_FILE_IO
+	if (is_kprobe && ret > 0) {
+		ai_agent_on_fork(ctx, (__u32)tgid, (__u32)data.pid);
+	}
+#endif
 	bpf_get_current_comm(data.name, sizeof(data.name));
 	bpf_perf_event_output(ctx, &NAME(socket_data),
 			      BPF_F_CURRENT_CPU, &data, sizeof(data));

--- a/agent/src/ebpf/test/test_ai_agent_governance_fallback_contracts.py
+++ b/agent/src/ebpf/test/test_ai_agent_governance_fallback_contracts.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import sys
+
+
+OSS_EBPF_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = OSS_EBPF_ROOT.parents[3]
+TRACER_C = OSS_EBPF_ROOT / "user" / "tracer.c"
+UPROBE_BASE = OSS_EBPF_ROOT / "kernel" / "uprobe_base.bpf.c"
+AI_AGENT_FILE_OPS = (
+    WORKSPACE_ROOT
+    / "deepflow-core"
+    / "agent"
+    / "src"
+    / "ebpf"
+    / "user"
+    / "extended"
+    / "bpf"
+    / "ai_agent_file_ops.bpf.c"
+)
+AI_AGENT_PERM_OPS = (
+    WORKSPACE_ROOT
+    / "deepflow-core"
+    / "agent"
+    / "src"
+    / "ebpf"
+    / "user"
+    / "extended"
+    / "bpf"
+    / "ai_agent_perm_ops.bpf.c"
+)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        print(message)
+        sys.exit(1)
+
+
+tracer_text = TRACER_C.read_text()
+uprobe_text = UPROBE_BASE.read_text()
+file_ops_text = AI_AGENT_FILE_OPS.read_text()
+perm_ops_text = AI_AGENT_PERM_OPS.read_text()
+
+require(
+    "ai_agent_submit_file_op_event(" in file_ops_text,
+    "AI Agent file-op BPF must expose a shared submit helper for TP/KPROBE reuse",
+)
+for symbol in (
+    "KPROG(__x64_sys_openat)",
+    "KPROG(__x64_sys_unlink)",
+    "KPROG(__x64_sys_unlinkat)",
+    "KPROG(__x64_sys_fchmodat)",
+    "KPROG(__x64_sys_chmod)",
+    "KPROG(__x64_sys_fchownat)",
+    "KPROG(__x64_sys_chown)",
+):
+    require(
+        symbol in file_ops_text,
+        f"missing AI Agent governance kprobe wrapper: {symbol}",
+    )
+
+require(
+    "ai_agent_submit_perm_event(" in perm_ops_text,
+    "AI Agent perm-op BPF must expose a shared submit helper for TP/KPROBE reuse",
+)
+for symbol in (
+    "KPROG(__x64_sys_setuid)",
+    "KPROG(__x64_sys_setgid)",
+    "KPROG(__x64_sys_setreuid)",
+    "KPROG(__x64_sys_setregid)",
+):
+    require(
+        symbol in perm_ops_text,
+        f"missing AI Agent governance kprobe wrapper: {symbol}",
+    )
+
+require(
+    "governance_tracepoint_fallback_probe_name(" in tracer_text,
+    "tracer.c must define governance tracepoint->kprobe fallback mapping",
+)
+require(
+    "governance_tracepoint_fallback_attach(" in tracer_text,
+    "tracer.c must attach governance kprobe fallback when tracepoint attach fails",
+)
+require(
+    "tracepoint/sched/sched_process_fork" in tracer_text,
+    "tracer.c fallback mapping must cover AI Agent fork governance tracepoint",
+)
+require(
+    "__x64_sys_unlink" in tracer_text
+    and '"kprobe/%s"' in tracer_text,
+    "tracer.c fallback mapping must resolve unlink governance kprobe target dynamically",
+)
+
+require(
+    "if (is_kprobe && ret > 0) {" in uprobe_text
+    and "ai_agent_on_fork(ctx, (__u32)tgid, (__u32)data.pid);" in uprobe_text,
+    "kernel_clone_exit() must propagate AI Agent fork state through shared kretprobe fallback",
+)
+
+print("[OK]")

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -681,6 +681,20 @@ static struct tracepoint *find_tracepoint_from_name(struct bpf_tracer *tracer,
 	return NULL;
 }
 
+static struct probe *find_probe_from_name(struct bpf_tracer *tracer,
+					  const char *name, bool isret)
+{
+	struct probe *p;
+
+	list_for_each_entry(p, &tracer->probes_head, list) {
+		if (p->type == KPROBE && p->isret == isret &&
+		    strcmp(p->name, name) == 0)
+			return p;
+	}
+
+	return NULL;
+}
+
 static struct kfunc *find_kfunc_from_name(struct bpf_tracer *tracer,
 					  const char *name)
 {
@@ -745,6 +759,190 @@ static struct kfunc *get_kfunc_from_tracer(struct bpf_tracer *tracer,
 	snprintf(p->name, sizeof(p->name), "%s", name);
 
 	return p;
+}
+
+static bool governance_tracepoint_fallback_probe_name(const char *tp_name,
+						      char *probe_name,
+						      size_t probe_name_sz,
+						      bool *isret)
+{
+	const char *const *symbols = NULL;
+	size_t symbols_nr = 0;
+
+	*isret = false;
+
+	if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_openat")) {
+		static const char *const candidates[] = {
+			"__x64_sys_openat", "__arm64_sys_openat", "sys_openat",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_unlinkat")) {
+		static const char *const candidates[] = {
+			"__x64_sys_unlinkat", "__arm64_sys_unlinkat",
+			"sys_unlinkat",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_unlink")) {
+		static const char *const candidates[] = {
+			"__x64_sys_unlink", "__arm64_sys_unlink", "sys_unlink",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_fchmodat")) {
+		static const char *const candidates[] = {
+			"__x64_sys_fchmodat", "__arm64_sys_fchmodat",
+			"sys_fchmodat",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_chmod")) {
+		static const char *const candidates[] = {
+			"__x64_sys_chmod", "__arm64_sys_chmod", "sys_chmod",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_fchownat")) {
+		static const char *const candidates[] = {
+			"__x64_sys_fchownat", "__arm64_sys_fchownat",
+			"sys_fchownat",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_chown")) {
+		static const char *const candidates[] = {
+			"__x64_sys_chown", "__arm64_sys_chown", "sys_chown",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_setuid")) {
+		static const char *const candidates[] = {
+			"__x64_sys_setuid", "__arm64_sys_setuid", "sys_setuid",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_setgid")) {
+		static const char *const candidates[] = {
+			"__x64_sys_setgid", "__arm64_sys_setgid", "sys_setgid",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_setreuid")) {
+		static const char *const candidates[] = {
+			"__x64_sys_setreuid", "__arm64_sys_setreuid",
+			"sys_setreuid",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else if (!strcmp(tp_name, "tracepoint/syscalls/sys_enter_setregid")) {
+		static const char *const candidates[] = {
+			"__x64_sys_setregid", "__arm64_sys_setregid",
+			"sys_setregid",
+		};
+		symbols = candidates;
+		symbols_nr = sizeof(candidates) / sizeof(candidates[0]);
+	} else {
+		return false;
+	}
+
+	for (size_t i = 0; i < symbols_nr; i++) {
+		if (!kallsyms_lookup_name(symbols[i]))
+			continue;
+
+		if (snprintf(probe_name, probe_name_sz, "kprobe/%s",
+			     symbols[i]) < 0) {
+			ebpf_warning("snprintf governance fallback probe failed.\n");
+			return false;
+		}
+		return true;
+	}
+
+	return false;
+}
+
+static int governance_fallback_probe_attach(struct bpf_tracer *tracer,
+					    const char *probe_name, bool isret)
+{
+	struct probe *probe = find_probe_from_name(tracer, probe_name, isret);
+	bool created = false;
+
+	if (!probe) {
+		probe = create_probe(tracer, probe_name, isret, KPROBE, NULL, true);
+		if (!probe)
+			return ETR_INVAL;
+		created = true;
+	}
+
+	int err = probe_attach(probe);
+	if (created && err && err != ETR_EXIST)
+		free_probe_from_tracer(probe);
+
+	return err;
+}
+
+static int governance_fork_fallback_attach(struct bpf_tracer *tracer)
+{
+	const char *const fork_symbols[] = {
+		"__x64_sys_fork", "__arm64_sys_fork", "sys_fork",
+	};
+	const char *const clone_symbols[] = {
+		"__x64_sys_clone", "__arm64_sys_clone", "sys_clone",
+	};
+	const char *const *groups[] = { fork_symbols, clone_symbols };
+	const size_t group_sizes[] = {
+		sizeof(fork_symbols) / sizeof(fork_symbols[0]),
+		sizeof(clone_symbols) / sizeof(clone_symbols[0]),
+	};
+	int attached = 0;
+
+	if (!is_pure_kprobe_ebpf() || !access(SYSCALL_FORK_TP_PATH, F_OK) ||
+	    !access(SYSCALL_CLONE_TP_PATH, F_OK))
+		return ETR_INVAL;
+
+	for (size_t group = 0; group < sizeof(groups) / sizeof(groups[0]);
+	     group++) {
+		for (size_t i = 0; i < group_sizes[group]; i++) {
+			char probe_name[PROBE_NAME_SZ];
+			int err;
+
+			if (!kallsyms_lookup_name(groups[group][i]))
+				continue;
+
+			if (snprintf(probe_name, sizeof(probe_name),
+				     "kretprobe/%s", groups[group][i]) < 0) {
+				ebpf_warning
+				    ("snprintf governance fork fallback probe failed.\n");
+				return ETR_INVAL;
+			}
+
+			err = governance_fallback_probe_attach(tracer, probe_name,
+							      true);
+			if (err == ETR_OK || err == ETR_EXIST) {
+				attached++;
+				break;
+			}
+		}
+	}
+
+	return attached > 0 ? ETR_OK : ETR_INVAL;
+}
+
+static int governance_tracepoint_fallback_attach(struct bpf_tracer *tracer,
+						 const char *tp_name)
+{
+	char probe_name[PROBE_NAME_SZ];
+	bool isret;
+
+	if (!strcmp(tp_name, "tracepoint/sched/sched_process_fork"))
+		return governance_fork_fallback_attach(tracer);
+
+	if (!governance_tracepoint_fallback_probe_name(tp_name, probe_name,
+						       sizeof(probe_name),
+						       &isret))
+		return ETR_INVAL;
+
+	return governance_fallback_probe_attach(tracer, probe_name, isret);
 }
 
 void add_probe_to_tracer(struct probe *pb)
@@ -1180,6 +1378,17 @@ int tracer_hooks_process(struct bpf_tracer *tracer, enum tracer_hook_type type,
 			continue;
 
 		if (error) {
+			if (type == HOOK_ATTACH) {
+				int fallback_err =
+				    governance_tracepoint_fallback_attach(tracer,
+									 tp->name);
+				if (fallback_err == ETR_OK ||
+				    fallback_err == ETR_EXIST) {
+				ebpf_info("attach tracepoint: '%s', fallback to governance kprobe succeed!",
+					  tp->name);
+				continue;
+				}
+			}
 			ebpf_info("%s tracepoint: '%s', failed!",
 				  type == HOOK_ATTACH ? "attach" : "detach",
 				  tp->name);


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


