### PR TITLE
fix: disable process GPID sync by default

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -609,7 +609,7 @@ impl Default for Proc {
             enabled: true,
             proc_dir_path: "/proc".to_string(),
             socket_info_sync_interval: Duration::from_secs(0),
-            process_gpid_sync_interval: Duration::from_secs(10),
+            process_gpid_sync_interval: Duration::ZERO,
             min_lifetime: Duration::from_secs(3),
             tag_extraction: TagExtraction::default(),
             process_blacklist: vec![

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -1705,6 +1705,35 @@ inputs:
 即 `inputs.proc.process_matcher.[*].enabled_features` 中需要包含 `proc.socket_list`。
 另外，也要注意确认 `inputs.proc.enabled` 已配置为 **true**。
 
+### 进程 GPID 同步间隔 {#inputs.proc.process_gpid_sync_interval}
+
+**标签**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.proc.process_gpid_sync_interval`
+
+**默认值**:
+```yaml
+inputs:
+  proc:
+    process_gpid_sync_interval: 0ns
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | duration |
+| Range | ['0ns', '1h'] |
+
+**详细描述**:
+
+进程 GPID 映射表的同步周期。
+
+'0ns' 表示不开启，除 '0ns' 外不要配置小于 `1s` 的值。
+
 ### 最小活跃时间 {#inputs.proc.min_lifetime}
 
 **标签**:

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -1733,6 +1733,35 @@ Note: When enabling this feature, the specific process list must also be specifi
 i.e., `proc.socket_list` must be included in `inputs.proc.process_matcher.[*].enabled_features`.
 Additionally, ensure `inputs.proc.enabled` is configured to **true**.
 
+### Process GPID Synchronization Interval {#inputs.proc.process_gpid_sync_interval}
+
+**Tags**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.proc.process_gpid_sync_interval`
+
+**Default value**:
+```yaml
+inputs:
+  proc:
+    process_gpid_sync_interval: 0ns
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | duration |
+| Range | ['0ns', '1h'] |
+
+**Description**:
+
+Synchronization interval for the process GPID mapping table.
+
+'0ns' means disabled. Do not configure a value less than `1s` except for `0ns`.
+
 ### Minimal Lifetime {#inputs.proc.min_lifetime}
 
 **Tags**:

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -1226,7 +1226,7 @@ inputs:
     #     进程 GPID 映射表的同步周期。
     #
     #     '0ns' 表示不开启，除 '0ns' 外不要配置小于 `1s` 的值。
-    process_gpid_sync_interval: 10s
+    process_gpid_sync_interval: 0ns
     # type: duration
     # name:
     #   en: Minimal Lifetime


### PR DESCRIPTION
## Summary

- disable process GPID synchronization by default
- regenerate the English and Chinese agent configuration documentation

## Test

- `cargo test -p deepflow-agent config::config::tests::validate_process_gpid_sync_interval --lib`