### PR TITLE
feat(agent): support TCP option tracing v2

### DIFF
--- a/agent/crates/public/src/consts.rs
+++ b/agent/crates/public/src/consts.rs
@@ -228,9 +228,11 @@ pub const TCP_TOA_IP_OFFSET: usize = 4;
 // YunShan https://github.com/deepflowio/tcp-option-tracing
 pub const TCP_OPT_TRACING: u8 = 253;
 pub const TCP_TOT_LEN: usize = 12;
-pub const TCP_TOT_MAGIC: u16 = 0xdeea;
+pub const TCP_TOT_V1_MAGIC: u16 = 0xdee9;
+pub const TCP_TOT_V2_MAGIC: u16 = 0xdeea;
 pub const TCP_TOT_MAGIC_OFFSET: usize = 2;
 pub const TCP_TOT_PID_OFFSET: usize = 4;
+pub const TCP_TOT_SOURCE_IP_OFFSET: usize = 8;
 pub const TCP_TOT_AGENT_ID_OFFSET: usize = 8;
 
 pub const VLAN_ID_MASK: u16 = 0xfff;

--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -184,10 +184,19 @@ pub struct SubPacket {
     tcp_seq: u32,
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct TraceInfo {
-    pub pid: u32,
-    pub agent_id: u32,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TraceInfo {
+    V1 { pid: u32, source_ip: Ipv4Addr },
+    V2 { pid: u32, agent_id: u32 },
+}
+
+impl Default for TraceInfo {
+    fn default() -> Self {
+        Self::V2 {
+            pid: 0,
+            agent_id: 0,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -456,15 +465,24 @@ impl<'a> MetaPacket<'a> {
                     offset += assume_length;
                 }
                 TcpOptionNumber(TCP_OPT_TRACING) => {
-                    if assume_length == TCP_TOT_LEN
-                        && offset + TCP_TOT_LEN <= payload_offset
-                        && read_u16_be(&packet[offset + TCP_TOT_MAGIC_OFFSET..]) == TCP_TOT_MAGIC
-                        && self.trace_info.is_none()
-                    {
-                        self.trace_info = Some(TraceInfo {
-                            pid: read_u32_be(&packet[offset + TCP_TOT_PID_OFFSET..]),
-                            agent_id: read_u32_be(&packet[offset + TCP_TOT_AGENT_ID_OFFSET..]),
-                        });
+                    if assume_length == TCP_TOT_LEN && offset + TCP_TOT_LEN <= payload_offset {
+                        let magic = read_u16_be(&packet[offset + TCP_TOT_MAGIC_OFFSET..]);
+                        let pid = read_u32_be(&packet[offset + TCP_TOT_PID_OFFSET..]);
+                        if magic == TCP_TOT_V2_MAGIC
+                            && !matches!(self.trace_info, Some(TraceInfo::V2 { .. }))
+                        {
+                            self.trace_info = Some(TraceInfo::V2 {
+                                pid,
+                                agent_id: read_u32_be(&packet[offset + TCP_TOT_AGENT_ID_OFFSET..]),
+                            });
+                        } else if magic == TCP_TOT_V1_MAGIC && self.trace_info.is_none() {
+                            self.trace_info = Some(TraceInfo::V1 {
+                                pid,
+                                source_ip: Ipv4Addr::from(read_u32_be(
+                                    &packet[offset + TCP_TOT_SOURCE_IP_OFFSET..],
+                                )),
+                            });
+                        }
                     }
                     offset += assume_length;
                 }
@@ -1524,6 +1542,16 @@ mod tests {
         meta_packet
     }
 
+    fn tcp_trace_option(magic: u16, pid: u32, metadata: u32) -> [u8; TCP_TOT_LEN] {
+        let mut option = [0; TCP_TOT_LEN];
+        option[0] = TCP_OPT_TRACING;
+        option[1] = TCP_TOT_LEN as u8;
+        option[2..4].copy_from_slice(&magic.to_be_bytes());
+        option[4..8].copy_from_slice(&pid.to_be_bytes());
+        option[8..12].copy_from_slice(&metadata.to_be_bytes());
+        option
+    }
+
     #[test]
     fn get_pkt_size() {
         let pkt = MetaPacket {
@@ -1571,7 +1599,7 @@ mod tests {
 
         assert_eq!(
             meta_packet.trace_info,
-            Some(TraceInfo {
+            Some(TraceInfo::V2 {
                 pid: 0x01234567,
                 agent_id: 0x89abcdef,
             })
@@ -1583,9 +1611,23 @@ mod tests {
     }
 
     #[test]
+    fn parse_v1_tcp_trace_option() {
+        let meta_packet =
+            parse_tcp_options(&tcp_trace_option(TCP_TOT_V1_MAGIC, 0x01234567, 0x0a000001));
+
+        assert_eq!(
+            meta_packet.trace_info,
+            Some(TraceInfo::V1 {
+                pid: 0x01234567,
+                source_ip: Ipv4Addr::new(10, 0, 0, 1),
+            })
+        );
+    }
+
+    #[test]
     fn ignore_invalid_tcp_trace_options() {
         let invalid_options = [
-            // v1 format
+            // Incorrect v1 length.
             vec![
                 TCP_OPT_TRACING,
                 16,
@@ -1631,40 +1673,30 @@ mod tests {
     }
 
     #[test]
-    fn keep_first_tcp_trace_option() {
+    fn prefer_v2_tcp_trace_option() {
+        let v1 = tcp_trace_option(TCP_TOT_V1_MAGIC, 1, 0x0a000001);
+        let v2 = tcp_trace_option(TCP_TOT_V2_MAGIC, 2, 3);
+
+        for options in [[v1, v2].concat(), [v2, v1].concat()] {
+            assert_eq!(
+                parse_tcp_options(&options).trace_info,
+                Some(TraceInfo::V2 {
+                    pid: 2,
+                    agent_id: 3,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn keep_first_v2_tcp_trace_option() {
         let mut options = Vec::new();
-        options.extend_from_slice(&[
-            TCP_OPT_TRACING,
-            TCP_TOT_LEN as u8,
-            0xde,
-            0xea,
-            0,
-            0,
-            0,
-            1,
-            0,
-            0,
-            0,
-            2,
-        ]);
-        options.extend_from_slice(&[
-            TCP_OPT_TRACING,
-            TCP_TOT_LEN as u8,
-            0xde,
-            0xea,
-            0,
-            0,
-            0,
-            3,
-            0,
-            0,
-            0,
-            4,
-        ]);
+        options.extend_from_slice(&tcp_trace_option(TCP_TOT_V2_MAGIC, 1, 2));
+        options.extend_from_slice(&tcp_trace_option(TCP_TOT_V2_MAGIC, 3, 4));
 
         assert_eq!(
             parse_tcp_options(&options).trace_info,
-            Some(TraceInfo {
+            Some(TraceInfo::V2 {
                 pid: 1,
                 agent_id: 2,
             })

--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -1043,8 +1043,65 @@ impl Default for EbpfSocketTunning {
 pub struct EbpfSocket {
     pub uprobe: EbpfSocketUprobe,
     pub kprobe: EbpfSocketKprobe,
+    pub sock_ops: EbpfSocketSockOps,
     pub tunning: EbpfSocketTunning,
     pub preprocess: EbpfSocketPreprocess,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EbpfSocketSockOps {
+    pub tcp_option_trace: EbpfTcpOptionTrace,
+}
+
+impl Default for EbpfSocketSockOps {
+    fn default() -> Self {
+        Self {
+            tcp_option_trace: EbpfTcpOptionTrace::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct EbpfTcpOptionTrace {
+    pub enabled: bool,
+    pub version: TcpOptionTraceVersion,
+    pub sampling_window_bytes: u32,
+}
+
+impl Default for EbpfTcpOptionTrace {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            version: TcpOptionTraceVersion::default(),
+            sampling_window_bytes: 16 * 1024,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u32)]
+pub enum TcpOptionTraceVersion {
+    V1 = 1,
+    #[default]
+    V2 = 2,
+}
+
+impl<'de> Deserialize<'de> for TcpOptionTraceVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match u8::deserialize(deserializer)? {
+            1 => Ok(Self::V1),
+            2 => Ok(Self::V2),
+            other => Err(de::Error::invalid_value(
+                Unexpected::Unsigned(other as u64),
+                &"1 or 2",
+            )),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
@@ -3745,6 +3802,29 @@ mod tests {
         for interval in ["1ns", "999ms", "3601s"] {
             let yaml = format!("process_gpid_sync_interval: {interval}");
             assert!(serde_yaml::from_str::<Proc>(&yaml).is_err(), "{interval}");
+        }
+    }
+
+    #[test]
+    fn validate_tcp_option_trace_version() {
+        let default = serde_yaml::from_str::<EbpfTcpOptionTrace>("{}").unwrap();
+        assert_eq!(default.version, TcpOptionTraceVersion::V2);
+
+        for (version, expected) in [
+            (1, TcpOptionTraceVersion::V1),
+            (2, TcpOptionTraceVersion::V2),
+        ] {
+            let yaml = format!("version: {version}");
+            assert_eq!(
+                serde_yaml::from_str::<EbpfTcpOptionTrace>(&yaml)
+                    .unwrap()
+                    .version,
+                expected
+            );
+        }
+        for version in [0, 3] {
+            let yaml = format!("version: {version}");
+            assert!(serde_yaml::from_str::<EbpfTcpOptionTrace>(&yaml).is_err());
         }
     }
 

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -3553,6 +3553,34 @@ impl ConfigHandler {
             ]
         );
 
+        let sock_ops = &mut ebpf.socket.sock_ops;
+        let new_sock_ops = &mut new_ebpf.socket.sock_ops;
+        if sock_ops.tcp_option_trace.enabled != new_sock_ops.tcp_option_trace.enabled {
+            info!(
+                "Update inputs.ebpf.socket.sock_ops.tcp_option_trace.enabled from {:?} to {:?}.",
+                sock_ops.tcp_option_trace.enabled, new_sock_ops.tcp_option_trace.enabled
+            );
+            sock_ops.tcp_option_trace.enabled = new_sock_ops.tcp_option_trace.enabled;
+        }
+        if sock_ops.tcp_option_trace.version != new_sock_ops.tcp_option_trace.version {
+            info!(
+                "Update inputs.ebpf.socket.sock_ops.tcp_option_trace.version from {:?} to {:?}.",
+                sock_ops.tcp_option_trace.version, new_sock_ops.tcp_option_trace.version
+            );
+            sock_ops.tcp_option_trace.version = new_sock_ops.tcp_option_trace.version;
+        }
+        if sock_ops.tcp_option_trace.sampling_window_bytes
+            != new_sock_ops.tcp_option_trace.sampling_window_bytes
+        {
+            info!(
+                "Update inputs.ebpf.socket.sock_ops.tcp_option_trace.sampling_window_bytes from {:?} to {:?}.",
+                sock_ops.tcp_option_trace.sampling_window_bytes,
+                new_sock_ops.tcp_option_trace.sampling_window_bytes
+            );
+            sock_ops.tcp_option_trace.sampling_window_bytes =
+                new_sock_ops.tcp_option_trace.sampling_window_bytes;
+        }
+
         let uprobe = &mut ebpf.socket.uprobe;
         let new_uprobe = &mut new_ebpf.socket.uprobe;
         update_fields_with_restart_reason!(

--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -157,7 +157,7 @@ SOCKET_TRACE_ELFS := user/socket_trace_bpf_common.c \
 PERF_PROFILER_ELFS := user/perf_profiler_bpf_common.c \
 	user/perf_profiler_bpf_5_2_plus.c
 
-ELFFILES := $(SOCKET_TRACE_ELFS) $(PERF_PROFILER_ELFS) $(AF_PACKET_FANOUT_ELFS)
+ELFFILES := $(SOCKET_TRACE_ELFS) $(PERF_PROFILER_ELFS) $(AF_PACKET_FANOUT_ELFS) $(TCP_OPTION_TRACING_ELFS)
 
 tools/bintobuffer:
 	$(call msg,TOOLS,tools/bintobuffer)

--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -109,6 +109,21 @@ static long
 							       const void
 							       *unsafe_ptr) =
     (void *)115;
+static int
+    __attribute__ ((__unused__)) (*bpf_sock_ops_cb_flags_set) (void *skops,
+							       int flags) =
+    (void *)59;
+static int
+    __attribute__ ((__unused__)) (*bpf_reserve_hdr_opt) (void *skops,
+							 __u32 reserve_len,
+							 __u32 flags) =
+    (void *)144;
+static int
+    __attribute__ ((__unused__)) (*bpf_store_hdr_opt) (void *skops,
+						       void *from,
+						       __u32 len,
+						       __u32 flags) =
+    (void *)143;
 
 static int
     __attribute__ ((__unused__)) (*bpf_get_stackid) (void *ctx, void *map,

--- a/agent/src/ebpf/kernel/include/utils.h
+++ b/agent/src/ebpf/kernel/include/utils.h
@@ -22,7 +22,11 @@
 #ifndef DF_UTILS_H
 #define DF_UTILS_H
 
+#if defined(DF_BPF_NO_ARPA_INET)
+#include <linux/in.h>
+#else
 #include <arpa/inet.h>
+#endif
 #include "../../user/common_utils.h"
 
 #undef __inline

--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -808,6 +808,7 @@ extern "C" {
     pub fn enable_fentry();
     pub fn set_hooked_socket_syscalls(bitmap: c_ulonglong);
     pub fn set_virtual_file_collect(enabled: bool) -> c_int;
+
     cfg_if::cfg_if! {
         if #[cfg(feature = "extended_observability")] {
             pub fn enable_offcpu_profiler() -> c_int;
@@ -899,6 +900,24 @@ extern "C" {
                */
                pub fn set_socket_fanout_ebpf(socket: c_int, group_id: c_int) -> c_int;
                pub fn envoy_trace_start() -> c_int;
+
+               /**
+                * @brief Enable or disable the TCP option tracing feature.
+                *
+                * When enabled, the tcp_option_tracing eBPF program is loaded and attached
+                * to the root cgroup to insert custom TCP options while processing
+                * sockops callbacks. Disabling this feature detaches the program and
+                * releases associated resources.
+                *
+                * @param enabled Set to `true` to enable the feature or `false` to disable.
+                * @return 0 on success, non-zero on error.
+                */
+                pub fn set_tcp_option_tracing_enabled(enabled: bool) -> c_int;
+                pub fn set_tcp_option_tracing_config(
+                    sampling_window_bytes: c_uint,
+                    version: c_uint,
+                    agent_id: c_uint,
+                ) -> c_int;
         }
     }
 }

--- a/agent/src/ebpf/user/load.c
+++ b/agent/src/ebpf/user/load.c
@@ -474,6 +474,8 @@ static enum bpf_prog_type get_prog_type(struct sec_desc *desc)
 		prog_type = BPF_PROG_TYPE_TRACING;
 	} else if (!memcmp(desc->name, "socket/", 7)) {
 		prog_type = BPF_PROG_TYPE_SOCKET_FILTER;
+	} else if (!strncmp(desc->name, "sockops", 7)) {
+		prog_type = BPF_PROG_TYPE_SOCK_OPS;
 	} else {
 		prog_type = BPF_PROG_TYPE_UNSPEC;
 	}

--- a/agent/src/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher.rs
@@ -1093,6 +1093,32 @@ impl EbpfCollector {
         #[cfg(feature = "extended_observability")]
         ebpf::set_dpdk_trace_enabled(config.dpdk_enabled);
 
+        #[cfg(feature = "extended_observability")]
+        {
+            let tcp_option_trace = &config.ebpf.socket.sock_ops.tcp_option_trace;
+
+            if ebpf::set_tcp_option_tracing_config(
+                tcp_option_trace.sampling_window_bytes as u32,
+                tcp_option_trace.version as u32,
+                config.agent_id as u32,
+            ) != 0
+            {
+                warn!(
+                    "failed to set tcp option tracing config: sampling window {}, version {:?}, agent ID {}",
+                    tcp_option_trace.sampling_window_bytes,
+                    tcp_option_trace.version,
+                    config.agent_id
+                );
+            }
+
+            if ebpf::set_tcp_option_tracing_enabled(tcp_option_trace.enabled) != 0 {
+                warn!(
+                    "tcp option tracing enable failed (set enabled = {})",
+                    tcp_option_trace.enabled
+                );
+            }
+        }
+
         if ebpf::running_socket_tracer(
             Self::ebpf_l7_callback,                              /* 回调接口 rust -> C */
             config.ebpf.tunning.userspace_worker_threads as i32, /* 工作线程数，是指用户态有多少线程参与数据处理 */
@@ -1352,6 +1378,12 @@ impl EbpfCollector {
         info!("ebpf collector stopping ebpf-kernel.");
         unsafe {
             ebpf::socket_tracer_stop();
+            #[cfg(feature = "extended_observability")]
+            {
+                if ebpf::set_tcp_option_tracing_enabled(false) != 0 {
+                    warn!("failed to disable tcp option tracing while stopping");
+                }
+            }
         }
     }
 
@@ -1526,6 +1558,32 @@ impl EbpfCollector {
             }
 
             Self::ebpf_on_config_change(config.l7_log_packet_size);
+
+            #[cfg(feature = "extended_observability")]
+            {
+                let tcp_option_trace = &config.ebpf.socket.sock_ops.tcp_option_trace;
+
+                if ebpf::set_tcp_option_tracing_config(
+                    tcp_option_trace.sampling_window_bytes as u32,
+                    tcp_option_trace.version as u32,
+                    config.agent_id as u32,
+                ) != 0
+                {
+                    warn!(
+                        "failed to set tcp option tracing config: sampling window {}, version {:?}, agent ID {}",
+                        tcp_option_trace.sampling_window_bytes,
+                        tcp_option_trace.version,
+                        config.agent_id
+                    );
+                }
+
+                if ebpf::set_tcp_option_tracing_enabled(tcp_option_trace.enabled) != 0 {
+                    warn!(
+                        "tcp option tracing enable failed (set enabled = {})",
+                        tcp_option_trace.enabled
+                    );
+                }
+            }
         }
         if config.l7_log_enabled() || config.dpdk_enabled {
             self.start();

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -2941,7 +2941,7 @@ mod tests {
         // direction correction makes the server the flow's destination peer.
         let mut packet = _new_meta_packet();
         packet.signal_source = SignalSource::Packet;
-        packet.trace_info = Some(TraceInfo {
+        packet.trace_info = Some(TraceInfo::V2 {
             agent_id: SERVER_AGENT_ID,
             pid: SERVER_PID,
         });
@@ -2968,7 +2968,7 @@ mod tests {
 
         let mut client_packet = packet.clone();
         client_packet.lookup_key.direction = PacketDirection::ClientToServer;
-        client_packet.trace_info = Some(TraceInfo {
+        client_packet.trace_info = Some(TraceInfo::V2 {
             agent_id: CLIENT_AGENT_ID,
             pid: CLIENT_PID,
         });
@@ -2983,7 +2983,7 @@ mod tests {
         );
 
         // Do not overwrite a GPID already set on the packet's source peer.
-        client_packet.trace_info = Some(TraceInfo {
+        client_packet.trace_info = Some(TraceInfo::V2 {
             agent_id: SERVER_AGENT_ID,
             pid: SERVER_PID,
         });
@@ -2993,7 +2993,7 @@ mod tests {
             CLIENT_GPID
         );
 
-        let mut ebpf_packet = client_packet;
+        let mut ebpf_packet = client_packet.clone();
         ebpf_packet.signal_source = SignalSource::EBPF;
         let mut ebpf_node = FlowNode::default();
         flow_map.lookup_process_gpid(&ebpf_packet, &mut ebpf_node);
@@ -3003,6 +3003,17 @@ mod tests {
         );
         assert_eq!(
             ebpf_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_DST].gpid,
+            0
+        );
+        let mut v1_packet = client_packet;
+        v1_packet.trace_info = Some(TraceInfo::V1 {
+            pid: CLIENT_PID,
+            source_ip: Ipv4Addr::LOCALHOST,
+        });
+        let mut v1_node = FlowNode::default();
+        flow_map.lookup_process_gpid(&v1_packet, &mut v1_node);
+        assert_eq!(
+            v1_node.tagged_flow.flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC].gpid,
             0
         );
     }

--- a/agent/src/process_gpid.rs
+++ b/agent/src/process_gpid.rs
@@ -168,8 +168,9 @@ impl ProcessGpidLookup {
     }
 
     pub(crate) fn lookup(&mut self, trace_info: TraceInfo) -> u32 {
-        let agent_id = trace_info.agent_id;
-        let pid = trace_info.pid;
+        let TraceInfo::V2 { agent_id, pid } = trace_info else {
+            return 0;
+        };
         if agent_id == 0 || pid == 0 {
             return 0;
         }
@@ -496,7 +497,7 @@ mod tests {
         table.update(1, AHashMap::from_iter([(make_key(10, 20), 30)]));
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-        let trace_info = TraceInfo {
+        let trace_info = TraceInfo::V2 {
             agent_id: 10,
             pid: 20,
         };
@@ -519,7 +520,7 @@ mod tests {
         let table = ProcessGpidTable::default();
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-        let trace_info = TraceInfo {
+        let trace_info = TraceInfo::V2 {
             agent_id: 10,
             pid: 20,
         };
@@ -537,7 +538,7 @@ mod tests {
         table.update(7, AHashMap::from_iter([(make_key(10, 20), 30)]));
         let stats = stats::Collector::new("", Arc::new(AtomicI64::new(0)));
         let mut lookup = table.new_lookup(1, &stats);
-        let trace_info = TraceInfo {
+        let trace_info = TraceInfo::V2 {
             agent_id: 10,
             pid: 20,
         };

--- a/server/agent_config/README-CH.md
+++ b/server/agent_config/README-CH.md
@@ -4048,6 +4048,111 @@ TCP 和 UDP 的端口白名单列表，白名单生效优先级低于 kprobe 黑
 
 配置样例: `ports: 80,1000-2000`
 
+#### SockOps {#inputs.ebpf.socket.sock_ops}
+
+##### TCP Option Trace {#inputs.ebpf.socket.sock_ops.tcp_option_trace}
+
+###### TCP Option 注入 {#inputs.ebpf.socket.sock_ops.tcp_option_trace.enabled}
+
+**标签**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.enabled`
+
+**默认值**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          enabled: false
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**详细描述**:
+
+是否开启 TCP Option Tracing SockOps 程序，用于在满足条件的 TCP 连接上注入 DeepFlow 元数据（如进程 PID）。
+注意：该功能依赖 cgroup v2（统一层级）和内核版本 > 5.10。在 cgroup v1 主机上 SockOps 绑定会失败.
+兼容性：已在 x86 上验证内核 > 5.10；arm 目前仅在 6.8 内核上测试。
+限制：PID 跟踪依赖per-CPU syscall map。CPU 拥堵、软中断可能在不同 CPU 运行时，注入的元数据可能缺失或过期。
+
+###### TCP Option 注入版本 {#inputs.ebpf.socket.sock_ops.tcp_option_trace.version}
+
+**标签**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.version`
+
+**默认值**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          version: 2
+```
+
+**枚举可选值**:
+| Value | Note                         |
+| ----- | ---------------------------- |
+| 1 | |
+| 2 | |
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | int |
+| Range | [1, 2] |
+
+**详细描述**:
+
+开启 TCP Option 注入时使用的元数据格式。版本 1 使用 magic 0xDEE9 注入 PID 和源 IPv4；
+版本 2 使用 magic 0xDEEA 注入 PID 和 Agent ID。
+
+###### PID 注入窗口 {#inputs.ebpf.socket.sock_ops.tcp_option_trace.sampling_window_bytes}
+
+**标签**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.sampling_window_bytes`
+
+**默认值**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          sampling_window_bytes: 16384
+```
+
+**模式**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | int |
+| Unit | Bytes |
+| Range | [0, 1048576] |
+
+**详细描述**:
+
+控制 PID 注入之间的最小 TCP 负载间隔字节数。缺省为 16KB，与历史行为一致；值越小注入越频繁，值越大越稀疏。
+设置为0关闭采样窗口功能，对所有数据包注入。
+
 #### 调优 {#inputs.ebpf.socket.tunning}
 
 ##### 最大采集速率 {#inputs.ebpf.socket.tunning.max_capture_rate}

--- a/server/agent_config/README.md
+++ b/server/agent_config/README.md
@@ -4135,6 +4135,117 @@ Use kprobe to collect data on ports that are not in the blacklist or whitelist.
 
 Example: `ports: 80,1000-2000`
 
+#### SockOps {#inputs.ebpf.socket.sock_ops}
+
+##### TCP Option Trace {#inputs.ebpf.socket.sock_ops.tcp_option_trace}
+
+###### TCP Option Tracing {#inputs.ebpf.socket.sock_ops.tcp_option_trace.enabled}
+
+**Tags**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.enabled`
+
+**Default value**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          enabled: false
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | bool |
+
+**Description**:
+
+Whether to enable the tcp-option tracing SockOps program, which injects DeepFlow metadata
+(for example, process PID) into a custom TCP option for eligible connections.
+Note: This feature requires cgroup v2 (unified hierarchy) and kernel > 5.10. On hosts
+using cgroup v1 the SockOps program will fail to attach and the agent will log a warning.
+Compatibility: validated on x86 with kernel > 5.10; on arm we have only tested with
+kernel 6.8 so far.
+Limitation: PID tracking relies on the per-CPU syscall map in. Under CPU congestion,
+softirqs handling TCP may run on a different CPU than the userspace thread, so the
+injected metadata can be missing or stale.
+
+###### TCP Option Trace Version {#inputs.ebpf.socket.sock_ops.tcp_option_trace.version}
+
+**Tags**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.version`
+
+**Default value**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          version: 2
+```
+
+**Enum options**:
+| Value | Note                         |
+| ----- | ---------------------------- |
+| 1 | |
+| 2 | |
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | int |
+| Range | [1, 2] |
+
+**Description**:
+
+TCP option metadata format used when tracing is enabled. Version 1 injects PID and
+source IPv4 with magic 0xDEE9. Version 2 injects PID and Agent ID with magic 0xDEEA.
+
+###### PID Injection Window {#inputs.ebpf.socket.sock_ops.tcp_option_trace.sampling_window_bytes}
+
+**Tags**:
+
+`hot_update`
+
+**FQCN**:
+
+`inputs.ebpf.socket.sock_ops.tcp_option_trace.sampling_window_bytes`
+
+**Default value**:
+```yaml
+inputs:
+  ebpf:
+    socket:
+      sock_ops:
+        tcp_option_trace:
+          sampling_window_bytes: 16384
+```
+
+**Schema**:
+| Key  | Value                        |
+| ---- | ---------------------------- |
+| Type | int |
+| Unit | Bytes |
+| Range | [0, 1048576] |
+
+**Description**:
+
+Minimum number of TCP payload bytes between PID injections. Default 16KB matches the
+legacy behavior; smaller windows increase frequency, larger windows decrease it. Set to
+0 to disable sampling and inject on every eligible packet.
+
 #### Tunning {#inputs.ebpf.socket.tunning}
 
 ##### Max Capture Rate {#inputs.ebpf.socket.tunning.max_capture_rate}

--- a/server/agent_config/template.yaml
+++ b/server/agent_config/template.yaml
@@ -3063,6 +3063,79 @@ inputs:
           ports: ""
       # type: section
       # name:
+      #   en: SockOps
+      #   ch: SockOps
+      # description:
+      sock_ops:
+        # type: section
+        # name:
+        #   en: TCP Option Trace
+        #   ch: TCP Option Trace
+        # description:
+        tcp_option_trace:
+          # type: bool
+          # name:
+          #   en: TCP Option Tracing
+          #   ch: TCP Option 注入
+          # unit:
+          # range: []
+          # enum_options: []
+          # modification: hot_update
+          # ee_feature: false
+          # description:
+          #   en: |-
+          #     Whether to enable the tcp-option tracing SockOps program, which injects DeepFlow metadata
+          #     (for example, process PID) into a custom TCP option for eligible connections.
+          #     Note: This feature requires cgroup v2 (unified hierarchy) and kernel > 5.10. On hosts
+          #     using cgroup v1 the SockOps program will fail to attach and the agent will log a warning.
+          #     Compatibility: validated on x86 with kernel > 5.10; on arm we have only tested with
+          #     kernel 6.8 so far.
+          #     Limitation: PID tracking relies on the per-CPU syscall map in. Under CPU congestion,
+          #     softirqs handling TCP may run on a different CPU than the userspace thread, so the
+          #     injected metadata can be missing or stale.
+          #   ch: |-
+          #     是否开启 TCP Option Tracing SockOps 程序，用于在满足条件的 TCP 连接上注入 DeepFlow 元数据（如进程 PID）。
+          #     注意：该功能依赖 cgroup v2（统一层级）和内核版本 > 5.10。在 cgroup v1 主机上 SockOps 绑定会失败.
+          #     兼容性：已在 x86 上验证内核 > 5.10；arm 目前仅在 6.8 内核上测试。
+          #     限制：PID 跟踪依赖per-CPU syscall map。CPU 拥堵、软中断可能在不同 CPU 运行时，注入的元数据可能缺失或过期。
+          enabled: false
+          # type: int
+          # name:
+          #   en: TCP Option Trace Version
+          #   ch: TCP Option 注入版本
+          # unit:
+          # range: [1, 2]
+          # enum_options: [1, 2]
+          # modification: hot_update
+          # ee_feature: false
+          # description:
+          #   en: |-
+          #     TCP option metadata format used when tracing is enabled. Version 1 injects PID and
+          #     source IPv4 with magic 0xDEE9. Version 2 injects PID and Agent ID with magic 0xDEEA.
+          #   ch: |-
+          #     开启 TCP Option 注入时使用的元数据格式。版本 1 使用 magic 0xDEE9 注入 PID 和源 IPv4；
+          #     版本 2 使用 magic 0xDEEA 注入 PID 和 Agent ID。
+          version: 2
+          # type: int
+          # name:
+          #   en: PID Injection Window
+          #   ch: PID 注入窗口
+          # unit: Bytes
+          # range: [0, 1048576]
+          # enum_options: []
+          # modification: hot_update
+          # ee_feature: false
+          # description:
+          #   en: |-
+          #     Minimum number of TCP payload bytes between PID injections. Default 16KB matches the
+          #     legacy behavior; smaller windows increase frequency, larger windows decrease it. Set to
+          #     0 to disable sampling and inject on every eligible packet.
+          #   ch: |-
+          #     控制 PID 注入之间的最小 TCP 负载间隔字节数。缺省为 16KB，与历史行为一致；值越小注入越频繁，值越大越稀疏。
+          #     设置为0关闭采样窗口功能，对所有数据包注入。
+          sampling_window_bytes: 16384
+      # type: section
+      # name:
       #   en: Tunning
       #   ch: 调优
       # description:


### PR DESCRIPTION
## What this PR does

Backports TCP Option eBPF injection to v6.6 and ports commit 851804009bbe72a1abbae70b6b2b744f4e399993.

- supports TCP Option trace formats v1 and v2
- injects PID/source IPv4 for v1 and PID/Agent ID for v2
- adds agent configuration, hot updates, parser validation, and Process GPID integration
- adds enterprise-gated eBPF configuration interfaces

## Validation

- cargo check -p public
- cargo fmt --all -- --check
- cargo test validate_tcp_option_trace_version --lib
- cargo test tcp_trace_option --lib
- cargo test process_gpid_updates_packet_source_peer --lib
- cargo check --features enterprise