### PR TITLE
fix(ebpf): relax MySQL split header length check

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -768,17 +768,24 @@ static __inline enum message_type infer_mysql_message(const char *buf,
 
 	if (conn_info->prev_count == 4) {
 		len = *(__u32 *) conn_info->prev_buf & 0x00ffffff;
-		if (len == count) {
-			seq = conn_info->prev_buf[3];
-			count += 4;
-			com = buf[0];
-			point_1 = buf[2];
-			point_2 = buf[4];
-		}
+		seq = conn_info->prev_buf[3];
+		count += 4;
+		com = buf[0];
+		point_1 = buf[2];
+		point_2 = buf[4];
 	}
 
 	if (count < 5 || len == 0)
 		return MSG_UNKNOWN;
+
+	/*
+	 * To prevent stale data from a previous map value remaining in
+	 * the unused portion of `__infer_buf->data` when the current
+	 * syscall provides fewer than 9 bytes of actual data.
+	 */
+	if (count < 9) {
+		point_1 = point_2 = 0;
+	}
 
 	bool is_mysqld = is_current_comm("mysqld");
 	if (is_socket_info_valid(conn_info->socket_info_ptr)) {


### PR DESCRIPTION
When MySQL packet header is read separately, prev_count == 4 means the 4-byte MySQL header has already been cached and the current buffer starts from the payload.

The packet payload length in the MySQL header does not necessarily equal the current syscall read/write length. Requiring len == count may cause valid split packets to skip MySQL inference.

Remove this strict check and always parse seq from the cached header and command bytes from the current payload buffer in the prev_count == 4 path. The later full packet length validation is still kept for initial protocol confirmation.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

### Affected branches
- v6.6
<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


