### PR TITLE
feat: support process GPID lookup

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -592,6 +592,8 @@ pub struct Proc {
     pub proc_dir_path: String,
     #[serde(deserialize_with = "deser_humantime_with_zero")]
     pub socket_info_sync_interval: Duration,
+    #[serde(deserialize_with = "deser_humantime_with_zero")]
+    pub process_gpid_sync_interval: Duration,
     #[serde(with = "humantime_serde")]
     pub min_lifetime: Duration,
     pub tag_extraction: TagExtraction,
@@ -607,6 +609,7 @@ impl Default for Proc {
             enabled: true,
             proc_dir_path: "/proc".to_string(),
             socket_info_sync_interval: Duration::from_secs(0),
+            process_gpid_sync_interval: Duration::from_secs(10),
             min_lifetime: Duration::from_secs(3),
             tag_extraction: TagExtraction::default(),
             process_blacklist: vec![

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -592,7 +592,7 @@ pub struct Proc {
     pub proc_dir_path: String,
     #[serde(deserialize_with = "deser_humantime_with_zero")]
     pub socket_info_sync_interval: Duration,
-    #[serde(deserialize_with = "deser_humantime_with_zero")]
+    #[serde(deserialize_with = "deser_process_gpid_sync_interval")]
     pub process_gpid_sync_interval: Duration,
     #[serde(with = "humantime_serde")]
     pub min_lifetime: Duration,
@@ -3653,6 +3653,27 @@ where
     }
 }
 
+fn deser_process_gpid_sync_interval<'de: 'a, 'a, D>(deserializer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = <&'a str>::deserialize(deserializer)?;
+    let interval = if value == "0" {
+        Duration::ZERO
+    } else {
+        humantime::parse_duration(value)
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &"a duration"))?
+    };
+    if !interval.is_zero()
+        && (interval < Duration::from_secs(1) || interval > Duration::from_secs(60 * 60))
+    {
+        return Err(de::Error::custom(format!(
+            "process_gpid_sync_interval {interval:?} not in [1s, 1h] or 0"
+        )));
+    }
+    Ok(interval)
+}
+
 fn deser_to_sorted_strings<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
 where
     D: Deserializer<'de>,
@@ -3701,6 +3722,18 @@ mod tests {
 
         let _: UserConfig = serde_yaml::from_str(&yaml_content)
             .expect("Failed to parse template.yaml to UserConfig");
+    }
+
+    #[test]
+    fn validate_process_gpid_sync_interval() {
+        for interval in ["0", "0ns", "1s", "1h"] {
+            let yaml = format!("process_gpid_sync_interval: {interval}");
+            assert!(serde_yaml::from_str::<Proc>(&yaml).is_ok(), "{interval}");
+        }
+        for interval in ["1ns", "999ms", "3601s"] {
+            let yaml = format!("process_gpid_sync_interval: {interval}");
+            assert!(serde_yaml::from_str::<Proc>(&yaml).is_err(), "{interval}");
+        }
     }
 
     #[test]

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -322,6 +322,7 @@ pub struct OsProcScanConfig;
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct PlatformConfig {
     pub sync_interval: Duration,
+    pub process_gpid_sync_interval: Duration,
     pub kubernetes_cluster_id: String,
     pub libvirt_xml_path: PathBuf,
     pub kubernetes_poller_type: KubernetesPollerType,
@@ -2131,6 +2132,7 @@ impl TryFrom<(Config, UserConfig)> for ModuleConfig {
             pcap: conf.processors.packet.pcap_stream,
             platform: PlatformConfig {
                 sync_interval: conf.inputs.resources.push_interval,
+                process_gpid_sync_interval: conf.inputs.proc.process_gpid_sync_interval,
                 kubernetes_cluster_id: static_config.kubernetes_cluster_id.clone(),
                 libvirt_xml_path: conf
                     .inputs
@@ -3858,6 +3860,13 @@ impl ConfigHandler {
                 proc.socket_info_sync_interval, new_proc.socket_info_sync_interval
             );
             proc.socket_info_sync_interval = new_proc.socket_info_sync_interval;
+        }
+        if proc.process_gpid_sync_interval != new_proc.process_gpid_sync_interval {
+            info!(
+                "Update inputs.proc.process_gpid_sync_interval from {:?} to {:?}.",
+                proc.process_gpid_sync_interval, new_proc.process_gpid_sync_interval
+            );
+            proc.process_gpid_sync_interval = new_proc.process_gpid_sync_interval;
         }
 
         let tag = &mut proc.tag_extraction;

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -100,6 +100,39 @@ use public::l7_protocol::L7Protocol;
 use public::proto::agent::{self, AgentType, PacketCaptureType};
 use public::utils::{bitmap::parse_range_list_to_bitmap, net::MacAddr};
 
+#[cfg(target_os = "linux")]
+fn update_tot_agent_id_with<F>(old_agent_id: u16, new_agent_id: u16, setter: F)
+where
+    F: FnOnce(u32) -> std::io::Result<()>,
+{
+    if old_agent_id == new_agent_id {
+        return;
+    }
+
+    match setter(u32::from(new_agent_id)) {
+        Ok(()) => info!(
+            "updated TOT agent ID from {} to {}",
+            old_agent_id, new_agent_id
+        ),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            debug!("skip updating TOT agent ID: /dev/tot not found")
+        }
+        Err(e) => warn!(
+            "failed to update TOT agent ID from {} to {}: {}",
+            old_agent_id, new_agent_id, e
+        ),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn update_tot_agent_id(old_agent_id: u16, new_agent_id: u16) {
+    update_tot_agent_id_with(
+        old_agent_id,
+        new_agent_id,
+        crate::utils::tcp_option_tracing::set_agent_id,
+    );
+}
+
 cfg_if::cfg_if! {
 if #[cfg(feature = "enterprise")] {
         use crate::common::{
@@ -5405,9 +5438,14 @@ impl ConfigHandler {
                 "collector config change from {:#?} to {:#?}",
                 candidate_config.collector, new_config.collector
             );
-            let restart_value = candidate_config.collector.agent_id
-                != new_config.collector.agent_id
-                && new_config.collector.enabled;
+            let agent_id_changed =
+                candidate_config.collector.agent_id != new_config.collector.agent_id;
+            #[cfg(target_os = "linux")]
+            update_tot_agent_id(
+                candidate_config.collector.agent_id,
+                new_config.collector.agent_id,
+            );
+            let restart_value = agent_id_changed && new_config.collector.enabled;
             restart_dispatcher |= restart_value;
             if restart_value {
                 dispatcher_restart_reasons.insert(changed_reason(
@@ -5718,6 +5756,43 @@ impl ModuleConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tot_agent_id_is_updated_only_when_changed() {
+        update_tot_agent_id_with(7, 7, |_| panic!("setter must not be called"));
+
+        let updated = std::cell::Cell::new(None);
+        update_tot_agent_id_with(7, u16::MAX, |agent_id| {
+            updated.set(Some(agent_id));
+            Ok(())
+        });
+        assert_eq!(updated.get(), Some(u32::from(u16::MAX)));
+
+        let updated = std::cell::Cell::new(None);
+        update_tot_agent_id_with(7, 0, |agent_id| {
+            updated.set(Some(agent_id));
+            Ok(())
+        });
+        assert_eq!(updated.get(), Some(0));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tot_agent_id_update_errors_are_non_fatal() {
+        update_tot_agent_id_with(1, 2, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "TOT is not installed",
+            ))
+        });
+        update_tot_agent_id_with(1, 2, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "missing CAP_NET_ADMIN",
+            ))
+        });
+    }
 
     #[test]
     fn test_new_trie() {

--- a/agent/src/dispatcher/analyzer_mode_dispatcher.rs
+++ b/agent/src/dispatcher/analyzer_mode_dispatcher.rs
@@ -263,6 +263,7 @@ impl AnalyzerModeDispatcher {
         let flow_output_queue = base.flow_output_queue.clone();
         let l7_stats_output_queue = base.l7_stats_output_queue.clone();
         let policy_getter = base.policy_getter;
+        let process_gpid_table = base.process_gpid_table.clone();
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
@@ -285,6 +286,7 @@ impl AnalyzerModeDispatcher {
                         Some(flow_output_queue),
                         l7_stats_output_queue,
                         policy_getter,
+                        process_gpid_table,
                         log_output_queue,
                         ntp_diff,
                         &flow_map_config.load(),
@@ -300,6 +302,7 @@ impl AnalyzerModeDispatcher {
                     }
 
                     while !terminated.load(Ordering::Relaxed) {
+                        flow_map.refresh_process_gpid();
                         let config = Config {
                             flow: &flow_map_config.load(),
                             log_parser: &log_parser_config.load(),

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -55,6 +55,7 @@ use crate::{
     flow_generator::AppProto,
     handler::PacketHandlerBuilder,
     policy::PolicyGetter,
+    process_gpid::ProcessGpidTable,
     rpc::get_timestamp,
     utils::{bytes::read_u16_be, stats::Collector},
 };
@@ -120,6 +121,7 @@ pub(super) struct InternalState {
     pub(super) platform_poller: Arc<crate::platform::GenericPoller>,
 
     pub(super) policy_getter: PolicyGetter,
+    pub(super) process_gpid_table: ProcessGpidTable,
     pub(super) exception_handler: ExceptionHandler,
     pub(super) ntp_diff: Arc<AtomicI64>,
 

--- a/agent/src/dispatcher/local_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_mode_dispatcher.rs
@@ -214,6 +214,7 @@ impl LocalModeDispatcher {
             Some(base.flow_output_queue.clone()),
             base.l7_stats_output_queue.clone(),
             base.policy_getter,
+            base.process_gpid_table.clone(),
             base.log_output_queue.clone(),
             base.ntp_diff.clone(),
             &base.flow_map_config.load(),
@@ -228,6 +229,7 @@ impl LocalModeDispatcher {
         let mut collector_config = base.collector_config.load().clone();
 
         while !base.terminated.load(Ordering::Relaxed) {
+            flow_map.refresh_process_gpid();
             if base.need_reload_config.swap(false, Ordering::Relaxed) {
                 info!("dispatcher reload config");
                 flow_config = base.flow_map_config.load().clone();

--- a/agent/src/dispatcher/local_multins_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_multins_mode_dispatcher.rs
@@ -98,6 +98,7 @@ impl LocalMultinsModeDispatcher {
             Some(base.flow_output_queue.clone()),
             base.l7_stats_output_queue.clone(),
             base.policy_getter,
+            base.process_gpid_table.clone(),
             base.log_output_queue.clone(),
             base.ntp_diff.clone(),
             &base.flow_map_config.load(),
@@ -112,6 +113,7 @@ impl LocalMultinsModeDispatcher {
 
         super::set_cpu_affinity(&base.options);
         while !base.terminated.load(Ordering::Relaxed) {
+            flow_map.refresh_process_gpid();
             let config = Config {
                 flow: &base.flow_map_config.load(),
                 log_parser: &base.log_parser_config.load(),

--- a/agent/src/dispatcher/local_plus_mode_dispatcher.rs
+++ b/agent/src/dispatcher/local_plus_mode_dispatcher.rs
@@ -99,6 +99,7 @@ impl LocalPlusModeDispatcher {
         let flow_output_queue = base.flow_output_queue.clone();
         let l7_stats_output_queue = base.l7_stats_output_queue.clone();
         let policy_getter = base.policy_getter;
+        let process_gpid_table = base.process_gpid_table.clone();
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
@@ -127,6 +128,7 @@ impl LocalPlusModeDispatcher {
                         Some(flow_output_queue),
                         l7_stats_output_queue,
                         policy_getter,
+                        process_gpid_table,
                         log_output_queue,
                         ntp_diff,
                         &flow_map_config.load(),
@@ -142,6 +144,7 @@ impl LocalPlusModeDispatcher {
                     }
 
                     while !terminated.load(Ordering::Relaxed) {
+                        flow_map.refresh_process_gpid();
                         let config = Config {
                             flow: &flow_map_config.load(),
                             log_parser: &log_parser_config.load(),

--- a/agent/src/dispatcher/mirror_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_mode_dispatcher.rs
@@ -553,6 +553,7 @@ impl MirrorModeDispatcher {
             Some(base.flow_output_queue.clone()),
             base.l7_stats_output_queue.clone(),
             base.policy_getter,
+            base.process_gpid_table.clone(),
             base.log_output_queue.clone(),
             base.ntp_diff.clone(),
             &base.flow_map_config.load(),
@@ -570,6 +571,7 @@ impl MirrorModeDispatcher {
         }
 
         while !base.terminated.load(Ordering::Relaxed) {
+            flow_map.refresh_process_gpid();
             let config = Config {
                 flow: &base.flow_map_config.load(),
                 log_parser: &base.log_parser_config.load(),

--- a/agent/src/dispatcher/mirror_plus_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_plus_mode_dispatcher.rs
@@ -273,6 +273,7 @@ impl MirrorPlusModeDispatcher {
         let flow_output_queue = base.flow_output_queue.clone();
         let l7_stats_output_queue = base.l7_stats_output_queue.clone();
         let policy_getter = base.policy_getter;
+        let process_gpid_table = base.process_gpid_table.clone();
         let log_output_queue = base.log_output_queue.clone();
         let ntp_diff = base.ntp_diff.clone();
         let flow_map_config = base.flow_map_config.clone();
@@ -304,6 +305,7 @@ impl MirrorPlusModeDispatcher {
                         Some(flow_output_queue),
                         l7_stats_output_queue,
                         policy_getter,
+                        process_gpid_table,
                         log_output_queue,
                         ntp_diff,
                         &flow_map_config.load(),
@@ -321,6 +323,7 @@ impl MirrorPlusModeDispatcher {
                     }
 
                     while !terminated.load(Ordering::Relaxed) {
+                        flow_map.refresh_process_gpid();
                         let config = Config {
                             flow: &flow_map_config.load(),
                             log_parser: &log_parser_config.load(),

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -88,6 +88,7 @@ use crate::{
     flow_generator::AppProto,
     handler::{PacketHandler, PacketHandlerBuilder},
     policy::PolicyGetter,
+    process_gpid::ProcessGpidTable,
     utils::{
         environment::get_mac_by_name,
         stats::{self, Collector},
@@ -755,6 +756,7 @@ pub struct DispatcherBuilder {
     collector_config: Option<CollectorAccess>,
     dispatcher_config: Option<DispatcherAccess>,
     policy_getter: Option<PolicyGetter>,
+    process_gpid_table: Option<ProcessGpidTable>,
     #[cfg(target_os = "linux")]
     platform_poller: Option<Arc<crate::platform::GenericPoller>>,
     exception_handler: Option<ExceptionHandler>,
@@ -892,6 +894,11 @@ impl DispatcherBuilder {
 
     pub fn policy_getter(mut self, v: PolicyGetter) -> Self {
         self.policy_getter = Some(v);
+        self
+    }
+
+    pub fn process_gpid_table(mut self, v: ProcessGpidTable) -> Self {
+        self.process_gpid_table = Some(v);
         self
     }
 
@@ -1099,6 +1106,10 @@ impl DispatcherBuilder {
             policy_getter: self
                 .policy_getter
                 .ok_or(Error::ConfigIncomplete("no policy".into()))?,
+            process_gpid_table: self
+                .process_gpid_table
+                .take()
+                .ok_or(Error::ConfigIncomplete("no process GPID table".into()))?,
             #[cfg(target_os = "linux")]
             platform_poller: platform_poller.clone(),
             exception_handler: self

--- a/agent/src/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher.rs
@@ -71,6 +71,7 @@ use crate::flow_generator::{flow_map::Config, AppProto, FlowMap};
 use crate::integration_collector::Profile;
 use crate::platform::ProcessData;
 use crate::policy::PolicyGetter;
+use crate::process_gpid::ProcessGpidTable;
 use crate::rpc::get_timestamp;
 use crate::utils::{process::ProcessListener, stats};
 
@@ -347,6 +348,7 @@ struct EbpfDispatcher {
 
     // 策略查询
     policy_getter: PolicyGetter,
+    process_gpid_table: ProcessGpidTable,
 
     // GRPC配置
     log_parser_config: LogParserAccess,
@@ -471,6 +473,7 @@ impl EbpfDispatcher {
             None,
             self.l7_stats_output.clone(),
             self.policy_getter,
+            self.process_gpid_table.clone(),
             self.output.clone(),
             self.time_diff.clone(),
             &self.flow_map_config.load(),
@@ -489,6 +492,7 @@ impl EbpfDispatcher {
         let mut last_packet_timestamp = 0;
 
         while unsafe { SWITCH } {
+            flow_map.refresh_process_gpid();
             if need_reload_config.swap(false, Ordering::Relaxed) {
                 info!("ebpf dispatcher reload config");
                 flow_config = self.flow_map_config.load().clone();
@@ -1356,6 +1360,7 @@ impl EbpfCollector {
         flow_map_config: FlowAccess,
         collector_config: CollectorAccess,
         policy_getter: PolicyGetter,
+        process_gpid_table: ProcessGpidTable,
         dpdk_senders: Vec<DebugSender<Box<packet::Packet<'static>>>>,
         output: DebugSender<AppProto>,
         l7_stats_output: DebugSender<BatchedBox<L7Stats>>,
@@ -1420,6 +1425,7 @@ impl EbpfCollector {
                 time_diff,
                 receiver: Arc::new(receiver),
                 policy_getter,
+                process_gpid_table,
                 config,
                 log_parser_config,
                 output,

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -80,6 +80,7 @@ use crate::{
     metric::document::TapSide,
     plugin::wasm::WasmVm,
     policy::{Policy, PolicyGetter},
+    process_gpid::{ProcessGpidLookup, ProcessGpidTable},
     rpc::get_timestamp,
     utils::stats::{self, Countable, StatsOption},
 };
@@ -210,6 +211,7 @@ pub struct FlowMap {
     service_table: ServiceTable,
     app_table: AppTable,
     policy_getter: PolicyGetter,
+    process_gpid: ProcessGpidLookup,
     start_time: Duration,    // 时间桶中的最早时间
     start_time_in_unit: u64, // 时间桶中的最早时间，以TIME_SLOT_UNIT为单位
     hash_slots: usize,
@@ -255,11 +257,29 @@ pub struct FlowMap {
 
 impl FlowMap {
     const MICROS_IN_SECONDS: u64 = 1_000_000;
+
+    pub fn refresh_process_gpid(&mut self) {
+        self.process_gpid.refresh();
+    }
+
+    #[inline]
+    fn lookup_policy(
+        &mut self,
+        meta_packet: &mut MetaPacket,
+        local_epc_id: i32,
+        local_agent_id: u32,
+    ) {
+        self.process_gpid.lookup(meta_packet, local_agent_id);
+        self.policy_getter
+            .lookup(meta_packet, self.id as usize, local_epc_id);
+    }
+
     pub fn new(
         id: u32,
         output_queue: Option<DebugSender<Arc<BatchedBox<TaggedFlow>>>>,
         l7_stats_output_queue: DebugSender<BatchedBox<L7Stats>>,
         policy_getter: PolicyGetter,
+        process_gpid_table: ProcessGpidTable,
         app_proto_log_queue: DebugSender<AppProto>,
         ntp_diff: Arc<AtomicI64>,
         config: &FlowConfig,
@@ -309,6 +329,7 @@ impl FlowMap {
                 config.l7_protocol_inference_whitelist.clone(),
             ),
             policy_getter,
+            process_gpid: process_gpid_table.new_lookup(id, &stats_collector),
             start_time,
             start_time_in_unit: start_time.as_secs(),
             hash_slots: config.hash_slots as usize,
@@ -724,7 +745,7 @@ impl FlowMap {
         };
         #[cfg(target_os = "windows")]
         let local_epc_id = 0;
-        (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
+        self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
     }
 
     pub fn inject_meta_packet(&mut self, config: &Config, meta_packet: &mut MetaPacket) {
@@ -1371,7 +1392,7 @@ impl FlowMap {
         let local_epc_id = 0;
 
         // tag
-        (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
+        self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
         self.init_endpoint_and_policy_data(&mut node, meta_packet);
         node.tagged_flow.flow.need_to_store = (self.pseq_output.is_some()
             && meta_packet.lookup_key.proto == IpProtocol::TCP)
@@ -1561,7 +1582,7 @@ impl FlowMap {
                 meta_packet.lookup_key.src_nat_port = metric.nat_real_port;
                 meta_packet.lookup_key.src_nat_source = TapPort::NAT_SOURCE_TOA;
             }
-            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
+            self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
             self.update_endpoint_and_policy_data(node, meta_packet);
             // Currently, only virtual traffic's tap_side is counted
             node.tagged_flow
@@ -1654,7 +1675,7 @@ impl FlowMap {
             #[cfg(target_os = "windows")]
             let local_epc_id = 0;
 
-            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
+            self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
         }
     }
 
@@ -2756,6 +2777,7 @@ pub fn _new_flow_map_and_receiver(
         Some(output_queue_sender),
         l7_stats_output_queue_sender,
         policy_getter,
+        ProcessGpidTable::default(),
         app_proto_log_queue,
         Arc::new(AtomicI64::new(0)),
         &config.flow,

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -263,15 +263,17 @@ impl FlowMap {
     }
 
     #[inline]
-    fn lookup_policy(
-        &mut self,
-        meta_packet: &mut MetaPacket,
-        local_epc_id: i32,
-        local_agent_id: u32,
-    ) {
-        self.process_gpid.lookup(meta_packet, local_agent_id);
-        self.policy_getter
-            .lookup(meta_packet, self.id as usize, local_epc_id);
+    fn lookup_process_gpid(&mut self, meta_packet: &MetaPacket, node: &mut FlowNode) {
+        if meta_packet.signal_source != SignalSource::Packet {
+            return;
+        }
+        let Some(trace_info) = meta_packet.trace_info else {
+            return;
+        };
+        let client = &mut node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC];
+        if client.gpid == 0 {
+            client.gpid = self.process_gpid.lookup(trace_info);
+        }
     }
 
     pub fn new(
@@ -745,7 +747,7 @@ impl FlowMap {
         };
         #[cfg(target_os = "windows")]
         let local_epc_id = 0;
-        self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
+        (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
     }
 
     pub fn inject_meta_packet(&mut self, config: &Config, meta_packet: &mut MetaPacket) {
@@ -969,6 +971,8 @@ impl FlowMap {
                 count += self.collect_metric(config, node, meta_packet, direction, false);
             }
         }
+
+        self.lookup_process_gpid(meta_packet, node);
 
         // After collect_metric() is called for eBPF MetaPacket, its direction is determined.
         if node.tagged_flow.flow.signal_source == SignalSource::EBPF && count > 0 {
@@ -1392,7 +1396,7 @@ impl FlowMap {
         let local_epc_id = 0;
 
         // tag
-        self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
+        (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
         self.init_endpoint_and_policy_data(&mut node, meta_packet);
         node.tagged_flow.flow.need_to_store = (self.pseq_output.is_some()
             && meta_packet.lookup_key.proto == IpProtocol::TCP)
@@ -1582,7 +1586,7 @@ impl FlowMap {
                 meta_packet.lookup_key.src_nat_port = metric.nat_real_port;
                 meta_packet.lookup_key.src_nat_source = TapPort::NAT_SOURCE_TOA;
             }
-            self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
+            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
             self.update_endpoint_and_policy_data(node, meta_packet);
             // Currently, only virtual traffic's tap_side is counted
             node.tagged_flow
@@ -1675,7 +1679,7 @@ impl FlowMap {
             #[cfg(target_os = "windows")]
             let local_epc_id = 0;
 
-            self.lookup_policy(meta_packet, local_epc_id, config.flow.agent_id as u32);
+            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
         }
     }
 
@@ -1936,6 +1940,8 @@ impl FlowMap {
                 node.residual_request -= count;
             }
         }
+
+        self.lookup_process_gpid(meta_packet, &mut node);
 
         // Enterprise Edition Feature: packet-sequence
         if let Some(output) = self.pseq_output.as_mut() {
@@ -2748,6 +2754,20 @@ pub fn _new_flow_map_and_receiver(
     flow_timeout: Option<FlowTimeout>,
     ignore_idc_vlan: bool,
 ) -> (ModuleConfig, FlowMap, Receiver<Arc<BatchedBox<TaggedFlow>>>) {
+    _new_flow_map_and_receiver_with_process_gpid(
+        agent_type,
+        flow_timeout,
+        ignore_idc_vlan,
+        ProcessGpidTable::default(),
+    )
+}
+
+fn _new_flow_map_and_receiver_with_process_gpid(
+    agent_type: AgentType,
+    flow_timeout: Option<FlowTimeout>,
+    ignore_idc_vlan: bool,
+    process_gpid_table: ProcessGpidTable,
+) -> (ModuleConfig, FlowMap, Receiver<Arc<BatchedBox<TaggedFlow>>>) {
     let (_, mut policy_getter) = Policy::new(1, 0, 1 << 10, 1 << 14, false, false);
     policy_getter.disable();
     let queue_debugger = QueueDebugger::new();
@@ -2777,7 +2797,7 @@ pub fn _new_flow_map_and_receiver(
         Some(output_queue_sender),
         l7_stats_output_queue_sender,
         policy_getter,
-        ProcessGpidTable::default(),
+        process_gpid_table,
         app_proto_log_queue,
         Arc::new(AtomicI64::new(0)),
         &config.flow,
@@ -2860,6 +2880,7 @@ mod tests {
             enums::EthernetType,
             flow::CloseType,
             l7_protocol_log::{LogCache, LogCacheKey, ParseParam},
+            meta_packet::TraceInfo,
             tap_port::TapPort,
         },
         flow_generator::protocol_logs::L7ResponseStatus,
@@ -2875,6 +2896,82 @@ mod tests {
             self.start_time = d;
             self.start_time_in_unit = (d.as_nanos() / TIME_UNIT.as_nanos()) as u64;
         }
+    }
+
+    #[test]
+    fn process_gpid_updates_only_packet_client_peer() {
+        const CLIENT_AGENT_ID: u32 = 10;
+        const CLIENT_PID: u32 = 20;
+        const CLIENT_GPID: u32 = 30;
+
+        let process_gpid_table = ProcessGpidTable::default();
+        process_gpid_table.update_for_test(
+            1,
+            AHashMap::from_iter([(
+                ((CLIENT_AGENT_ID as u64) << 32) | CLIENT_PID as u64,
+                CLIENT_GPID,
+            )]),
+        );
+        let (mut module_config, mut flow_map, _) = _new_flow_map_and_receiver_with_process_gpid(
+            AgentType::TtProcess,
+            None,
+            false,
+            process_gpid_table,
+        );
+        module_config.flow.collector_enabled = false;
+        let config = Config {
+            flow: &module_config.flow,
+            log_parser: &module_config.log_parser,
+            collector: &module_config.collector,
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            ebpf: None,
+        };
+
+        // TraceInfo identifies the client even when the first packet is a SYN-ACK and the
+        // packet direction has to be reversed before creating the flow.
+        let mut packet = _new_meta_packet();
+        packet.signal_source = SignalSource::Packet;
+        packet.trace_info = Some(TraceInfo {
+            agent_id: CLIENT_AGENT_ID,
+            pid: CLIENT_PID,
+        });
+        if let ProtocolData::TcpHeader(tcp_data) = &mut packet.protocol_data {
+            tcp_data.flags = TcpFlags::SYN_ACK;
+        }
+        let server_ip = packet.lookup_key.src_ip;
+        let client_ip = packet.lookup_key.dst_ip;
+
+        let node = flow_map.new_tcp_node(&config, &mut packet);
+
+        assert_eq!(packet.lookup_key.direction, PacketDirection::ServerToClient);
+        assert_eq!((packet.gpid_0, packet.gpid_1), (0, 0));
+        assert_eq!(node.tagged_flow.flow.flow_key.ip_src, client_ip);
+        assert_eq!(node.tagged_flow.flow.flow_key.ip_dst, server_ip);
+        assert_eq!(
+            node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            CLIENT_GPID
+        );
+        assert_eq!(
+            node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_DST].gpid,
+            0
+        );
+
+        let mut existing_node = FlowNode::default();
+        existing_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid = 100;
+        flow_map.lookup_process_gpid(&packet, &mut existing_node);
+        assert_eq!(
+            existing_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            100
+        );
+
+        let mut ebpf_packet = packet.clone();
+        ebpf_packet.signal_source = SignalSource::EBPF;
+        let mut ebpf_node = FlowNode::default();
+        flow_map.lookup_process_gpid(&ebpf_packet, &mut ebpf_node);
+        assert_eq!(
+            ebpf_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            0
+        );
     }
 
     #[test]

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -35,6 +35,7 @@ mod monitor;
 mod platform;
 mod plugin;
 mod policy;
+mod process_gpid;
 pub mod rpc;
 mod sender;
 pub mod trident;

--- a/agent/src/policy/policy.rs
+++ b/agent/src/policy/policy.rs
@@ -182,6 +182,12 @@ impl Policy {
             return;
         }
 
+        let fill_if_empty = |target: &mut u32, gpid| {
+            if *target == 0 {
+                *target = gpid;
+            }
+        };
+
         let mut direction = packet.lookup_key.direction;
 
         // We consider the direction (role) in GpidEntry to be the ground truth because
@@ -207,8 +213,8 @@ impl Policy {
                     // 用于客户端处采集的流量，流量服务端IP为NAT IP，需要通过客户端信息查询流量真实的服务端IP
                     match gpid_entry.role_real {
                         RoleType::RoleServer => {
-                            packet.gpid_0 = gpid_entry.pid_0;
-                            packet.gpid_1 = gpid_entry.pid_real;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_0);
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_real);
                             // NAT_SOURCE_RTOA高于当前优先级会更新数据
                             if TapPort::NAT_SOURCE_RTOA > packet.lookup_key.dst_nat_source {
                                 packet.lookup_key.dst_nat_source = TapPort::NAT_SOURCE_RTOA;
@@ -218,7 +224,7 @@ impl Policy {
                             }
                         }
                         RoleType::RoleClient => {
-                            packet.gpid_0 = gpid_entry.pid_real;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_real);
                             // NAT_SOURCE_TOA高于当前优先级会更新数据
                             if TapPort::NAT_SOURCE_TOA > packet.lookup_key.src_nat_source {
                                 packet.lookup_key.src_nat_source = TapPort::NAT_SOURCE_TOA;
@@ -226,16 +232,16 @@ impl Policy {
                                 packet.lookup_key.src_nat_ip =
                                     IpAddr::V4(Ipv4Addr::from(gpid_entry.ip_real));
                             }
-                            packet.gpid_1 = gpid_entry.pid_1;
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_1);
                         }
                         RoleType::RoleNone => {
-                            packet.gpid_0 = gpid_entry.pid_0;
-                            packet.gpid_1 = gpid_entry.pid_1;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_0);
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_1);
                         }
                     }
                 } else {
-                    packet.gpid_0 = gpid_entry.pid_0;
-                    packet.gpid_1 = gpid_entry.pid_1;
+                    fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_0);
+                    fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_1);
                 }
             }
             PacketDirection::ServerToClient => {
@@ -243,7 +249,7 @@ impl Policy {
                     // 用于客户端处采集的流量，流量服务端IP为NAT IP，需要通过客户端信息查询流量真实的服务端IP
                     match gpid_entry.role_real {
                         RoleType::RoleServer => {
-                            packet.gpid_0 = gpid_entry.pid_real;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_real);
                             // NNAT_SOURCE_RTOA高于当前优先级会更新数据
                             if TapPort::NAT_SOURCE_RTOA > packet.lookup_key.src_nat_source {
                                 packet.lookup_key.src_nat_source = TapPort::NAT_SOURCE_RTOA;
@@ -251,11 +257,11 @@ impl Policy {
                                 packet.lookup_key.src_nat_ip =
                                     IpAddr::V4(Ipv4Addr::from(gpid_entry.ip_real));
                             }
-                            packet.gpid_1 = gpid_entry.pid_0;
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_0);
                         }
                         RoleType::RoleClient => {
-                            packet.gpid_0 = gpid_entry.pid_1;
-                            packet.gpid_1 = gpid_entry.pid_real;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_1);
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_real);
                             // NAT_SOURCE_RTOA高于当前优先级会更新数据
                             if TapPort::NAT_SOURCE_TOA > packet.lookup_key.dst_nat_source {
                                 packet.lookup_key.dst_nat_source = TapPort::NAT_SOURCE_TOA;
@@ -265,13 +271,13 @@ impl Policy {
                             }
                         }
                         RoleType::RoleNone => {
-                            packet.gpid_0 = gpid_entry.pid_1;
-                            packet.gpid_1 = gpid_entry.pid_0;
+                            fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_1);
+                            fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_0);
                         }
                     }
                 } else {
-                    packet.gpid_0 = gpid_entry.pid_1;
-                    packet.gpid_1 = gpid_entry.pid_0;
+                    fill_if_empty(&mut packet.gpid_0, gpid_entry.pid_1);
+                    fill_if_empty(&mut packet.gpid_1, gpid_entry.pid_0);
                 }
             }
         }
@@ -871,5 +877,25 @@ mod test {
             assert_eq!(2, e.src_info.l3_epc_id);
             assert_eq!(10, e.dst_info.l3_epc_id);
         }
+    }
+
+    #[test]
+    fn legacy_gpid_only_fills_empty_side() {
+        let mut packet = MetaPacket::default();
+        packet.lookup_key.direction = PacketDirection::ClientToServer;
+        packet.lookup_key.dst_ip = Ipv4Addr::UNSPECIFIED.into();
+        packet.lookup_key.dst_port = 2;
+        packet.gpid_0 = 100;
+        let entry = GpidEntry {
+            port_0: 1,
+            pid_0: 10,
+            port_1: 2,
+            pid_1: 20,
+            ..Default::default()
+        };
+
+        Policy::fill_gpid_entry(&mut packet, &entry);
+        assert_eq!(packet.gpid_0, 100);
+        assert_eq!(packet.gpid_1, 20);
     }
 }

--- a/agent/src/process_gpid.rs
+++ b/agent/src/process_gpid.rs
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2024 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Condvar, Mutex, Weak,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use ahash::AHashMap;
+use arc_swap::{access::Access, ArcSwap};
+use log::{debug, error, info, warn};
+use lru::LruCache;
+use parking_lot::RwLock;
+use prost::Message;
+use tokio::runtime::Runtime;
+
+use public::{
+    counter::{Countable, Counter, CounterType, CounterValue, RefCountable},
+    proto::agent::{ProcessGpidEntries, ProcessGpidSyncRequest, ProcessGpidSyncResponse},
+};
+
+use crate::{
+    common::{flow::PacketDirection, MetaPacket},
+    config::handler::PlatformAccess,
+    rpc::Session,
+    trident::AgentId,
+    utils::stats,
+};
+
+const PROCESS_GPID_LRU_CAPACITY: usize = 4096;
+const MAX_PROCESS_GPID_ENTRIES: usize = 1_000_000;
+const MAX_PROCESS_GPID_MESSAGE_SIZE: usize = 32 << 20;
+const SOCKET_ROLE_SERVER: u8 = 2;
+
+#[derive(Default)]
+struct VersionedTable {
+    version: u64,
+    entries: AHashMap<u64, u32>,
+}
+
+struct SharedTable {
+    version: AtomicU64,
+    table: ArcSwap<VersionedTable>,
+}
+
+impl Default for SharedTable {
+    fn default() -> Self {
+        Self {
+            version: AtomicU64::new(0),
+            table: ArcSwap::from_pointee(VersionedTable::default()),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ProcessGpidTable {
+    inner: Arc<SharedTable>,
+}
+
+impl ProcessGpidTable {
+    fn version(&self) -> u64 {
+        self.inner.version.load(Ordering::Acquire)
+    }
+
+    fn update(&self, version: u64, entries: AHashMap<u64, u32>) {
+        self.inner
+            .table
+            .store(Arc::new(VersionedTable { version, entries }));
+        self.inner.version.store(version, Ordering::Release);
+    }
+
+    pub fn new_lookup(&self, id: u32, stats_collector: &stats::Collector) -> ProcessGpidLookup {
+        ProcessGpidLookup::new(self.inner.clone(), id, stats_collector)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum LookupRole {
+    Client,
+    Server,
+}
+
+#[derive(Default)]
+struct ProcessGpidCounter {
+    client_lru_hit: AtomicU64,
+    client_lru_negative_hit: AtomicU64,
+    client_table_hit: AtomicU64,
+    client_table_miss: AtomicU64,
+    server_lru_hit: AtomicU64,
+    server_lru_negative_hit: AtomicU64,
+    server_table_hit: AtomicU64,
+    server_table_miss: AtomicU64,
+    table_reload: AtomicU64,
+}
+
+impl RefCountable for ProcessGpidCounter {
+    fn get_counters(&self) -> Vec<Counter> {
+        macro_rules! counted {
+            ($name:literal, $field:ident) => {
+                (
+                    $name,
+                    CounterType::Counted,
+                    CounterValue::Unsigned(self.$field.swap(0, Ordering::Relaxed)),
+                )
+            };
+        }
+
+        vec![
+            counted!("client_lru_hit", client_lru_hit),
+            counted!("client_lru_negative_hit", client_lru_negative_hit),
+            counted!("client_table_hit", client_table_hit),
+            counted!("client_table_miss", client_table_miss),
+            counted!("server_lru_hit", server_lru_hit),
+            counted!("server_lru_negative_hit", server_lru_negative_hit),
+            counted!("server_table_hit", server_table_hit),
+            counted!("server_table_miss", server_table_miss),
+            counted!("table_reload", table_reload),
+        ]
+    }
+}
+
+pub struct ProcessGpidLookup {
+    shared: Arc<SharedTable>,
+    table: Arc<VersionedTable>,
+    version: u64,
+    lru: LruCache<u64, u32>,
+    counter: Arc<ProcessGpidCounter>,
+}
+
+impl ProcessGpidLookup {
+    fn new(shared: Arc<SharedTable>, id: u32, stats_collector: &stats::Collector) -> Self {
+        let table = shared.table.load_full();
+        let counter = Arc::new(ProcessGpidCounter::default());
+        stats_collector.register_countable(
+            &stats::SingleTagModule("process-gpid", "id", id),
+            Countable::Ref(Arc::downgrade(&counter) as Weak<dyn RefCountable>),
+        );
+        Self {
+            version: table.version,
+            shared,
+            table,
+            lru: LruCache::new(NonZeroUsize::new(PROCESS_GPID_LRU_CAPACITY).unwrap()),
+            counter,
+        }
+    }
+
+    pub fn refresh(&mut self) {
+        if self.shared.version.load(Ordering::Acquire) == self.version {
+            return;
+        }
+        let table = self.shared.table.load_full();
+        self.version = table.version;
+        self.table = table;
+        self.lru.clear();
+        self.counter.table_reload.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn query(&mut self, agent_id: u32, pid: u32, role: LookupRole) -> u32 {
+        if agent_id == 0 || pid == 0 {
+            return 0;
+        }
+        let key = make_key(agent_id, pid);
+        if let Some(gpid) = self.lru.get(&key).copied() {
+            let counter = match (role, gpid == 0) {
+                (LookupRole::Client, false) => &self.counter.client_lru_hit,
+                (LookupRole::Client, true) => &self.counter.client_lru_negative_hit,
+                (LookupRole::Server, false) => &self.counter.server_lru_hit,
+                (LookupRole::Server, true) => &self.counter.server_lru_negative_hit,
+            };
+            counter.fetch_add(1, Ordering::Relaxed);
+            return gpid;
+        }
+
+        let gpid = self.table.entries.get(&key).copied().unwrap_or_default();
+        let counter = match (role, gpid == 0) {
+            (LookupRole::Client, false) => &self.counter.client_table_hit,
+            (LookupRole::Client, true) => &self.counter.client_table_miss,
+            (LookupRole::Server, false) => &self.counter.server_table_hit,
+            (LookupRole::Server, true) => &self.counter.server_table_miss,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        self.lru.put(key, gpid);
+        gpid
+    }
+
+    pub fn lookup(&mut self, packet: &mut MetaPacket, local_agent_id: u32) {
+        let client_is_src = packet.lookup_key.direction == PacketDirection::ClientToServer;
+        let client_gpid_is_empty = if client_is_src {
+            packet.gpid_0 == 0
+        } else {
+            packet.gpid_1 == 0
+        };
+        if client_gpid_is_empty {
+            if let Some(trace_info) = packet.trace_info {
+                let gpid = self.query(trace_info.agent_id, trace_info.pid, LookupRole::Client);
+                if client_is_src {
+                    packet.gpid_0 = gpid;
+                } else {
+                    packet.gpid_1 = gpid;
+                }
+            }
+        }
+
+        let server_gpid_is_empty = if client_is_src {
+            packet.gpid_1 == 0
+        } else {
+            packet.gpid_0 == 0
+        };
+        if server_gpid_is_empty
+            && packet.socket_role == SOCKET_ROLE_SERVER
+            && packet.process_id != 0
+        {
+            let gpid = self.query(local_agent_id, packet.process_id, LookupRole::Server);
+            if client_is_src {
+                packet.gpid_1 = gpid;
+            } else {
+                packet.gpid_0 = gpid;
+            }
+        }
+    }
+}
+
+fn make_key(agent_id: u32, pid: u32) -> u64 {
+    ((agent_id as u64) << 32) | pid as u64
+}
+
+pub struct ProcessGpidSynchronizer {
+    runtime: Arc<Runtime>,
+    config: PlatformAccess,
+    agent_id: Arc<RwLock<AgentId>>,
+    session: Arc<Session>,
+    table: ProcessGpidTable,
+    running: Arc<Mutex<bool>>,
+    stop_notify: Arc<Condvar>,
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl ProcessGpidSynchronizer {
+    pub fn new(
+        runtime: Arc<Runtime>,
+        config: PlatformAccess,
+        agent_id: Arc<RwLock<AgentId>>,
+        session: Arc<Session>,
+        table: ProcessGpidTable,
+    ) -> Self {
+        Self {
+            runtime,
+            config,
+            agent_id,
+            session,
+            table,
+            running: Arc::new(Mutex::new(false)),
+            stop_notify: Arc::new(Condvar::new()),
+            thread_handle: None,
+        }
+    }
+
+    pub fn start(&mut self) {
+        let mut running = self.running.lock().unwrap();
+        if *running {
+            warn!("process GPID synchronizer is already running");
+            return;
+        }
+        *running = true;
+
+        let runtime = self.runtime.clone();
+        let config = self.config.clone();
+        let agent_id = self.agent_id.clone();
+        let session = self.session.clone();
+        let table = self.table.clone();
+        let running_clone = self.running.clone();
+        let stop_notify = self.stop_notify.clone();
+        self.thread_handle = Some(
+            thread::Builder::new()
+                .name("process-gpid-synchronizer".to_string())
+                .spawn(move || {
+                    Self::run(
+                        runtime,
+                        config,
+                        agent_id,
+                        session,
+                        table,
+                        running_clone,
+                        stop_notify,
+                    )
+                })
+                .unwrap(),
+        );
+        info!("process GPID synchronizer started");
+    }
+
+    pub fn stop(&mut self) {
+        let mut running = self.running.lock().unwrap();
+        if !*running {
+            return;
+        }
+        *running = false;
+        self.stop_notify.notify_one();
+        drop(running);
+        if let Some(handle) = self.thread_handle.take() {
+            let _ = handle.join();
+        }
+        info!("process GPID synchronizer stopped");
+    }
+
+    fn run(
+        runtime: Arc<Runtime>,
+        config: PlatformAccess,
+        agent_id: Arc<RwLock<AgentId>>,
+        session: Arc<Session>,
+        table: ProcessGpidTable,
+        running: Arc<Mutex<bool>>,
+        stop_notify: Arc<Condvar>,
+    ) {
+        let mut last_interval = Duration::ZERO;
+        let mut next_sync = Instant::now();
+        loop {
+            let interval = config.load().process_gpid_sync_interval;
+            if interval.is_zero() {
+                last_interval = Duration::ZERO;
+                next_sync = Instant::now();
+                if !wait_for_running(&running, &stop_notify, Duration::from_secs(1)) {
+                    return;
+                }
+                continue;
+            }
+            if interval != last_interval {
+                last_interval = interval;
+                next_sync = Instant::now();
+            }
+            let now = Instant::now();
+            if now < next_sync {
+                if !wait_for_running(
+                    &running,
+                    &stop_notify,
+                    (next_sync - now).min(Duration::from_secs(1)),
+                ) {
+                    return;
+                }
+                continue;
+            }
+
+            let request = ProcessGpidSyncRequest {
+                agent_id: Some({
+                    let id = agent_id.read();
+                    (&*id).into()
+                }),
+                process_gpid_version: Some(table.version()),
+            };
+            match runtime.block_on(session.grpc_process_gpid_sync(request)) {
+                Err(e) => error!("process GPID sync failed: {e}"),
+                Ok(response) => {
+                    let response = response.into_inner();
+                    let version = response.process_gpid_version.unwrap_or_default();
+                    if version != table.version() {
+                        match decode_entries(&response) {
+                            Ok(entries) => {
+                                let count = entries.len();
+                                table.update(version, entries);
+                                debug!(
+                                    "updated process GPID table to version {version} with {count} entries"
+                                );
+                            }
+                            Err(e) => error!("failed to update process GPID table: {e}"),
+                        }
+                    }
+                }
+            }
+            next_sync = Instant::now() + interval;
+        }
+    }
+}
+
+fn wait_for_running(running: &Mutex<bool>, stop_notify: &Condvar, timeout: Duration) -> bool {
+    let guard = running.lock().unwrap();
+    if !*guard {
+        return false;
+    }
+    let (guard, _) = stop_notify.wait_timeout(guard, timeout).unwrap();
+    *guard
+}
+
+fn decode_entries(response: &ProcessGpidSyncResponse) -> Result<AHashMap<u64, u32>, String> {
+    let data = response.gprocess_infos.as_deref().unwrap_or_default();
+    let decoded = match response.compress_algorithm.unwrap_or_default() {
+        0 => {
+            if data.len() > MAX_PROCESS_GPID_MESSAGE_SIZE {
+                return Err(format!(
+                    "process GPID message is too large: {} > {}",
+                    data.len(),
+                    MAX_PROCESS_GPID_MESSAGE_SIZE
+                ));
+            }
+            data.to_vec()
+        }
+        1 => zstd::bulk::decompress(data, MAX_PROCESS_GPID_MESSAGE_SIZE)
+            .map_err(|e| format!("failed to decompress process GPID message: {e}"))?,
+        algorithm => {
+            return Err(format!(
+                "unknown process GPID compression algorithm {algorithm}"
+            ))
+        }
+    };
+
+    let entries = ProcessGpidEntries::decode(decoded.as_slice())
+        .map_err(|e| format!("failed to decode process GPID entries: {e}"))?
+        .entries;
+    if entries.len() > MAX_PROCESS_GPID_ENTRIES {
+        return Err(format!(
+            "too many process GPID entries: {} > {}",
+            entries.len(),
+            MAX_PROCESS_GPID_ENTRIES
+        ));
+    }
+
+    let mut table = AHashMap::with_capacity(entries.len());
+    for entry in entries {
+        let agent_id = entry.agent_id.unwrap_or_default();
+        let pid = entry.pid.unwrap_or_default();
+        let gpid = entry.gprocess_id.unwrap_or_default();
+        if agent_id == 0 || pid == 0 || gpid == 0 {
+            continue;
+        }
+        table.insert(make_key(agent_id, pid), gpid);
+    }
+    Ok(table)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicI64;
+
+    use crate::common::meta_packet::TraceInfo;
+    use public::proto::agent::ProcessGpidEntry;
+
+    #[test]
+    fn decode_process_gpid_entries() {
+        let entries = ProcessGpidEntries {
+            entries: vec![
+                ProcessGpidEntry {
+                    agent_id: Some(1),
+                    pid: Some(2),
+                    gprocess_id: Some(3),
+                },
+                ProcessGpidEntry {
+                    agent_id: Some(1),
+                    pid: Some(2),
+                    gprocess_id: Some(4),
+                },
+                ProcessGpidEntry::default(),
+            ],
+        };
+        let encoded = entries.encode_to_vec();
+        let response = ProcessGpidSyncResponse {
+            process_gpid_version: Some(1),
+            compress_algorithm: Some(0),
+            gprocess_infos: Some(encoded),
+        };
+
+        let table = decode_entries(&response).unwrap();
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.get(&make_key(1, 2)), Some(&4));
+    }
+
+    #[test]
+    fn decode_zstd_process_gpid_entries() {
+        let entries = ProcessGpidEntries {
+            entries: vec![ProcessGpidEntry {
+                agent_id: Some(10),
+                pid: Some(20),
+                gprocess_id: Some(30),
+            }],
+        };
+        let encoded = zstd::bulk::compress(&entries.encode_to_vec(), 0).unwrap();
+        let response = ProcessGpidSyncResponse {
+            process_gpid_version: Some(1),
+            compress_algorithm: Some(1),
+            gprocess_infos: Some(encoded),
+        };
+
+        let table = decode_entries(&response).unwrap();
+        assert_eq!(table.get(&make_key(10, 20)), Some(&30));
+    }
+
+    #[test]
+    fn lookup_client_and_server_with_lru_and_reload() {
+        let table = ProcessGpidTable::default();
+        table.update(
+            1,
+            AHashMap::from_iter([(make_key(10, 20), 30), (make_key(40, 50), 60)]),
+        );
+        let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
+        let mut lookup = table.new_lookup(1, &stats);
+
+        let mut packet = MetaPacket::default();
+        packet.lookup_key.direction = PacketDirection::ClientToServer;
+        packet.trace_info = Some(TraceInfo {
+            agent_id: 10,
+            pid: 20,
+        });
+        packet.socket_role = SOCKET_ROLE_SERVER;
+        packet.process_id = 50;
+        lookup.lookup(&mut packet, 40);
+        assert_eq!((packet.gpid_0, packet.gpid_1), (30, 60));
+        assert_eq!(lookup.counter.client_table_hit.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.server_table_hit.load(Ordering::Relaxed), 1);
+
+        let mut cached_packet = packet.clone();
+        cached_packet.gpid_0 = 0;
+        cached_packet.gpid_1 = 0;
+        lookup.lookup(&mut cached_packet, 40);
+        assert_eq!(lookup.counter.client_lru_hit.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.server_lru_hit.load(Ordering::Relaxed), 1);
+
+        table.update(
+            2,
+            AHashMap::from_iter([(make_key(10, 20), 31), (make_key(40, 50), 61)]),
+        );
+        lookup.refresh();
+        assert_eq!(lookup.counter.table_reload.load(Ordering::Relaxed), 1);
+
+        let mut reverse_packet = MetaPacket::default();
+        reverse_packet.lookup_key.direction = PacketDirection::ServerToClient;
+        reverse_packet.trace_info = packet.trace_info;
+        reverse_packet.socket_role = SOCKET_ROLE_SERVER;
+        reverse_packet.process_id = 50;
+        lookup.lookup(&mut reverse_packet, 40);
+        assert_eq!((reverse_packet.gpid_0, reverse_packet.gpid_1), (61, 31));
+    }
+
+    #[test]
+    fn lookup_preserves_existing_gpid_and_caches_misses() {
+        let table = ProcessGpidTable::default();
+        let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
+        let mut lookup = table.new_lookup(1, &stats);
+        let mut packet = MetaPacket::default();
+        packet.trace_info = Some(TraceInfo {
+            agent_id: 10,
+            pid: 20,
+        });
+        packet.gpid_0 = 100;
+        packet.socket_role = SOCKET_ROLE_SERVER;
+        packet.process_id = 50;
+
+        lookup.lookup(&mut packet, 40);
+        assert_eq!(packet.gpid_0, 100);
+        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 0);
+        assert_eq!(lookup.counter.server_table_miss.load(Ordering::Relaxed), 1);
+
+        lookup.lookup(&mut packet, 40);
+        assert_eq!(
+            lookup
+                .counter
+                .server_lru_negative_hit
+                .load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn lookup_ignores_process_id_for_non_server_socket() {
+        let table = ProcessGpidTable::default();
+        table.update(1, AHashMap::from_iter([(make_key(40, 50), 60)]));
+        let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
+        let mut lookup = table.new_lookup(1, &stats);
+        let mut packet = MetaPacket::default();
+        packet.socket_role = 1;
+        packet.process_id = 50;
+
+        lookup.lookup(&mut packet, 40);
+        assert_eq!((packet.gpid_0, packet.gpid_1), (0, 0));
+        assert_eq!(lookup.counter.server_table_hit.load(Ordering::Relaxed), 0);
+    }
+}

--- a/agent/src/process_gpid.rs
+++ b/agent/src/process_gpid.rs
@@ -38,9 +38,9 @@ use public::{
 };
 
 use crate::{
-    common::{flow::PacketDirection, MetaPacket},
+    common::meta_packet::TraceInfo,
     config::handler::PlatformAccess,
-    rpc::Session,
+    rpc::{Session, DEFAULT_TIMEOUT},
     trident::AgentId,
     utils::stats,
 };
@@ -48,7 +48,6 @@ use crate::{
 const PROCESS_GPID_LRU_CAPACITY: usize = 4096;
 const MAX_PROCESS_GPID_ENTRIES: usize = 1_000_000;
 const MAX_PROCESS_GPID_MESSAGE_SIZE: usize = 32 << 20;
-const SOCKET_ROLE_SERVER: u8 = 2;
 
 #[derive(Default)]
 struct VersionedTable {
@@ -87,6 +86,11 @@ impl ProcessGpidTable {
         self.inner.version.store(version, Ordering::Release);
     }
 
+    #[cfg(test)]
+    pub(crate) fn update_for_test(&self, version: u64, entries: AHashMap<u64, u32>) {
+        self.update(version, entries);
+    }
+
     fn clear(&self) {
         self.update(0, AHashMap::new());
     }
@@ -96,22 +100,12 @@ impl ProcessGpidTable {
     }
 }
 
-#[derive(Clone, Copy)]
-enum LookupRole {
-    Client,
-    Server,
-}
-
 #[derive(Default)]
 struct ProcessGpidCounter {
     client_lru_hit: AtomicU64,
     client_lru_negative_hit: AtomicU64,
     client_table_hit: AtomicU64,
     client_table_miss: AtomicU64,
-    server_lru_hit: AtomicU64,
-    server_lru_negative_hit: AtomicU64,
-    server_table_hit: AtomicU64,
-    server_table_miss: AtomicU64,
     table_reload: AtomicU64,
 }
 
@@ -132,10 +126,6 @@ impl RefCountable for ProcessGpidCounter {
             counted!("client_lru_negative_hit", client_lru_negative_hit),
             counted!("client_table_hit", client_table_hit),
             counted!("client_table_miss", client_table_miss),
-            counted!("server_lru_hit", server_lru_hit),
-            counted!("server_lru_negative_hit", server_lru_negative_hit),
-            counted!("server_table_hit", server_table_hit),
-            counted!("server_table_miss", server_table_miss),
             counted!("table_reload", table_reload),
         ]
     }
@@ -177,73 +167,45 @@ impl ProcessGpidLookup {
         self.counter.table_reload.fetch_add(1, Ordering::Relaxed);
     }
 
-    fn query(&mut self, agent_id: u32, pid: u32, role: LookupRole) -> u32 {
+    pub(crate) fn lookup(&mut self, trace_info: TraceInfo) -> u32 {
+        let agent_id = trace_info.agent_id;
+        let pid = trace_info.pid;
         if agent_id == 0 || pid == 0 {
             return 0;
         }
         let key = make_key(agent_id, pid);
         if let Some(gpid) = self.lru.get(&key).copied() {
-            let counter = match (role, gpid == 0) {
-                (LookupRole::Client, false) => &self.counter.client_lru_hit,
-                (LookupRole::Client, true) => &self.counter.client_lru_negative_hit,
-                (LookupRole::Server, false) => &self.counter.server_lru_hit,
-                (LookupRole::Server, true) => &self.counter.server_lru_negative_hit,
+            let counter = match gpid == 0 {
+                false => &self.counter.client_lru_hit,
+                true => &self.counter.client_lru_negative_hit,
             };
             counter.fetch_add(1, Ordering::Relaxed);
             return gpid;
         }
 
         let gpid = self.table.entries.get(&key).copied().unwrap_or_default();
-        let counter = match (role, gpid == 0) {
-            (LookupRole::Client, false) => &self.counter.client_table_hit,
-            (LookupRole::Client, true) => &self.counter.client_table_miss,
-            (LookupRole::Server, false) => &self.counter.server_table_hit,
-            (LookupRole::Server, true) => &self.counter.server_table_miss,
+        let counter = match gpid == 0 {
+            false => &self.counter.client_table_hit,
+            true => &self.counter.client_table_miss,
         };
         counter.fetch_add(1, Ordering::Relaxed);
         self.lru.put(key, gpid);
         gpid
     }
-
-    pub fn lookup(&mut self, packet: &mut MetaPacket, local_agent_id: u32) {
-        let client_is_src = packet.lookup_key.direction == PacketDirection::ClientToServer;
-        let client_gpid_is_empty = if client_is_src {
-            packet.gpid_0 == 0
-        } else {
-            packet.gpid_1 == 0
-        };
-        if client_gpid_is_empty {
-            if let Some(trace_info) = packet.trace_info {
-                let gpid = self.query(trace_info.agent_id, trace_info.pid, LookupRole::Client);
-                if client_is_src {
-                    packet.gpid_0 = gpid;
-                } else {
-                    packet.gpid_1 = gpid;
-                }
-            }
-        }
-
-        let server_gpid_is_empty = if client_is_src {
-            packet.gpid_1 == 0
-        } else {
-            packet.gpid_0 == 0
-        };
-        if server_gpid_is_empty
-            && packet.socket_role == SOCKET_ROLE_SERVER
-            && packet.process_id != 0
-        {
-            let gpid = self.query(local_agent_id, packet.process_id, LookupRole::Server);
-            if client_is_src {
-                packet.gpid_1 = gpid;
-            } else {
-                packet.gpid_0 = gpid;
-            }
-        }
-    }
 }
 
 fn make_key(agent_id: u32, pid: u32) -> u64 {
     ((agent_id as u64) << 32) | pid as u64
+}
+
+async fn rpc_with_timeout<F>(
+    timeout: Duration,
+    future: F,
+) -> Result<F::Output, tokio::time::error::Elapsed>
+where
+    F: std::future::Future,
+{
+    tokio::time::timeout(timeout, future).await
 }
 
 pub struct ProcessGpidSynchronizer {
@@ -376,9 +338,13 @@ impl ProcessGpidSynchronizer {
                 }),
                 process_gpid_version: Some(table.version()),
             };
-            match runtime.block_on(session.grpc_process_gpid_sync(request)) {
-                Err(e) => error!("process GPID sync failed: {e}"),
-                Ok(response) => {
+            match runtime.block_on(rpc_with_timeout(
+                DEFAULT_TIMEOUT,
+                session.grpc_process_gpid_sync(request),
+            )) {
+                Err(_) => error!("process GPID sync timed out after {:?}", DEFAULT_TIMEOUT),
+                Ok(Err(e)) => error!("process GPID sync failed: {e}"),
+                Ok(Ok(response)) => {
                     let response = response.into_inner();
                     let version = response.process_gpid_version.unwrap_or_default();
                     if version != table.version() {
@@ -464,6 +430,18 @@ mod tests {
     use public::proto::agent::ProcessGpidEntry;
 
     #[test]
+    fn rpc_timeout_bounds_wait() {
+        let runtime = Runtime::new().unwrap();
+        let timeout = Duration::from_millis(10);
+        let start = Instant::now();
+
+        let result = runtime.block_on(rpc_with_timeout(timeout, std::future::pending::<()>()));
+
+        assert!(result.is_err());
+        assert!(start.elapsed() < Duration::from_secs(1));
+    }
+
+    #[test]
     fn decode_process_gpid_entries() {
         let entries = ProcessGpidEntries {
             entries: vec![
@@ -513,93 +491,50 @@ mod tests {
     }
 
     #[test]
-    fn lookup_client_and_server_with_lru_and_reload() {
+    fn lookup_with_lru_and_reload() {
         let table = ProcessGpidTable::default();
-        table.update(
-            1,
-            AHashMap::from_iter([(make_key(10, 20), 30), (make_key(40, 50), 60)]),
-        );
+        table.update(1, AHashMap::from_iter([(make_key(10, 20), 30)]));
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-
-        let mut packet = MetaPacket::default();
-        packet.lookup_key.direction = PacketDirection::ClientToServer;
-        packet.trace_info = Some(TraceInfo {
+        let trace_info = TraceInfo {
             agent_id: 10,
             pid: 20,
-        });
-        packet.socket_role = SOCKET_ROLE_SERVER;
-        packet.process_id = 50;
-        lookup.lookup(&mut packet, 40);
-        assert_eq!((packet.gpid_0, packet.gpid_1), (30, 60));
+        };
+
+        assert_eq!(lookup.lookup(trace_info), 30);
         assert_eq!(lookup.counter.client_table_hit.load(Ordering::Relaxed), 1);
-        assert_eq!(lookup.counter.server_table_hit.load(Ordering::Relaxed), 1);
 
-        let mut cached_packet = packet.clone();
-        cached_packet.gpid_0 = 0;
-        cached_packet.gpid_1 = 0;
-        lookup.lookup(&mut cached_packet, 40);
+        assert_eq!(lookup.lookup(trace_info), 30);
         assert_eq!(lookup.counter.client_lru_hit.load(Ordering::Relaxed), 1);
-        assert_eq!(lookup.counter.server_lru_hit.load(Ordering::Relaxed), 1);
 
-        table.update(
-            2,
-            AHashMap::from_iter([(make_key(10, 20), 31), (make_key(40, 50), 61)]),
-        );
+        table.update(2, AHashMap::from_iter([(make_key(10, 20), 31)]));
         lookup.refresh();
         assert_eq!(lookup.counter.table_reload.load(Ordering::Relaxed), 1);
 
-        let mut reverse_packet = MetaPacket::default();
-        reverse_packet.lookup_key.direction = PacketDirection::ServerToClient;
-        reverse_packet.trace_info = packet.trace_info;
-        reverse_packet.socket_role = SOCKET_ROLE_SERVER;
-        reverse_packet.process_id = 50;
-        lookup.lookup(&mut reverse_packet, 40);
-        assert_eq!((reverse_packet.gpid_0, reverse_packet.gpid_1), (61, 31));
+        assert_eq!(lookup.lookup(trace_info), 31);
     }
 
     #[test]
-    fn lookup_preserves_existing_gpid_and_caches_misses() {
+    fn lookup_caches_misses() {
         let table = ProcessGpidTable::default();
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-        let mut packet = MetaPacket::default();
-        packet.trace_info = Some(TraceInfo {
+        let trace_info = TraceInfo {
             agent_id: 10,
             pid: 20,
-        });
-        packet.gpid_0 = 100;
-        packet.socket_role = SOCKET_ROLE_SERVER;
-        packet.process_id = 50;
+        };
 
-        lookup.lookup(&mut packet, 40);
-        assert_eq!(packet.gpid_0, 100);
-        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 0);
-        assert_eq!(lookup.counter.server_table_miss.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.lookup(trace_info), 0);
+        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 1);
 
-        lookup.lookup(&mut packet, 40);
+        assert_eq!(lookup.lookup(trace_info), 0);
         assert_eq!(
             lookup
                 .counter
-                .server_lru_negative_hit
+                .client_lru_negative_hit
                 .load(Ordering::Relaxed),
             1
         );
-    }
-
-    #[test]
-    fn lookup_ignores_process_id_for_non_server_socket() {
-        let table = ProcessGpidTable::default();
-        table.update(1, AHashMap::from_iter([(make_key(40, 50), 60)]));
-        let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
-        let mut lookup = table.new_lookup(1, &stats);
-        let mut packet = MetaPacket::default();
-        packet.socket_role = 1;
-        packet.process_id = 50;
-
-        lookup.lookup(&mut packet, 40);
-        assert_eq!((packet.gpid_0, packet.gpid_1), (0, 0));
-        assert_eq!(lookup.counter.server_table_hit.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -608,15 +543,12 @@ mod tests {
         table.update(7, AHashMap::from_iter([(make_key(10, 20), 30)]));
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-        let trace_info = Some(TraceInfo {
+        let trace_info = TraceInfo {
             agent_id: 10,
             pid: 20,
-        });
+        };
 
-        let mut packet = MetaPacket::default();
-        packet.trace_info = trace_info;
-        lookup.lookup(&mut packet, 0);
-        assert_eq!(packet.gpid_0, 30);
+        assert_eq!(lookup.lookup(trace_info), 30);
 
         let old_version = table.version();
         table.clear();
@@ -624,10 +556,7 @@ mod tests {
         assert_ne!(table.version(), old_version);
         lookup.refresh();
 
-        let mut packet = MetaPacket::default();
-        packet.trace_info = trace_info;
-        lookup.lookup(&mut packet, 0);
-        assert_eq!(packet.gpid_0, 0);
+        assert_eq!(lookup.lookup(trace_info), 0);
         assert_eq!(lookup.counter.table_reload.load(Ordering::Relaxed), 1);
         assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 1);
     }

--- a/agent/src/process_gpid.rs
+++ b/agent/src/process_gpid.rs
@@ -87,6 +87,10 @@ impl ProcessGpidTable {
         self.inner.version.store(version, Ordering::Release);
     }
 
+    fn clear(&self) {
+        self.update(0, AHashMap::new());
+    }
+
     pub fn new_lookup(&self, id: u32, stats_collector: &stats::Collector) -> ProcessGpidLookup {
         ProcessGpidLookup::new(self.inner.clone(), id, stats_collector)
     }
@@ -332,9 +336,15 @@ impl ProcessGpidSynchronizer {
     ) {
         let mut last_interval = Duration::ZERO;
         let mut next_sync = Instant::now();
+        let mut disabled = false;
         loop {
             let interval = config.load().process_gpid_sync_interval;
             if interval.is_zero() {
+                if !disabled {
+                    table.clear();
+                    disabled = true;
+                    info!("process GPID synchronization disabled and lookup table cleared");
+                }
                 last_interval = Duration::ZERO;
                 next_sync = Instant::now();
                 if !wait_for_running(&running, &stop_notify, Duration::from_secs(1)) {
@@ -342,6 +352,7 @@ impl ProcessGpidSynchronizer {
                 }
                 continue;
             }
+            disabled = false;
             if interval != last_interval {
                 last_interval = interval;
                 next_sync = Instant::now();
@@ -589,5 +600,35 @@ mod tests {
         lookup.lookup(&mut packet, 40);
         assert_eq!((packet.gpid_0, packet.gpid_1), (0, 0));
         assert_eq!(lookup.counter.server_table_hit.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn clear_invalidates_lookup_table_and_lru() {
+        let table = ProcessGpidTable::default();
+        table.update(7, AHashMap::from_iter([(make_key(10, 20), 30)]));
+        let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
+        let mut lookup = table.new_lookup(1, &stats);
+        let trace_info = Some(TraceInfo {
+            agent_id: 10,
+            pid: 20,
+        });
+
+        let mut packet = MetaPacket::default();
+        packet.trace_info = trace_info;
+        lookup.lookup(&mut packet, 0);
+        assert_eq!(packet.gpid_0, 30);
+
+        let old_version = table.version();
+        table.clear();
+        assert_eq!(table.version(), 0);
+        assert_ne!(table.version(), old_version);
+        lookup.refresh();
+
+        let mut packet = MetaPacket::default();
+        packet.trace_info = trace_info;
+        lookup.lookup(&mut packet, 0);
+        assert_eq!(packet.gpid_0, 0);
+        assert_eq!(lookup.counter.table_reload.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 1);
     }
 }

--- a/agent/src/rpc/session.rs
+++ b/agent/src/rpc/session.rs
@@ -43,7 +43,7 @@ use public::{
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 pub const SESSION_TIMEOUT: Duration = Duration::from_secs(30);
 
-const GRPC_CALL_ENDPOINTS: [&str; 10] = [
+const GRPC_CALL_ENDPOINTS: [&str; 11] = [
     "push",
     "ntp",
     "upgrade",
@@ -52,6 +52,7 @@ const GRPC_CALL_ENDPOINTS: [&str; 10] = [
     "kubernetes_api_sync",
     "get_kubernetes_cluster_id",
     "gpid_sync",
+    "process_gpid_sync",
     "plugin",
     "prometheus_api_sync",
 ];
@@ -64,7 +65,8 @@ const GENESIS_SYNC_ENDPOINT: usize = 4;
 const KUBERNETES_API_SYNC_ENDPOINT: usize = 5;
 const GET_KUBERNETES_CLUSTER_ID_ENDPOINT: usize = 6;
 const GPID_SYNC_ENDPOINT: usize = 7;
-const PLUGIN_ENDPOINT: usize = 8;
+const PROCESS_GPID_SYNC_ENDPOINT: usize = 8;
+const PLUGIN_ENDPOINT: usize = 9;
 
 macro_rules! response_size {
     (push, $($_:ident),*) => {
@@ -431,6 +433,13 @@ impl Session {
         request: agent::GpidSyncRequest,
     ) -> Result<tonic::Response<agent::GpidSyncResponse>, tonic::Status> {
         sync_grpc_call_unary!(self, gpid_sync, request, GPID_SYNC_ENDPOINT)
+    }
+
+    pub async fn grpc_process_gpid_sync(
+        &self,
+        request: agent::ProcessGpidSyncRequest,
+    ) -> Result<tonic::Response<agent::ProcessGpidSyncResponse>, tonic::Status> {
+        sync_grpc_call_unary!(self, process_gpid_sync, request, PROCESS_GPID_SYNC_ENDPOINT)
     }
 
     pub async fn grpc_plugin(

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -84,6 +84,7 @@ use crate::{
     monitor::Monitor,
     platform::synchronizer::Synchronizer as PlatformSynchronizer,
     policy::{Policy, PolicyGetter, PolicySetter},
+    process_gpid::{ProcessGpidSynchronizer, ProcessGpidTable},
     rpc::{Session, Synchronizer, DEFAULT_TIMEOUT},
     sender::{
         npb_sender::NpbArpTable,
@@ -1325,6 +1326,7 @@ fn component_on_config_change(
                     components.npb_arp_table.clone(),
                     components.rx_leaky_bucket.clone(),
                     components.policy_getter,
+                    components.process_gpid_table.clone(),
                     components.exception_handler.clone(),
                     components.bpf_options.clone(),
                     components.packet_sequence_uniform_output.clone(),
@@ -1446,6 +1448,7 @@ fn component_on_config_change(
                     components.npb_arp_table.clone(),
                     components.rx_leaky_bucket.clone(),
                     components.policy_getter,
+                    components.process_gpid_table.clone(),
                     components.exception_handler.clone(),
                     components.bpf_options.clone(),
                     components.packet_sequence_uniform_output.clone(),
@@ -1804,6 +1807,8 @@ pub struct AgentComponents {
     pub kubernetes_poller: Arc<GenericPoller>,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub socket_synchronizer: SocketSynchronizer,
+    pub process_gpid_synchronizer: ProcessGpidSynchronizer,
+    pub process_gpid_table: ProcessGpidTable,
     pub debugger: Debugger,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub ebpf_dispatcher_component: Option<EbpfDispatcherComponent>,
@@ -2404,6 +2409,15 @@ impl AgentComponents {
             process_listener.clone(),
         );
 
+        let process_gpid_table = ProcessGpidTable::default();
+        let process_gpid_synchronizer = ProcessGpidSynchronizer::new(
+            runtime.clone(),
+            config_handler.platform(),
+            synchronizer.agent_id.clone(),
+            session.clone(),
+            process_gpid_table.clone(),
+        );
+
         let rx_leaky_bucket = Arc::new(LeakyBucket::new(match candidate_config.capture_mode {
             PacketCaptureType::Analyzer => None,
             _ => Some(
@@ -2665,6 +2679,7 @@ impl AgentComponents {
                 npb_arp_table.clone(),
                 rx_leaky_bucket.clone(),
                 policy_getter,
+                process_gpid_table.clone(),
                 exception_handler.clone(),
                 bpf_options.clone(),
                 packet_sequence_uniform_output.clone(),
@@ -2918,6 +2933,7 @@ impl AgentComponents {
                 config_handler.flow(),
                 config_handler.collector(),
                 policy_getter,
+                process_gpid_table.clone(),
                 dpdk_ebpf_senders,
                 log_sender,
                 l7_stats_sender,
@@ -3180,6 +3196,8 @@ impl AgentComponents {
             kubernetes_poller,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             socket_synchronizer,
+            process_gpid_synchronizer,
+            process_gpid_table,
             debugger,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             ebpf_dispatcher_component,
@@ -3242,6 +3260,7 @@ impl AgentComponents {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         self.socket_synchronizer.start();
+        self.process_gpid_synchronizer.start();
         #[cfg(target_os = "linux")]
         if crate::utils::environment::is_tt_pod(self.config.agent_type) {
             self.kubernetes_poller.start();
@@ -3318,6 +3337,7 @@ impl AgentComponents {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         self.socket_synchronizer.stop();
+        self.process_gpid_synchronizer.stop();
         #[cfg(target_os = "linux")]
         self.kubernetes_poller.stop();
 
@@ -3524,6 +3544,7 @@ fn build_dispatchers(
     npb_arp_table: Arc<NpbArpTable>,
     rx_leaky_bucket: Arc<LeakyBucket>,
     policy_getter: PolicyGetter,
+    process_gpid_table: ProcessGpidTable,
     exception_handler: ExceptionHandler,
     bpf_options: Arc<Mutex<BpfOptions>>,
     packet_sequence_uniform_output: DebugSender<BoxedPacketSequenceBlock>,
@@ -3752,6 +3773,7 @@ fn build_dispatchers(
         .collector_config(config_handler.collector())
         .dispatcher_config(config_handler.dispatcher())
         .policy_getter(policy_getter)
+        .process_gpid_table(process_gpid_table)
         .exception_handler(exception_handler.clone())
         .ntp_diff(synchronizer.ntp_diff())
         .src_interface(

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -28,6 +28,8 @@ pub mod stats;
 
 #[cfg(target_os = "linux")]
 pub(crate) mod pid_file;
+#[cfg(target_os = "linux")]
+pub(crate) mod tcp_option_tracing;
 
 pub use public::bytes;
 

--- a/agent/src/utils/tcp_option_tracing.rs
+++ b/agent/src/utils/tcp_option_tracing.rs
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::{fs::OpenOptions, io, os::unix::io::AsRawFd};
+
+const TOT_DEVICE_PATH: &str = "/dev/tot";
+
+// Keep in sync with TOT_IOC_SET_AGENT_ID in tot/module/tot_ioctl.h:
+// _IOW('T', 1, __u32)
+nix::ioctl_write_ptr!(tot_set_agent_id, b'T', 1, u32);
+
+pub(crate) fn set_agent_id(agent_id: u32) -> io::Result<()> {
+    let device = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(TOT_DEVICE_PATH)?;
+
+    unsafe { tot_set_agent_id(device.as_raw_fd(), &agent_id) }
+        .map(|_| ())
+        .map_err(|errno| io::Error::from_raw_os_error(errno as i32))
+}

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -1210,6 +1210,25 @@ inputs:
     socket_info_sync_interval: 0ns
     # type: duration
     # name:
+    #   en: Process GPID Synchronization Interval
+    #   ch: 进程 GPID 同步间隔
+    # unit:
+    # range: [0ns, 1h]
+    # enum_options: []
+    # modification: hot_update
+    # ee_feature: false
+    # description:
+    #   en: |-
+    #     Synchronization interval for the process GPID mapping table.
+    #
+    #     '0ns' means disabled. Do not configure a value less than `1s` except for `0ns`.
+    #   ch: |-
+    #     进程 GPID 映射表的同步周期。
+    #
+    #     '0ns' 表示不开启，除 '0ns' 外不要配置小于 `1s` 的值。
+    process_gpid_sync_interval: 10s
+    # type: duration
+    # name:
     #   en: Minimal Lifetime
     #   ch: 最小活跃时间
     # unit:


### PR DESCRIPTION
## Summary
- synchronize the versioned `(agent_id, pid) -> gprocess_id` table through ProcessGPIDSync with a hot-updatable 10s default interval
- use an immutable AHashMap published through ArcSwap, per-FlowMap 4096-entry positive/negative LRU caches, batch-level refresh, and lookup counters
- mark client GPID from TraceInfo and server GPID from the local agent/process ID while preserving existing GPIDs and legacy direction/NAT correction

## Tests
- `cargo check --lib`
- `cargo test --lib process_gpid`
- `cargo test --lib legacy_gpid_only_fills_empty_side`
- `cargo test --lib parse_user_config`
- `go test ./agent_config -run ^TestValidateYAML$`
- `cargo fmt --all -- --check`