### PR TITLE
fix(ingester): clear pooled string slices before reuse

### DIFF
--- a/server/ingester/app_log/dbwriter/log.go
+++ b/server/ingester/app_log/dbwriter/log.go
@@ -305,8 +305,17 @@ func ReleaseApplicationLogStore(l *ApplicationLogStore) {
 	if l == nil || l.SubReferenceCount() {
 		return
 	}
+	for i := range l.AttributeNames {
+		l.AttributeNames[i] = ""
+	}
 	attributeNames := l.AttributeNames[:0]
+	for i := range l.AttributeValues {
+		l.AttributeValues[i] = ""
+	}
 	attributeValues := l.AttributeValues[:0]
+	for i := range l.MetricsNames {
+		l.MetricsNames[i] = ""
+	}
 	metricsNames := l.MetricsNames[:0]
 	metricsValues := l.MetricsValues[:0]
 	*l = ApplicationLogStore{}

--- a/server/ingester/event/dbwriter/event.go
+++ b/server/ingester/event/dbwriter/event.go
@@ -392,7 +392,13 @@ func ReleaseEventStore(e *EventStore) {
 	if e == nil || e.SubReferenceCount() {
 		return
 	}
+	for i := range e.AttributeNames {
+		e.AttributeNames[i] = ""
+	}
 	attributeNames := e.AttributeNames[:0]
+	for i := range e.AttributeValues {
+		e.AttributeValues[i] = ""
+	}
 	attributeValues := e.AttributeValues[:0]
 	*e = EventStore{}
 	e.AttributeNames = attributeNames

--- a/server/ingester/ext_metrics/dbwriter/ext_metrics.go
+++ b/server/ingester/ext_metrics/dbwriter/ext_metrics.go
@@ -255,8 +255,17 @@ var emptyUniversalTag = flow_metrics.UniversalTag{}
 
 func ReleaseExtMetrics(m *ExtMetrics) {
 	m.UniversalTag = emptyUniversalTag
+	for i := range m.TagNames {
+		m.TagNames[i] = ""
+	}
 	m.TagNames = m.TagNames[:0]
+	for i := range m.TagValues {
+		m.TagValues[i] = ""
+	}
 	m.TagValues = m.TagValues[:0]
+	for i := range m.MetricsFloatNames {
+		m.MetricsFloatNames[i] = ""
+	}
 	m.MetricsFloatNames = m.MetricsFloatNames[:0]
 	m.MetricsFloatValues = m.MetricsFloatValues[:0]
 	extMetricsPool.Put(m)

--- a/server/ingester/flow_log/log_data/l7_flow_log.go
+++ b/server/ingester/flow_log/log_data/l7_flow_log.go
@@ -629,7 +629,32 @@ func ReleaseL7FlowLog(l *L7FlowLog) {
 	if l.SubReferenceCount() {
 		return
 	}
+	ip60 := l.IP60[:0]
+	ip61 := l.IP61[:0]
+	encodedSpan := l.EncodedSpan[:0]
+	for i := range l.AttributeNames {
+		l.AttributeNames[i] = ""
+	}
+	attributeNames := l.AttributeNames[:0]
+	for i := range l.AttributeValues {
+		l.AttributeValues[i] = ""
+	}
+	attributeValues := l.AttributeValues[:0]
+	for i := range l.MetricsNames {
+		l.MetricsNames[i] = ""
+	}
+	metricsNames := l.MetricsNames[:0]
+	metricsValues := l.MetricsValues[:0]
+
 	*l = L7FlowLog{}
+	l.IP60 = ip60
+	l.IP61 = ip61
+	l.EncodedSpan = encodedSpan
+	l.AttributeNames = attributeNames
+	l.AttributeValues = attributeValues
+	l.MetricsNames = metricsNames
+	l.MetricsValues = metricsValues
+
 	poolL7FlowLog.Put(l)
 }
 


### PR DESCRIPTION
### This PR is for:

- Server

### Fixes ingester pooled objects retaining old string references

#### Steps to reproduce the bug

- Ingest application logs, events, external metrics, or L7 flow logs with many native tag / metric string values.
- Release the objects back to their pools.
- The slices are reset with `[:0]`, but their backing arrays still hold references to old strings.
- Heap memory may stay higher than expected because pooled objects keep those old strings reachable.

#### Changes to fix the bug

- Clear string slice elements before reusing pooled `ApplicationLogStore`.
- Clear string slice elements before reusing pooled `EventStore`.
- Clear string slice elements before reusing pooled `ExtMetrics`.
- Clear string slice elements before reusing pooled `L7FlowLog`.
- Keep slice capacity for reuse after clearing references.

#### Affected branches

- main

#### Checklist

This change only touches server-side ingester object reuse and does not affect eBPF programs.

- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.