### PR TITLE
fix(eBPF): enforce reassembly path when MySQL reassembly is enabled

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -783,6 +783,30 @@ static __inline enum message_type infer_mysql_message(const char *buf,
 	bool is_mysqld = is_current_comm("mysqld");
 	if (is_socket_info_valid(conn_info->socket_info_ptr)) {
 		/*
+		 * When MySQL reassembly is enabled, all related traffic must be forced into
+		 * the reassembly processing pipeline.
+		 *
+		 * Otherwise, under a single-packet-based protocol detection model, the
+		 * detection capability is limited, and consecutive same-direction packets may
+		 * be incorrectly identified as complete MySQL requests or responses.
+		 *
+		 * In such cases, these packets will continue to be parsed as valid MySQL
+		 * traffic, and MSG_UNKNOWN will not be returned, thus preventing entry into
+		 * the reassembly process.
+		 *
+		 * This leads to behavior inconsistent with expectations, since correct
+		 * reassembly logic relies on returning MSG_UNKNOWN for incomplete packets in
+		 * order to trigger reassembly.
+		 *
+		 * The goal of this design is to ensure that, when reassembly is enabled,
+		 * consecutive same-direction data is not reported as independent complete
+		 * MySQL messages (requests or responses).
+		 */
+		if (conn_info->enable_reasm) {
+			return MSG_UNKNOWN;
+		}
+
+		/*
 		 * Ensure the authentication response packet is captured
 		 * and distinguish it based on the 5th byte (Payload start):  
 		 *


### PR DESCRIPTION
When MySQL reassembly is enabled, force all related traffic into the reassembly pipeline. Otherwise, single-packet protocol inference may misidentify consecutive same-direction packets as complete MySQL requests or responses.

This could lead to MSG_UNKNOWN not being returned, preventing the reassembly logic from being triggered and causing incorrect parsing behavior.

Ensure same-direction continuous data is not prematurely treated as independent complete MySQL messages when reassembly is enabled.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

### Affected branches


- v6.6

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


