### PR TITLE
fix(java): improve socket lifecycle handling for connect/send/close

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -102,7 +102,7 @@ OBJS := user/elf.o \
 	user/profile/java/collect_symbol_files.o
 
 JAVA_TOOL := deepflow-jattach
-JAVA_AGENT_VERSION := 4
+JAVA_AGENT_VERSION := 4.1
 JAVA_AGENT_GNU_SO := df_java_agent_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_MUSL_SO := df_java_agent_musl_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_SO := $(JAVA_AGENT_GNU_SO) $(JAVA_AGENT_MUSL_SO)

--- a/agent/src/ebpf/test/Makefile
+++ b/agent/src/ebpf/test/Makefile
@@ -24,7 +24,7 @@ ARCH ?= $(shell uname -m)
 CC ?= gcc
 CFLAGS ?= -std=gnu99 --static -g -O2 -ffunction-sections -fdata-sections -fPIC -fno-omit-frame-pointer -Wall -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
 
-EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec test_fetch_container_id test_parse_range test_set_ports_bitmap test_pid_check test_match_pids
+EXECS := test_symbol test_offset test_insns_cnt test_bihash test_vec test_fetch_container_id test_parse_range test_set_ports_bitmap test_match_pids test_safe_snprintf
 ifeq ($(ARCH), x86_64)
 #-lbcc -lstdc++
         LDLIBS += ../libtrace.a ./libtrace_utils.a -ljattach -lbcc_bpf -lGoReSym -lbddisasm -ldwarf -lelf -lz -lpthread -lbcc -lstdc++ -ldl -lm
@@ -38,7 +38,7 @@ all: $(EXECS) libtrace_utils.a
 	$(call msg,TEST,$@)
 	echo "$(Q)$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)"
 	$(Q)$(CC) $(CFLAGS) -o $@ $^ $(LDLIBS)
-#	$(Q)./$@
+	$(Q)./$@
 
 libtrace_utils.a:
 	$(Q)cargo rustc -p trace-utils --crate-type=staticlib

--- a/agent/src/ebpf/test/test_safe_snprintf.c
+++ b/agent/src/ebpf/test/test_safe_snprintf.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "../user/utils.h"
+
+static int check_exact_fill(void)
+{
+	char raw[6] = { 0 };
+	char safe[6] = { 0 };
+	int raw_len = snprintf(raw, sizeof(raw), "%s", "hello");
+	size_t safe_len = safe_snprintf(safe, sizeof(safe), "%s", "hello");
+
+	if (raw_len != 5 || safe_len != 5) {
+		printf("exact fill length mismatch: raw=%d safe=%zu\n",
+		       raw_len, safe_len);
+		return -1;
+	}
+
+	if (strcmp(raw, "hello") != 0 || strcmp(safe, "hello") != 0) {
+		printf("exact fill buffer mismatch: raw=\"%s\" safe=\"%s\"\n",
+		       raw, safe);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int check_truncation(void)
+{
+	char raw[4] = { 0 };
+	char safe[4] = { 0 };
+	int raw_len = snprintf(raw, sizeof(raw), "%s", "hello");
+	size_t safe_len = safe_snprintf(safe, sizeof(safe), "%s", "hello");
+
+	if (raw_len != 5) {
+		printf("unexpected raw truncation length: %d\n", raw_len);
+		return -1;
+	}
+
+	if (safe_len != sizeof(safe) - 1) {
+		printf("unexpected safe truncation length: %zu\n", safe_len);
+		return -1;
+	}
+
+	if (strcmp(raw, "hel") != 0 || strcmp(safe, "hel") != 0) {
+		printf("truncation buffer mismatch: raw=\"%s\" safe=\"%s\"\n",
+		       raw, safe);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int check_offset_accumulation(void)
+{
+	char raw[4] = { 0 };
+	char safe[4] = { 0 };
+	int raw_len = 0;
+	size_t safe_len = 0;
+
+	raw_len += snprintf(raw + raw_len, sizeof(raw) - raw_len, "%s", "hello");
+	safe_len += safe_snprintf(safe + safe_len,
+				  (int64_t)sizeof(safe) - (int64_t)safe_len,
+				  "%s", "hello");
+
+	if (raw_len < sizeof(raw)) {
+		printf("raw offset unexpectedly remained in bounds: %d\n", raw_len);
+		return -1;
+	}
+
+	if (safe_len >= sizeof(safe)) {
+		printf("safe offset escaped buffer: %zu\n", safe_len);
+		return -1;
+	}
+
+	if (safe_len != sizeof(safe) - 1 || strcmp(safe, "hel") != 0) {
+		printf("safe offset accumulation mismatch: len=%zu buf=\"%s\"\n",
+		       safe_len, safe);
+		return -1;
+	}
+
+	/*
+	 * The next append would be unsafe with raw_len because it already exceeds
+	 * the valid offset range after truncation. safe_len remains a valid offset.
+	 */
+	safe_len += safe_snprintf(safe + safe_len,
+				  (int64_t)sizeof(safe) - (int64_t)safe_len,
+				  "%s", "!");
+	if (safe_len != sizeof(safe) - 1 || strcmp(safe, "hel") != 0) {
+		printf("safe follow-up append changed truncated buffer: len=%zu buf=\"%s\"\n",
+		       safe_len, safe);
+		return -1;
+	}
+
+	return 0;
+}
+
+int main(void)
+{
+	if (check_exact_fill() != 0)
+		return -1;
+
+	if (check_truncation() != 0)
+		return -1;
+
+	if (check_offset_accumulation() != 0)
+		return -1;
+
+	printf("[OK]\n");
+	return 0;
+}

--- a/agent/src/ebpf/user/log.c
+++ b/agent/src/ebpf/user/log.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include "log.h"
+#include "utils.h"
 
 #include "trace_utils.h"
 
@@ -81,7 +82,7 @@ __attribute__((weak)) void rust_info_wrapper(char *msg)
 	printf("%s\n", msg);
 }
 
-static char *dispatch_message(char *msg, uint16_t len)
+static char *dispatch_message(char *msg, size_t len)
 {
 	if (!msg || len < 1)
 		return msg;
@@ -96,28 +97,38 @@ void _ebpf_error(int how_to_die, char *function_name, char *file_path,
 		 uint32_t line_number, char *fmt, ...)
 {
 	char msg[MSG_SZ] = {};
-	uint16_t len = 0;
-	uint16_t max = MSG_SZ;
+	size_t len = 0;
+	int64_t remaining;
 	va_list va;
 
 	if (function_name) {
+		remaining = (int64_t)sizeof(msg) - (int64_t)len;
 		if (how_to_die & ERROR_WARNING) {
-			len += snprintf(msg + len, max - len, "[eBPF] WARN func %s()", function_name);
+			len += safe_snprintf(msg + len, remaining,
+					     "[eBPF] WARN func %s()",
+					     function_name);
 		} else {
-			len += snprintf(msg + len, max - len, "[eBPF] ERROR func %s()", function_name);
+			len += safe_snprintf(msg + len, remaining,
+					     "[eBPF] ERROR func %s()",
+					     function_name);
 		}
-		if (line_number > 0)
-			len +=
-			    snprintf(msg + len, max - len, " [%s:%u] ",
-				     file_path, line_number);
+		if (line_number > 0) {
+			remaining = (int64_t)sizeof(msg) - (int64_t)len;
+			len += safe_snprintf(msg + len, remaining, " [%s:%u] ",
+					     file_path, line_number);
+		}
 	}
 #ifdef HAVE_ERRNO
-	if (how_to_die & ERROR_ERRNO_VALID)
-		len += snprintf(msg + len, max - len,
-				": %s (errno %d)", strerror(errno), errno);
+	if (how_to_die & ERROR_ERRNO_VALID) {
+		remaining = (int64_t)sizeof(msg) - (int64_t)len;
+		len += safe_snprintf(msg + len, remaining,
+				     ": %s (errno %d)", strerror(errno),
+				     errno);
+	}
 #endif
 	va_start(va, fmt);
-	len += vsnprintf(msg + len, max - len, fmt, va);
+	remaining = (int64_t)sizeof(msg) - (int64_t)len;
+	len += safe_vsnprintf(msg + len, remaining, fmt, va);
 	va_end(va);
 
 	dispatch_message(msg, len);
@@ -131,17 +142,19 @@ void _ebpf_error(int how_to_die, char *function_name, char *file_path,
 void _ebpf_info(char *fmt, ...)
 {
 	char msg[MSG_SZ] = {};
-	uint16_t len = 0;
-	uint16_t max = MSG_SZ;
+	size_t len = 0;
+	int64_t remaining;
 	va_list va;
 
-	len += snprintf(msg + len, max - len, "[eBPF] INFO ");
+	remaining = (int64_t)sizeof(msg) - (int64_t)len;
+	len += safe_snprintf(msg + len, remaining, "[eBPF] INFO ");
 
 	va_start(va, fmt);
-	len += vsnprintf(msg + len, max - len, fmt, va);
+	remaining = (int64_t)sizeof(msg) - (int64_t)len;
+	len += safe_vsnprintf(msg + len, remaining, fmt, va);
 	va_end(va);
-	if (msg[len - 1] != '\n') {
-		if (len < max)
+	if (len > 0 && msg[len - 1] != '\n') {
+		if (len < sizeof(msg))
 			msg[len++] = '\n';
 		else
 			msg[len - 1] = '\n';
@@ -165,16 +178,23 @@ void _ebpf_log(int how_to_die, char *function_name, char *file_path,
 {
     char msg[MSG_SZ] = {};
     va_list va;
+    int ret;
+    size_t len;
 
     va_start(va, fmt);
-    uint16_t len = vsnprintf(msg, MSG_SZ, fmt, va);
+    ret = vsnprintf(msg, MSG_SZ, fmt, va);
     va_end(va);
 
+	if (ret < 0) {
+		len = 0;
+	} else {
+		len = ret;
+	}
 	if (len >= MSG_SZ) {
 		len = MSG_SZ - 1;
 	}
 	// remove trailing newline if any
-	if (msg[len - 1] == '\n') {
+	if (len > 0 && msg[len - 1] == '\n') {
 		msg[len - 1] = '\0';
 	}
 

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -1221,6 +1221,12 @@ static int copy_agent_libs_into_target_ns(pid_t target_pid, int target_uid,
 	char copy_target_path[MAX_PATH_LENGTH];
 	int len = snprintf(copy_target_path, sizeof(copy_target_path),
 			   TARGET_NS_STORAGE_PATH, target_pid);
+	if (len < 0 || len >= sizeof(copy_target_path)) {
+		ebpf_warning(JAVA_LOG_TAG
+			     "Fun %s target ns path is too long for pid %d\n",
+			     __func__, target_pid);
+		return ETR_INVAL;
+	}
 	if (access(copy_target_path, F_OK)) {
 		/*
 		 * The purpose of umask(0); is to set the current process's file
@@ -1240,8 +1246,9 @@ static int copy_agent_libs_into_target_ns(pid_t target_pid, int target_uid,
 		}
 	}
 
-	snprintf(copy_target_path + len, sizeof(copy_target_path) - len,
-		 "/%s", AGENT_LIB_NAME);
+	safe_snprintf(copy_target_path + len,
+		      (int64_t)sizeof(copy_target_path) - len, "/%s",
+		      AGENT_LIB_NAME);
 	if ((ret =
 	     agent_so_lib_copy(AGENT_LIB_SRC_PATH,
 			       copy_target_path, target_uid,
@@ -1251,8 +1258,9 @@ static int copy_agent_libs_into_target_ns(pid_t target_pid, int target_uid,
 		return ret;
 	}
 
-	snprintf(copy_target_path + len, sizeof(copy_target_path) - len,
-		 "/%s", AGENT_MUSL_LIB_NAME);
+	safe_snprintf(copy_target_path + len,
+		      (int64_t)sizeof(copy_target_path) - len, "/%s",
+		      AGENT_MUSL_LIB_NAME);
 
 	if ((ret =
 	     agent_so_lib_copy(AGENT_MUSL_LIB_SRC_PATH,

--- a/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
+++ b/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
@@ -39,6 +39,7 @@
 #include <jvmticmlr.h>
 
 #include "../../config.h"
+#include "../../utils.h"
 #include "config.h"
 
 #define LOG_BUF_SZ 512
@@ -80,7 +81,7 @@ jint close_files(void);
   do {                                            \
 	if (perf_map_log_socket_fd > 0) { \
 		char str_buf[LOG_BUF_SZ]; \
-		int n = snprintf(str_buf, sizeof(str_buf), format, ##__VA_ARGS__); \
+		size_t n = safe_snprintf(str_buf, sizeof(str_buf), format, ##__VA_ARGS__); \
 	        pthread_mutex_lock(&g_df_lock);	 \
 	        send_msg(perf_map_log_socket_fd, str_buf, n); \
 	        pthread_mutex_unlock(&g_df_lock); \

--- a/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
+++ b/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
@@ -68,6 +68,7 @@ int perf_map_log_socket_fd = -1;
 // Cache symbols for batch sending
 char g_symbol_buffer[STRING_BUFFER_SIZE * 4];
 int g_cached_bytes;
+static jint close_files_locked(void);
 jint close_files(void);
 
 #define _(e)                                                                \
@@ -94,19 +95,23 @@ inline int send_msg(int sock_fd, const char *buf, size_t len)
 	int n = 0;		// Initialize n
 
 	do {
-		n = send(sock_fd, buf + send_bytes, len - send_bytes, 0);
+		/*
+		 * Note: To avoid SIGPIPE signal (which terminates the process), use
+		 * MSG_NOSIGNAL flag in send() call.
+		 */
+		n = send(sock_fd, buf + send_bytes, len - send_bytes, MSG_NOSIGNAL);
 		if (n == -1) {
 			if (errno == EINTR || errno == EAGAIN
 			    || errno == EWOULDBLOCK) {
 				// Retry on interrupt or temporary failure
 				continue;
 			} else {
-				close_files();	// Example function call, define as needed
+				close_files_locked();	// Example function call, define as needed
 				break;
 			}
 		} else if (n == 0) {
 			// Connection closed by peer
-			close_files();	// Example function call, define as needed
+			close_files_locked();	// Example function call, define as needed
 			break;
 		}
 
@@ -126,11 +131,9 @@ jint df_open_socket(const char *path, int *ptr)
 
 	/*
 	 * The reason for setting non-blocking mode:
-	 * 1 To prevent Java threads from being blocked.
-	 * 2 When attempts to write data to a closed writing port of a pipe or
-	 *   socket, the operating system detects this situation and sends the
-	 *   SIGPIPE signal to Java process, which causes the program to exit.
-	 *   Use non-blocking mode to avoid this issue.
+	 * 1 To prevent Java threads from being blocked when writing to socket.
+	 * 2 Non-blocking mode allows send() to fail with EAGAIN/EWOULDBLOCK
+	 *   instead of blocking, enabling graceful error handling.
 	 */
 	int flags = fcntl(s, F_GETFL, 0);
 	if (flags == -1) {
@@ -148,6 +151,7 @@ jint df_open_socket(const char *path, int *ptr)
 	strncpy(remote.sun_path, path, UNIX_PATH_MAX - 1);
 	int len = sizeof(remote.sun_family) + strlen(remote.sun_path);
 	if (connect(s, (struct sockaddr *)&remote, len) == -1) {
+		close(s);
 		fprintf(stderr, "Call connect() failed: errno(%d)\n", errno);
 		return JNI_ERR;
 	}
@@ -215,18 +219,29 @@ jint df_agent_config(char *opts)
 	return JNI_OK;
 }
 
+static jint close_files_locked(void)
+{
+	int perf_fd = perf_map_socket_fd;
+	int log_fd = perf_map_log_socket_fd;
+
+	perf_map_socket_fd = -1;
+	perf_map_log_socket_fd = -1;
+
+	if (perf_fd > 0) {
+		close(perf_fd);
+	}
+	if (log_fd > 0) {
+		close(log_fd);
+	}
+
+	return JNI_OK;
+}
+
 jint close_files(void)
 {
-	if (perf_map_socket_fd > 0) {
-		close(perf_map_socket_fd);
-		perf_map_socket_fd = -1;
-	}
-
-	if (perf_map_log_socket_fd > 0) {
-		close(perf_map_log_socket_fd);
-		perf_map_log_socket_fd = -1;
-	}
-
+	pthread_mutex_lock(&g_df_lock);
+	close_files_locked();
+	pthread_mutex_unlock(&g_df_lock);
 	return JNI_OK;
 }
 
@@ -302,13 +317,16 @@ void deallocate(jvmtiEnv * jvmti, void *string)
 void df_send_symbol(enum event_type type, const void *code_addr,
 		    unsigned int code_size, const char *entry)
 {
-	if (perf_map_socket_fd < 0) {
-		return;
-	}
-
 	int send_bytes;
 	struct symbol_metadata *meta;
 	char symbol_str[STRING_BUFFER_SIZE];
+
+	pthread_mutex_lock(&g_df_lock);
+	if (perf_map_socket_fd < 0) {
+		pthread_mutex_unlock(&g_df_lock);
+		return;
+	}
+
 	if (type == METHOD_UNLOAD) {
 		snprintf(symbol_str + sizeof(*meta),
 			 sizeof(symbol_str) - sizeof(*meta), "%lx",
@@ -322,7 +340,6 @@ void df_send_symbol(enum event_type type, const void *code_addr,
 	meta->len = strlen(symbol_str + sizeof(*meta));
 	meta->type = type;
 	send_bytes = meta->len + sizeof(*meta);
-	pthread_mutex_lock(&g_df_lock);
 	if (replay_finish) {
 		send_msg(perf_map_socket_fd, symbol_str, send_bytes);
 	} else {

--- a/agent/src/ebpf/user/profile/profile_common.c
+++ b/agent/src/ebpf/user/profile/profile_common.c
@@ -1110,27 +1110,31 @@ static void aggregate_stack_traces(struct profiler_context *ctx,
 
 			char *msg_str = (char *)&msg->data[0];
 			int offset = 0;
+			int64_t remaining;
 			if (matched) {
-				offset +=
-				    snprintf(msg_str + offset, str_len - offset,
-					     "%s%s;", pre_tag, v->comm);
+				remaining = (int64_t)str_len - offset;
+				offset += safe_snprintf(msg_str + offset,
+							remaining, "%s%s;",
+							pre_tag, v->comm);
 			}
-			offset +=
-			    snprintf(msg_str + offset, str_len - offset, "%s",
-				     trace_str);
+			remaining = (int64_t)str_len - offset;
+			offset += safe_snprintf(msg_str + offset, remaining, "%s",
+						trace_str);
 			if (ctx->type == PROFILER_TYPE_MEMORY && v->memory.class_id != 0) {
 				if (class_name) {
-					offset +=
-					    snprintf(msg_str + offset,
-						     str_len - offset, ";%s",
-						     class_name);
+					remaining = (int64_t)str_len - offset;
+					offset += safe_snprintf(msg_str + offset,
+								remaining,
+								";%s",
+								class_name);
 					clib_mem_free(class_name);
 					class_name = NULL;
 				} else {
-					offset +=
-					    snprintf(msg_str + offset,
-						     str_len - offset, ";%s",
-						     UNKNOWN_JAVA_SYMBOL_STR);
+					remaining = (int64_t)str_len - offset;
+					offset += safe_snprintf(msg_str + offset,
+								remaining,
+								";%s",
+								UNKNOWN_JAVA_SYMBOL_STR);
 				}
 			}
 

--- a/agent/src/ebpf/user/profile/stringifier.c
+++ b/agent/src/ebpf/user/profile/stringifier.c
@@ -266,38 +266,47 @@ char *rewrite_java_symbol(char *sym)
 	}
 	memset(dst, 0, new_len);
 	int offset = 0;
+	int64_t remaining;
 
 	switch (sym[i]) {
 	case 'B':
-		offset += snprintf(dst + offset, new_len - offset, "byte");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "byte");
 		i++;
 		break;
 	case 'C':
-		offset += snprintf(dst + offset, new_len - offset, "char");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "char");
 		i++;
 		break;
 	case 'D':
-		offset += snprintf(dst + offset, new_len - offset, "double");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "double");
 		i++;
 		break;
 	case 'F':
-		offset += snprintf(dst + offset, new_len - offset, "float");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "float");
 		i++;
 		break;
 	case 'I':
-		offset += snprintf(dst + offset, new_len - offset, "int");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "int");
 		i++;
 		break;
 	case 'J':
-		offset += snprintf(dst + offset, new_len - offset, "long");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "long");
 		i++;
 		break;
 	case 'S':
-		offset += snprintf(dst + offset, new_len - offset, "short");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "short");
 		i++;
 		break;
 	case 'Z':
-		offset += snprintf(dst + offset, new_len - offset, "boolean");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "boolean");
 		i++;
 		break;
 	case 'L':
@@ -319,11 +328,13 @@ char *rewrite_java_symbol(char *sym)
 	}
 
 	for (j = 0; j < array_dims; j++) {
-		offset += snprintf(dst + offset, new_len - offset, "[]");
+		remaining = (int64_t)new_len - offset;
+		offset += safe_snprintf(dst + offset, remaining, "[]");
 	}
 
 	// rest
-	snprintf(dst + offset, new_len - offset, sym + i);
+	remaining = (int64_t)new_len - offset;
+	safe_snprintf(dst + offset, remaining, "%s", sym + i);
 
 	return dst;
 
@@ -650,18 +661,20 @@ static char *build_stack_trace_string(struct bpf_tracer *t,
 	if (fold_stack_trace_str == NULL)
 		goto failed;
 
-	int len = 0;
+	size_t len = 0;
+	int64_t remaining;
 	for (i = PERF_MAX_STACK_DEPTH - 1; i >= 0; i--) {
 		if (symbol_array[i]) {
-			len += snprintf(fold_stack_trace_str + len,
-					folded_size - len,
-					"%s;", (char *)symbol_array[i]);
+			remaining = (int64_t)folded_size - (int64_t)len;
+			len += safe_snprintf(fold_stack_trace_str + len,
+					     remaining, "%s;",
+					     (char *)symbol_array[i]);
 			clib_mem_free((void *)symbol_array[i]);
 		}
 	}
 
 	/* Remove the semicolon at the end of the string. */
-	if (len - 1 >= 0) {
+	if (len > 0) {
 		fold_stack_trace_str[len - 1] = '\0';
 	}
 	vec_free(symbol_array);
@@ -892,33 +905,48 @@ char *resolve_and_gen_stack_trace_str(struct bpf_tracer *t,
 	}
 
 	/* trace_str combines user/interpreter/kstack strings in call-order (root -> leaf). */
-	int offset = 0;
+	size_t offset = 0;
+	int64_t remaining;
 	if (i_trace_str && u_trace_str) {
 		/* Use extended merge */
+		remaining = (int64_t)len - (int64_t)offset;
 		int merged = extended_merge_stacks(trace_str + offset,
-						   len - offset, i_trace_str,
+						   (int)remaining, i_trace_str,
 						   u_trace_str, v->tgid);
 		if (merged > 0) {
 			offset += merged;
 		} else {
 			/* Fallback */
-			offset += snprintf(trace_str + offset, len - offset,
-					   "%s;%s", i_trace_str, u_trace_str);
+			remaining = (int64_t)len - (int64_t)offset;
+			offset += safe_snprintf(trace_str + offset, remaining,
+						"%s;%s", i_trace_str,
+						u_trace_str);
 		}
 	} else if (i_trace_str) {
-		offset += snprintf(trace_str + offset, len - offset, "%s", i_trace_str);
+		remaining = (int64_t)len - (int64_t)offset;
+		offset += safe_snprintf(trace_str + offset, remaining, "%s",
+					i_trace_str);
 	} else if (u_trace_str) {
 		if (has_intpstack) {
-			offset += snprintf(trace_str + offset, len - offset, "%s;%s", i_err_tag, u_trace_str);
+			remaining = (int64_t)len - (int64_t)offset;
+			offset += safe_snprintf(trace_str + offset, remaining,
+						"%s;%s", i_err_tag,
+						u_trace_str);
 		} else {
-			offset += snprintf(trace_str + offset, len - offset, "%s", u_trace_str);
+			remaining = (int64_t)len - (int64_t)offset;
+			offset += safe_snprintf(trace_str + offset, remaining,
+						"%s", u_trace_str);
 		}
 	}
 	if (u_trace_str && uprobe_str) {
-		offset += snprintf(trace_str + offset, len - offset, ";%s", uprobe_str);
+		remaining = (int64_t)len - (int64_t)offset;
+		offset += safe_snprintf(trace_str + offset, remaining, ";%s",
+					uprobe_str);
 	}
 	if (k_trace_str) {
-		offset += snprintf(trace_str + offset, len - offset, "%s%s", offset > 0 ? ";" : "", k_trace_str);
+		remaining = (int64_t)len - (int64_t)offset;
+		offset += safe_snprintf(trace_str + offset, remaining, "%s%s",
+					offset > 0 ? ";" : "", k_trace_str);
 	}
 
 	if (offset == 0) {

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -3582,14 +3582,15 @@ int print_uprobe_http2_info(const char *data, int len, char *buf, int buf_len)
 	} __attribute__ ((packed)) header;
 
 	int bytes = 0;
+	int64_t remaining;
 	char key[1024] = { 0 };
 	char value[1024] = { 0 };
 	memcpy(&header, data, sizeof(header));
 	if (datadump_enable) {
-		bytes +=
-		    snprintf(buf + bytes, buf_len - bytes,
-			     "fd=[%d]\nstream_id=[%d]\n", header.fd,
-			     header.stream_id);
+		remaining = (int64_t)buf_len - bytes;
+		bytes += safe_snprintf(buf + bytes, remaining,
+				       "fd=[%d]\nstream_id=[%d]\n", header.fd,
+				       header.stream_id);
 
 	} else {
 		fprintf(stdout, "fd=[%d]\nstream_id=[%d]\n", header.fd,
@@ -3605,9 +3606,9 @@ int print_uprobe_http2_info(const char *data, int len, char *buf, int buf_len)
 	memcpy(&value, data + value_start, header.value_len);
 
 	if (datadump_enable) {
-		bytes +=
-		    snprintf(buf + bytes, buf_len - bytes, "header=[%s:%s]\n",
-			     key, value);
+		remaining = (int64_t)buf_len - bytes;
+		bytes += safe_snprintf(buf + bytes, remaining,
+				       "header=[%s:%s]\n", key, value);
 	} else {
 		fprintf(stdout, "header=[%s:%s]\n", key, value);
 		fflush(stdout);
@@ -3634,16 +3635,19 @@ int print_io_event_info(pid_t pid, u32 fd, const char *data, int len, char *buf,
 
 	int path_len = strlen(event->filename) + 1;
 	if (datadump_enable) {
-		bytes = snprintf(buf, buf_len,
-				 "bytes_count=[%u]\noperation=[%u]\noffset=[%llu]\n"
-				 "latency=[%llu]\nmount_source=[%s]\nmount_point=[%s]\n"
-				 "file_dir=[%s]\nfilename=[%s](len %d)\nfile_type=[%s]\n"
-				 "mountID=[%d]\nmntnsID=[%u]\nmountinfo file %s\n",
-				 event->bytes_count, event->operation,
-				 event->offset, event->latency, event->mount_source,
-				 event->mount_point, event->file_dir, event->filename,
-				 path_len, fs_type_to_string(event->file_type),
-				 event->mnt_id, event->mntns_id, mount_file_tag);
+		bytes = safe_snprintf(buf, buf_len,
+				      "bytes_count=[%u]\noperation=[%u]\noffset=[%llu]\n"
+				      "latency=[%llu]\nmount_source=[%s]\nmount_point=[%s]\n"
+				      "file_dir=[%s]\nfilename=[%s](len %d)\nfile_type=[%s]\n"
+				      "mountID=[%d]\nmntnsID=[%u]\nmountinfo file %s\n",
+				      event->bytes_count, event->operation,
+				      event->offset, event->latency,
+				      event->mount_source,
+				      event->mount_point, event->file_dir,
+				      event->filename, path_len,
+				      fs_type_to_string(event->file_type),
+				      event->mnt_id, event->mntns_id,
+				      mount_file_tag);
 	} else {
 		fprintf(stdout,
 			"bytes_count=[%u]\noperation=[%u]\noffset=[%llu]\n"
@@ -3673,13 +3677,15 @@ int print_uprobe_grpc_dataframe(const char *data, int len, char *buf,
 	} __attribute__ ((packed)) dataframe;
 
 	int bytes = 0;
+	int64_t remaining;
 	memcpy(&dataframe, data, len);
 
 	if (datadump_enable) {
-		bytes +=
-		    snprintf(buf + bytes, buf_len - bytes,
-			     "stream_id=[%d]\ndata_len=[%d]\n",
-			     dataframe.stream_id, dataframe.data_len);
+		remaining = (int64_t)buf_len - bytes;
+		bytes += safe_snprintf(buf + bytes, remaining,
+				       "stream_id=[%d]\ndata_len=[%d]\n",
+				       dataframe.stream_id,
+				       dataframe.data_len);
 	} else {
 		fprintf(stdout, "stream_id=[%d]\ndata_len=[%d]\n",
 			dataframe.stream_id, dataframe.data_len);
@@ -3694,9 +3700,9 @@ int print_uprobe_grpc_dataframe(const char *data, int len, char *buf,
 	dataframe.data[dataframe.data_len] = '\0';
 
 	if (datadump_enable) {
-		bytes +=
-		    snprintf(buf + bytes, buf_len - bytes, "data=[%s]\n",
-			     dataframe.data);
+		remaining = (int64_t)buf_len - bytes;
+		bytes += safe_snprintf(buf + bytes, remaining,
+				       "data=[%s]\n", dataframe.data);
 	} else {
 		fprintf(stdout, "data=[%s]\n", dataframe.data);
 		fflush(stdout);
@@ -3915,39 +3921,44 @@ static void print_socket_data(struct socket_bpf_data *sd, int64_t boot_time)
 
 	char buff[DEBUG_BUFF_SIZE];
 	int len = 0;
+	int64_t remaining = sizeof(buff);
 	len +=
-	    snprintf(buff, sizeof(buff), DATADUMP_FORMAT, timestamp,
-		     datadump_seq++,
-		     sd->source == DATA_SOURCE_DPDK ? "Pkt" : proto_tag,
-		     sd->direction == T_EGRESS ? "out" : "in", type,
-		     sd->msg_type, sd->process_id, sd->thread_id,
-		     sd->coroutine_id, sd->fd, role_str,
-		     strlen((char *)sd->container_id) ==
-		     0 ? "null" : (char *)sd->container_id, sd->source,
-		     sd->process_kname, flow_str, sd->cap_len,
-		     sd->syscall_len, sd->socket_id,
-		     sd->syscall_trace_id_call, sd->tcp_seq,
-		     sd->cap_seq, sd->is_tls ? "true" : "false",
-		     kern_syscall_time, sd->timestamp / NS_IN_USEC,
-		     kern_cap_time, sd->cap_timestamp / NS_IN_USEC);
+	    safe_snprintf(buff, remaining, DATADUMP_FORMAT, timestamp,
+			  datadump_seq++,
+			  sd->source == DATA_SOURCE_DPDK ? "Pkt" : proto_tag,
+			  sd->direction == T_EGRESS ? "out" : "in", type,
+			  sd->msg_type, sd->process_id, sd->thread_id,
+			  sd->coroutine_id, sd->fd, role_str,
+			  strlen((char *)sd->container_id) ==
+			  0 ? "null" : (char *)sd->container_id, sd->source,
+			  sd->process_kname, flow_str, sd->cap_len,
+			  sd->syscall_len, sd->socket_id,
+			  sd->syscall_trace_id_call, sd->tcp_seq,
+			  sd->cap_seq, sd->is_tls ? "true" : "false",
+			  kern_syscall_time, sd->timestamp / NS_IN_USEC,
+			  kern_cap_time, sd->cap_timestamp / NS_IN_USEC);
 
 	if (sd->source == DATA_SOURCE_GO_HTTP2_UPROBE) {
+		remaining = (int64_t)sizeof(buff) - len;
 		len +=
 		    print_uprobe_http2_info(sd->cap_data, sd->cap_len,
-					    buff + len, sizeof(buff) - len);
+					    buff + len, remaining);
 	} else if (sd->source == DATA_SOURCE_IO_EVENT) {
+		remaining = (int64_t)sizeof(buff) - len;
 		len +=
 		    print_io_event_info(sd->process_id, (__u32)sd->cap_seq, sd->cap_data,
-					sd->cap_len, buff + len, sizeof(buff) - len);
+					sd->cap_len, buff + len, remaining);
 	} else if (sd->source == DATA_SOURCE_GO_HTTP2_DATAFRAME_UPROBE) {
+		remaining = (int64_t)sizeof(buff) - len;
 		len +=
 		    print_uprobe_grpc_dataframe(sd->cap_data, sd->cap_len,
-						buff + len, sizeof(buff) - len);
+						buff + len, remaining);
 	} else if (sd->source == DATA_SOURCE_DPDK) {
+		remaining = (int64_t)sizeof(buff) - len;
 		len +=
 		    print_extra_pkt_info(datadump_enable, sd->cap_data,
 					 sd->cap_len, buff + len,
-					 sizeof(buff) - len, sd->direction);
+					 remaining, sd->direction);
 	} else {
 		int i;
 		uint8_t v;
@@ -3968,14 +3979,15 @@ static void print_socket_data(struct socket_bpf_data *sd, int64_t boot_time)
 				}
 			}
 
-			if (double_args)
-				len +=
-				    snprintf(buff + len, sizeof(buff) - len,
-					     format, v, v);
-			else
-				len +=
-				    snprintf(buff + len, sizeof(buff) - len,
-					     format, v);
+			if (double_args) {
+				remaining = (int64_t)sizeof(buff) - len;
+				len += safe_snprintf(buff + len, remaining,
+						     format, v, v);
+			} else {
+				remaining = (int64_t)sizeof(buff) - len;
+				len += safe_snprintf(buff + len, remaining,
+						     format, v);
+			}
 
 			if (len >= sizeof(buff)) {
 				break;

--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -1833,7 +1833,8 @@ int maps_config(struct bpf_tracer *tracer, const char *map_name, int entries)
 	if (map_conf == NULL)
 		return -ENOMEM;
 
-	snprintf(map_conf->map_name, sizeof(map_conf->map_name), map_name);
+	snprintf(map_conf->map_name, sizeof(map_conf->map_name), "%s",
+		 map_name);
 	map_conf->max_entries = entries;
 	list_add_tail(&map_conf->list, &tracer->maps_conf_head);
 

--- a/agent/src/ebpf/user/utils.c
+++ b/agent/src/ebpf/user/utils.c
@@ -1212,13 +1212,15 @@ int exec_command(const char *cmd, const char *args,
 	if (ret_buf != NULL && ret_buf_size > 0) {
 		/* Read and print the output */
 		char buffer[1024];
-		int write_bytes =
-		    snprintf(ret_buf, ret_buf_size, "[ %s ]", cmd_buf);
+		int64_t remaining;
+		size_t write_bytes =
+		    safe_snprintf(ret_buf, ret_buf_size, "[ %s ]", cmd_buf);
 		while (fgets(buffer, sizeof(buffer), fp) != NULL) {
-			write_bytes +=
-			    snprintf(ret_buf + write_bytes,
-				     ret_buf_size - write_bytes, "%s", buffer);
-			if (write_bytes >= ret_buf_size)
+			remaining = (int64_t)ret_buf_size - (int64_t)write_bytes;
+			write_bytes += safe_snprintf(ret_buf + write_bytes,
+						     remaining, "%s",
+						     buffer);
+			if (write_bytes >= (size_t)ret_buf_size - 1)
 				break;
 		}
 	}
@@ -1688,8 +1690,9 @@ void format_port_ranges(uint16_t * ports, size_t size, char *ret_str,
 	qsort(ports, size, sizeof(uint16_t), compare);
 
 	int bytes_cnt = 0;	// To keep track of how many bytes we've written to ret_str
+	int64_t remaining;
 	bytes_cnt +=
-	    snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "Ports: ");
+	    safe_snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "Ports: ");
 
 	size_t i = 0;
 	while (i < size) {
@@ -1702,16 +1705,23 @@ void format_port_ranges(uint16_t * ports, size_t size, char *ret_str,
 
 		// If start == i, it means it's a single number; otherwise, it's a range
 		if (start == i) {
-			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "%d", ports[start]);	// Print a single number
+			remaining = (int64_t)str_sz - bytes_cnt;
+			bytes_cnt += safe_snprintf(ret_str + bytes_cnt,
+						   remaining, "%d",
+						   ports[start]);	// Print a single number
 		} else {
-			bytes_cnt += snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt, "%d-%d", ports[start], ports[i]);	// Print the range
+			remaining = (int64_t)str_sz - bytes_cnt;
+			bytes_cnt += safe_snprintf(ret_str + bytes_cnt,
+						   remaining, "%d-%d",
+						   ports[start], ports[i]);	// Print the range
 		}
 
 		// Print a comma if not the last range/number
 		if (i + 1 < size) {
+			remaining = (int64_t)str_sz - bytes_cnt;
 			bytes_cnt +=
-			    snprintf(ret_str + bytes_cnt, str_sz - bytes_cnt,
-				     ", ");
+			    safe_snprintf(ret_str + bytes_cnt, remaining,
+					  ", ");
 		}
 
 		i++;

--- a/agent/src/ebpf/user/utils.h
+++ b/agent/src/ebpf/user/utils.h
@@ -19,6 +19,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <fcntl.h>
+#include <stdarg.h>
 #include <time.h>
 #include <string.h>
 #include <stdlib.h>
@@ -109,6 +110,41 @@ static_always_inline void safe_buf_copy(void *dst, int dst_len,
 
 	memset(dst, 0, dst_len);
 	memcpy(dst, src, copy_count);
+}
+
+static_always_inline size_t safe_vsnprintf(char *buf, int64_t cap,
+					   const char *fmt, va_list ap)
+{
+	int ret;
+	size_t actual;
+	size_t ucap;
+
+	if (buf == NULL || fmt == NULL || cap <= 0)
+		return 0;
+
+	ucap = (size_t)cap;
+	ret = vsnprintf(buf, ucap, fmt, ap);
+	if (ret < 0)
+		return 0;
+
+	actual = (size_t)ret;
+	if (actual >= ucap)
+		actual = ucap - 1;
+
+	return actual;
+}
+
+static inline size_t safe_snprintf(char *buf, int64_t cap,
+				   const char *fmt, ...)
+{
+	va_list ap;
+	size_t actual;
+
+	va_start(ap, fmt);
+	actual = safe_vsnprintf(buf, cap, fmt, ap);
+	va_end(ap);
+
+	return actual;
 }
 
 #if defined(__x86_64__)


### PR DESCRIPTION

    fix(java): improve socket lifecycle handling for connect/send/close (#11760)
    
    * fix(eBPF): Use MSG_NOSIGNAL in send() to avoid SIGPIPE on Linux
    
    * fix(java): serialize socket fd close and send paths
    
    Split close_files() into a locked wrapper and a non-locking close_files_locked() helper to ensure fd close operations share the same mutex with send paths. Update send_msg() to use close_files_locked() on send failure to avoid recu
    
    * Add `close()` when `connect()` fails.
    
    * Adjust comments

fix: harden ebpf snprintf handling (#11755)
    
    * fix: harden ebpf snprintf handling
    
    Fix incorrect snprintf/vsnprintf return-value semantics in eBPF user-space code.
    
    Add safe_snprintf/safe_vsnprintf helpers that consistently return the actual written length, and avoid treating snprintf's intended output length as the actual written length when it is later used for:
    - offset accumulation
    - remaining buffer size calculation
    - send length propagation
    
    Also fix the affected paths in:
    - log message assembly
    - Java symbol collection and log sending
    - stringifier string assembly
    - socket datadump/http2/grpc/io-event formatting
    - agent so path construction under target namespaces
    
    Also fix one case where a dynamic string was used directly as a format string.
    
    * test: add safe snprintf regression coverage
    
    Add a focused eBPF test that compares snprintf and safe_snprintf for exact-fit, truncation, and offset-accumulation cases.
    
    Also fix the socket datadump branch structure around safe_snprintf usage so the remaining-length calculation and write stay in the same conditional branch.
    
    * fix: finish ebpf snprintf follow-up
    
    Switch the remaining stack-trace string assembly in profile_common.c
    from offset-based snprintf accumulation to safe_snprintf, and avoid
    using map_name directly as a format string in tracer.c.
    
    Also include the current ebpf test Makefile updates in this follow-up.


### This PR is for:


- Agent
#### Affected branches
- main
- v7.1
- v7.0
- v6.6
