### PR TITLE
fix: l7 metrics is empty

### DIFF
--- a/agent/src/collector/l7_quadruple_generator.rs
+++ b/agent/src/collector/l7_quadruple_generator.rs
@@ -187,6 +187,7 @@ impl SubQuadGen {
 
         self.batch_buffer.clear();
         for (_, mut flow_meters) in stash.meters.drain() {
+            flow_meters.retain(|meter| !meter.app_meter.is_empty());
             while flow_meters.len() >= QUEUE_BATCH_SIZE {
                 self.batch_buffer
                     .extend(flow_meters.drain(..QUEUE_BATCH_SIZE));


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

###  fix: l7 metrics is empty
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 6.6
- 7.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


