### PR TITLE
fix(server): fix http response body resource leak in master controller forwarder

### DIFF
--- a/server/controller/http/router/common/controller.go
+++ b/server/controller/http/router/common/controller.go
@@ -58,6 +58,7 @@ func ForwardMasterController(c *gin.Context, masterControllerName string, port i
 		c.Abort()
 		return
 	}
+	defer resp.Body.Close()
 
 	c.DataFromReader(resp.StatusCode, resp.ContentLength, resp.Header.Get("Content-Type"), resp.Body, make(map[string]string))
 }


### PR DESCRIPTION
### Background and Problem / 背景与问题

**Chinese:**
在多控制器部署架构中，控制器的 HTTP 路由转发模块（`ForwardMasterController`）负责将 API 请求转发至主控制器。
在当前的实现中，通过 `http.DefaultClient.Do(req)` 发起 HTTP 请求后，直接将响应体 `resp.Body` 传递给了 Gin 框架的 `c.DataFromReader()` 处理：
```go
c.DataFromReader(resp.StatusCode, resp.ContentLength, resp.Header.Get("Content-Type"), resp.Body, make(map[string]string))