### PR TITLE
fix: match process GPID to packet source

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -270,9 +270,10 @@ impl FlowMap {
         let Some(trace_info) = meta_packet.trace_info else {
             return;
         };
-        let client = &mut node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC];
-        if client.gpid == 0 {
-            client.gpid = self.process_gpid.lookup(trace_info);
+        let source = &mut node.tagged_flow.flow.flow_metrics_peers
+            [meta_packet.lookup_key.direction as usize];
+        if source.gpid == 0 {
+            source.gpid = self.process_gpid.lookup(trace_info);
         }
     }
 
@@ -2899,18 +2900,27 @@ mod tests {
     }
 
     #[test]
-    fn process_gpid_updates_only_packet_client_peer() {
+    fn process_gpid_updates_packet_source_peer() {
         const CLIENT_AGENT_ID: u32 = 10;
         const CLIENT_PID: u32 = 20;
         const CLIENT_GPID: u32 = 30;
+        const SERVER_AGENT_ID: u32 = 40;
+        const SERVER_PID: u32 = 50;
+        const SERVER_GPID: u32 = 60;
 
         let process_gpid_table = ProcessGpidTable::default();
         process_gpid_table.update_for_test(
             1,
-            AHashMap::from_iter([(
-                ((CLIENT_AGENT_ID as u64) << 32) | CLIENT_PID as u64,
-                CLIENT_GPID,
-            )]),
+            AHashMap::from_iter([
+                (
+                    ((CLIENT_AGENT_ID as u64) << 32) | CLIENT_PID as u64,
+                    CLIENT_GPID,
+                ),
+                (
+                    ((SERVER_AGENT_ID as u64) << 32) | SERVER_PID as u64,
+                    SERVER_GPID,
+                ),
+            ]),
         );
         let (mut module_config, mut flow_map, _) = _new_flow_map_and_receiver_with_process_gpid(
             AgentType::TtProcess,
@@ -2927,13 +2937,13 @@ mod tests {
             ebpf: None,
         };
 
-        // TraceInfo identifies the client even when the first packet is a SYN-ACK and the
-        // packet direction has to be reversed before creating the flow.
+        // TraceInfo identifies the MetaPacket source. When the first packet is a SYN-ACK,
+        // direction correction makes the server the flow's destination peer.
         let mut packet = _new_meta_packet();
         packet.signal_source = SignalSource::Packet;
         packet.trace_info = Some(TraceInfo {
-            agent_id: CLIENT_AGENT_ID,
-            pid: CLIENT_PID,
+            agent_id: SERVER_AGENT_ID,
+            pid: SERVER_PID,
         });
         if let ProtocolData::TcpHeader(tcp_data) = &mut packet.protocol_data {
             tcp_data.flags = TcpFlags::SYN_ACK;
@@ -2941,7 +2951,7 @@ mod tests {
         let server_ip = packet.lookup_key.src_ip;
         let client_ip = packet.lookup_key.dst_ip;
 
-        let node = flow_map.new_tcp_node(&config, &mut packet);
+        let mut node = flow_map.new_tcp_node(&config, &mut packet);
 
         assert_eq!(packet.lookup_key.direction, PacketDirection::ServerToClient);
         assert_eq!((packet.gpid_0, packet.gpid_1), (0, 0));
@@ -2949,27 +2959,50 @@ mod tests {
         assert_eq!(node.tagged_flow.flow.flow_key.ip_dst, server_ip);
         assert_eq!(
             node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            0
+        );
+        assert_eq!(
+            node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_DST].gpid,
+            SERVER_GPID
+        );
+
+        let mut client_packet = packet.clone();
+        client_packet.lookup_key.direction = PacketDirection::ClientToServer;
+        client_packet.trace_info = Some(TraceInfo {
+            agent_id: CLIENT_AGENT_ID,
+            pid: CLIENT_PID,
+        });
+        flow_map.lookup_process_gpid(&client_packet, &mut node);
+        assert_eq!(
+            node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
             CLIENT_GPID
         );
         assert_eq!(
             node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_DST].gpid,
-            0
+            SERVER_GPID
         );
 
-        let mut existing_node = FlowNode::default();
-        existing_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid = 100;
-        flow_map.lookup_process_gpid(&packet, &mut existing_node);
+        // Do not overwrite a GPID already set on the packet's source peer.
+        client_packet.trace_info = Some(TraceInfo {
+            agent_id: SERVER_AGENT_ID,
+            pid: SERVER_PID,
+        });
+        flow_map.lookup_process_gpid(&client_packet, &mut node);
         assert_eq!(
-            existing_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
-            100
+            node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            CLIENT_GPID
         );
 
-        let mut ebpf_packet = packet.clone();
+        let mut ebpf_packet = client_packet;
         ebpf_packet.signal_source = SignalSource::EBPF;
         let mut ebpf_node = FlowNode::default();
         flow_map.lookup_process_gpid(&ebpf_packet, &mut ebpf_node);
         assert_eq!(
             ebpf_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
+            0
+        );
+        assert_eq!(
+            ebpf_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_DST].gpid,
             0
         );
     }

--- a/agent/src/process_gpid.rs
+++ b/agent/src/process_gpid.rs
@@ -102,10 +102,10 @@ impl ProcessGpidTable {
 
 #[derive(Default)]
 struct ProcessGpidCounter {
-    client_lru_hit: AtomicU64,
-    client_lru_negative_hit: AtomicU64,
-    client_table_hit: AtomicU64,
-    client_table_miss: AtomicU64,
+    lru_hit: AtomicU64,
+    lru_negative_hit: AtomicU64,
+    table_hit: AtomicU64,
+    table_miss: AtomicU64,
     table_reload: AtomicU64,
 }
 
@@ -122,10 +122,10 @@ impl RefCountable for ProcessGpidCounter {
         }
 
         vec![
-            counted!("client_lru_hit", client_lru_hit),
-            counted!("client_lru_negative_hit", client_lru_negative_hit),
-            counted!("client_table_hit", client_table_hit),
-            counted!("client_table_miss", client_table_miss),
+            counted!("lru_hit", lru_hit),
+            counted!("lru_negative_hit", lru_negative_hit),
+            counted!("table_hit", table_hit),
+            counted!("table_miss", table_miss),
             counted!("table_reload", table_reload),
         ]
     }
@@ -176,8 +176,8 @@ impl ProcessGpidLookup {
         let key = make_key(agent_id, pid);
         if let Some(gpid) = self.lru.get(&key).copied() {
             let counter = match gpid == 0 {
-                false => &self.counter.client_lru_hit,
-                true => &self.counter.client_lru_negative_hit,
+                false => &self.counter.lru_hit,
+                true => &self.counter.lru_negative_hit,
             };
             counter.fetch_add(1, Ordering::Relaxed);
             return gpid;
@@ -185,8 +185,8 @@ impl ProcessGpidLookup {
 
         let gpid = self.table.entries.get(&key).copied().unwrap_or_default();
         let counter = match gpid == 0 {
-            false => &self.counter.client_table_hit,
-            true => &self.counter.client_table_miss,
+            false => &self.counter.table_hit,
+            true => &self.counter.table_miss,
         };
         counter.fetch_add(1, Ordering::Relaxed);
         self.lru.put(key, gpid);
@@ -502,10 +502,10 @@ mod tests {
         };
 
         assert_eq!(lookup.lookup(trace_info), 30);
-        assert_eq!(lookup.counter.client_table_hit.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.table_hit.load(Ordering::Relaxed), 1);
 
         assert_eq!(lookup.lookup(trace_info), 30);
-        assert_eq!(lookup.counter.client_lru_hit.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.lru_hit.load(Ordering::Relaxed), 1);
 
         table.update(2, AHashMap::from_iter([(make_key(10, 20), 31)]));
         lookup.refresh();
@@ -525,16 +525,10 @@ mod tests {
         };
 
         assert_eq!(lookup.lookup(trace_info), 0);
-        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.table_miss.load(Ordering::Relaxed), 1);
 
         assert_eq!(lookup.lookup(trace_info), 0);
-        assert_eq!(
-            lookup
-                .counter
-                .client_lru_negative_hit
-                .load(Ordering::Relaxed),
-            1
-        );
+        assert_eq!(lookup.counter.lru_negative_hit.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -558,6 +552,6 @@ mod tests {
 
         assert_eq!(lookup.lookup(trace_info), 0);
         assert_eq!(lookup.counter.table_reload.load(Ordering::Relaxed), 1);
-        assert_eq!(lookup.counter.client_table_miss.load(Ordering::Relaxed), 1);
+        assert_eq!(lookup.counter.table_miss.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Summary

- treat TCP option TraceInfo as belonging to the MetaPacket source
- write C2S lookups to the client peer and S2C lookups to the server peer
- rename ProcessGPID lookup counters to remove the client-only meaning

## Tests

- cargo fmt --all -- --check
- cargo test --lib process_gpid -- --nocapture