### PR TITLE
agent: Supports inference of common Redis error responses ￼

### DIFF
--- a/agent/src/ebpf/kernel/include/protocol_inference.h
+++ b/agent/src/ebpf/kernel/include/protocol_inference.h
@@ -1715,6 +1715,26 @@ static __inline bool is_include_crlf(const char *buf)
 	return true;
 }
 
+static __inline bool is_redis_error_response(const char *buf)
+{
+	/*
+	 * Common Redis error prefixes:
+	 * ASK, BUSY, CLUSTERDOWN, ERR, LOADING, MISCONF, MOVED,
+	 * NOAUTH, NOPERM, OOM, READONLY, TRYAGAIN, WRONGTYPE,
+	 * WRONGPASS, WRONGTYPE.
+	 *
+	 * Use relaxed range checks to reduce eBPF verifier branches:
+	 * buf[1]: A, B, C, E, L, M, N, O, R, T, W -> A ~ W
+	 * buf[2]: E, I, L, O, R, S, U -> E ~ U
+	 */
+	if (buf[1] < 'A' || buf[1] > 'W')
+		return false;
+	if (buf[2] < 'E' || buf[2] > 'U')
+		return false;
+
+	return true;
+}
+
 // ref:
 //  http://redisdoc.com/topic/protocol.html
 //  https://redis.io/docs/reference/protocol-spec/
@@ -1769,10 +1789,8 @@ static __inline enum message_type infer_redis_message(const char *buf,
 	if (first_byte != '-' && !is_include_crlf(buf))
 		return MSG_UNKNOWN;
 
-	//-ERR unknown command 'foobar'
-	//-WRONGTYPE Operation against a key holding the wrong kind of value
-	if (first_byte == '-'
-	    && ((buf[1] != 'E' && buf[1] != 'W') || buf[2] != 'R'))
+	/* Check common Redis Simple Error responses. */
+	if (first_byte == '-' && !is_redis_error_response(buf))
 		return MSG_UNKNOWN;
 
 	return MSG_REQUEST;


### PR DESCRIPTION
Current eBPF Redis protocol inference logic only recognizes `-ERR` and `-WRONGTYPE` Simple Error responses. Common Redis server error responses such as the following are currently classified as `MSG_UNKNOWN`, resulting in incomplete Redis response identification:

* `-NOAUTH Authentication required.`
* `-MOVED 3999 127.0.0.1:6381`
* `-ASK 3999 127.0.0.1:6381`
* `-TRYAGAIN Multiple keys request during rehashing of slot`
* `-CLUSTERDOWN Hash slot not served`
* `-LOADING Redis is loading the dataset in memory`
* `-BUSY Redis is busy running a script`
* `-NOSCRIPT No matching script. Please use EVAL.`
* `-READONLY You can't write against a read only replica.`
* `-WRONGPASS invalid username-password pair or user is disabled.`
* `-NOPERM this user has no permissions to run the command`
* `-OOM command not allowed when used memory > 'maxmemory'`
* `-MISCONF Redis is configured to save RDB snapshots...`

The Redis Simple Error detection logic in:

`@agent/src/ebpf/kernel/include/protocol_inference.h`

only allows the following error prefixes:

* `ERR`
* `WRONGTYPE`

The current logic is too restrictive:

```c
if (first_byte == '-'
    && ((buf[1] != 'E' && buf[1] != 'W') || buf[2] != 'R'))
    return MSG_UNKNOWN;
```

As a result, common Redis error responses related to authentication, cluster redirection, read-only replicas, ACL permissions, loading state, out-of-memory conditions, and similar scenarios are not recognized.

Introduce `is_redis_error_response()` and use short-prefix matching to recognize common Redis Simple Error prefixes, including:

* `ERR`
* `WRONGTYPE`
* `NOAUTH`
* `MOVED`
* `ASK`
* `TRYAGAIN`
* `CLUSTERDOWN`
* `LOADING`
* `BUSY`
* `NOSCRIPT`
* `READONLY`
* `WRONGPASS`
* `NOPERM`
* `OOM`
* `MISCONF`

Replace the Redis error response detection logic with:

```c
if (first_byte == '-' && !is_redis_error_response(buf))
    return MSG_UNKNOWN;
```

This implementation keeps matching logic lightweight using short-prefix checks to minimize eBPF verifier complexity and avoid unnecessary instruction growth.

* Affects Redis protocol inference logic in:

  `@agent/src/ebpf/kernel/include/protocol_inference.h`

* Expands Redis Simple Error response recognition coverage.

* External behavior change:
  More Redis error responses will now be correctly identified as Redis messages instead of being classified as unknown protocol messages due to unsupported error prefixes.

* No changes to Redis request handling, normal response handling, or RESP3 type detection logic.

* Verified code changes using:

```bash
git diff -- agent/src/ebpf/kernel/include/protocol_inference.h
```

* Additional protocol inference verification can be performed using sample Redis error responses such as:

```text
-ERR unknown command 'foobar'\r\n
-WRONGTYPE Operation against a key holding the wrong kind of value\r\n
-NOAUTH Authentication required.\r\n
-MOVED 3999 127.0.0.1:6381\r\n
-ASK 3999 127.0.0.1:6381\r\n
-READONLY You can't write against a read only replica.\r\n
-NOPERM this user has no permissions to run the command\r\n
-OOM command not allowed when used memory > 'maxmemory'.\r\n
```

Expected result:

All examples above should pass Redis Simple Error detection and should no longer return `MSG_UNKNOWN`.

* Suggested narrow-scope validation:

Run eBPF/agent-related build or `just check` under the `@agent` directory.
### This PR is for:
- agent
### Affected branches
* v6.6
