### PR TITLE
Fix: the issue with the first path matching error

### DIFF
--- a/agent/src/common/matched_field.rs
+++ b/agent/src/common/matched_field.rs
@@ -223,13 +223,13 @@ impl<const N: usize> MatchedFieldN<N> {
         for b in bits {
             let b = *b;
             if b < 8 * N {
-                self.src_ip[b >> 3] = 1 << (b & 7);
+                self.src_ip[b >> 3] |= 1 << (b & 7);
             } else if b < 8 * 2 * N {
                 let b = b - 8 * N;
-                self.dst_ip[b >> 3] = 1 << (b & 7);
+                self.dst_ip[b >> 3] |= 1 << (b & 7);
             } else if b < 8 * (2 * N + 10) {
                 let b = b - 8 * 2 * N;
-                self.others[b >> 3] = 1 << (b & 7);
+                self.others[b >> 3] |= 1 << (b & 7);
             } else {
                 panic!("bits({:?}) out of bounds", bits)
             }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent


### Fix: the issue with the first path matching error
#### Steps to reproduce the bug
#### Changes to fix the bug
#### Affected branches
- main
- 6.6
- 7.1
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->


