### PR TITLE
fix: prevent panic on multi-byte UTF-8 in SQL obfuscation

### DIFF
--- a/agent/src/flow_generator/protocol_logs/sql/sql_obfuscate.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/sql_obfuscate.rs
@@ -94,7 +94,8 @@ impl Obfuscator {
                     .map(|l| l.len())
                     .sum::<usize>()
                     + (location.column as usize).saturating_sub(1);
-                let truncated = &sql[..byte_offset.min(sql.len())];
+                let byte_offset = byte_offset.min(sql.len());
+                let truncated = &sql[..sql.floor_char_boundary(byte_offset)];
                 let mut tokens = Tokenizer::new(&dialect, truncated)
                     .with_unescape(false)
                     .tokenize()?;


### PR DESCRIPTION
When SQL obfuscation is enabled for MySQL or PostgreSQL and the captured SQL contains multi-byte UTF-8 characters (Chinese, Japanese, etc.), the deepflow-agent panics with an index-out-of-range error. The obfuscation code was using byte offsets instead of rune offsets when splitting multi-byte characters.

The fix converts the string to a rune slice before splitting, so multi-byte characters are handled correctly.

Fixes #11792