### PR TITLE
fix(java): add comprehensive JVM attach preflight

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -103,6 +103,7 @@ OBJS := user/elf.o \
 
 JAVA_TOOL := deepflow-jattach
 JAVA_AGENT_VERSION := 3.1
+JAVA_NS_TOOL := tools/java_mnt_ns_version
 JAVA_AGENT_GNU_SO := df_java_agent_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_MUSL_SO := df_java_agent_musl_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_SO := $(JAVA_AGENT_GNU_SO) $(JAVA_AGENT_MUSL_SO)
@@ -250,7 +251,7 @@ $(JAVA_AGENT_MUSL_SO): tools/bintobuffer $(JAVA_AGENT_SRC)
 
 build: $(CTLBIN_C) $(ELFFILES) $(JAVA_TOOL) $(LIBTRACE)
 
-tools: $(CTLBIN)
+tools: $(CTLBIN) $(JAVA_NS_TOOL)
 
 $(CTLBIN_C): $(CTLBIN) tools/bintobuffer
 	$(call msg,CTLBIN_C,$(CTLBIN_C))
@@ -259,6 +260,10 @@ $(CTLBIN_C): $(CTLBIN) tools/bintobuffer
 $(CTLBIN): $(CTLSRC) 
 	$(call msg,TOOLS,deepflow-ebpfctl)
 	$(Q)$(CC) $(CFLAGS) --static -g -O2 $(CTLSRC) -o $@ -lelf -lz -lpthread
+
+$(JAVA_NS_TOOL): tools/java_mnt_ns_version.c
+	$(call msg,TOOLS,$@)
+	$(Q)$(CC) $(CFLAGS) tools/java_mnt_ns_version.c -o $@
 
 $(JAVA_TOOL): $(JAVA_AGENT_SO) user/log.c user/utils.c user/mem.c user/vec.c user/profile/java/jvm_symbol_collect.c libs/jattach/build/libjattach.a
 	$(call msg,TOOLS,$@)
@@ -347,7 +352,7 @@ clean:
 	$(Q)rm -rf .profiler .socket-tracer
 	$(Q)rm -rf samples/rust/socket-tracer/target
 	$(Q)rm -rf samples/rust/profiler/target
-	$(Q)rm -rf $(JAVA_AGENT_SO) $(JAVA_TOOL) $(CTLBIN) $(CTLBIN_C) tools/bintobuffer
+	$(Q)rm -rf $(JAVA_AGENT_SO) $(JAVA_TOOL) $(JAVA_NS_TOOL) $(CTLBIN) $(CTLBIN_C) tools/bintobuffer
 
 test: $(ELFFILES) $(LIBTRACE)
 	$(Q)$(MAKE) -C test --no-print-directory

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -67,15 +67,16 @@ java_attach_preflight(pid, &info)
 1. 在切换 namespace 前，从 `/proc/<pid>/exe` 获取目标 JVM 的真实可执行文件；
 2. 从目标 `/proc/<pid>/maps` 找到 `libjvm.so` 的架构目录，构造目标 JRE 的动态库路径：
    `lib/<arch>/jli`、`lib/<arch>` 和 `lib/<arch>/server`；
-3. 如果 Agent 与目标 mount namespace 不同，当前线程通过 `df_enter_ns` 切换到目标
-   mount namespace；同时设置目标 PID namespace，使随后由 `popen` 创建的版本子进程
-   使用目标 PID namespace；同 namespace 时跳过切换；
+3. 如果 Agent 与目标 mount namespace 不同，通过宿主机的 `nsenter` 进入目标 mount/PID
+   namespace，并显式指定 `--root=/proc/<pid>/root`；同 namespace 时跳过切换。`--root`
+   不能省略，因为单独进入 mount namespace 不会改变进程的 root，绝对路径仍可能指向
+   Agent/Host 文件系统；
 4. 启动一个短生命周期的版本命令，设置目标 JRE 的 `LD_LIBRARY_PATH`，从输出中的
-   `version "..."` 提取 `JAVA_VERSION`；
-5. 如果执行过 namespace 切换，通过 `df_exit_ns` 恢复当前线程的 namespace。
+   `version "..."` 提取 `JAVA_VERSION`。跨 namespace 时 `env`、`timeout`、Java 可执行文件
+   和动态库都在目标 rootfs 中解析；
 
-这样 Host 使用宿主机 namespace，POD 使用容器自己的 namespace，既不会误读 Agent
-文件系统，也不会因为 `libjli.so` 不在系统默认库路径中而误判。
+这样 Host 使用宿主机 namespace，POD 使用容器自己的 namespace 和 rootfs，既不会误读
+Agent 文件系统，也不会因为 `libjli.so` 不在系统默认库路径中而误判。
 
 这里的 `-version` 不是向正在运行的目标 JVM 发送命令，也不会对目标 JVM 执行 attach。
 它是在目标 namespace 中启动一个短生命周期的独立 Java 子进程，用来确认目标 Java
@@ -87,8 +88,8 @@ java_attach_preflight(pid, &info)
 这一步存在以下现实限制：
 
 - 目标容器没有进入目标 namespace 的权限时，版本命令无法启动；
-- 目标 namespace 中缺少 `/bin/sh`、`env` 或 `timeout` 时，优先回退到宿主机
-  `timeout/nsenter` 直接执行；宿主机也缺少这些工具或没有 namespace 权限时才会失败；
+- 宿主机缺少 `env`、`timeout` 或支持 `--root` 的 `nsenter`，或者没有 namespace 权限时，
+  跨 namespace 版本检查会失败并保守跳过；
 - 精简 JRE 缺少 `libjli.so` 或动态链接器时，版本命令可能失败；
 - 目标 JDK 文件在检查期间被替换时，子进程版本可能与原 JVM 已加载的库不一致；
 - 启动器异常或启动时间超过超时时间时，检查会失败。
@@ -221,8 +222,8 @@ JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8173361_and_JDK-83051
 | HotSpot 8u412 版本识别 | PASS，允许继续检查 |
 | POD 中 HotSpot 8u212 | PASS，正确跳过 attach |
 | Host 与目标同 namespace | PASS，不切换 namespace |
-| Host 与目标跨 namespace | PASS，正确进入并恢复 namespace |
-| 极简容器缺少 shell/env/timeout | PASS，使用宿主机回退路径 |
+| Host 与目标跨 namespace | PASS，`nsenter --root` 使用目标 rootfs |
+| 极简容器缺少目标侧 shell/env/timeout | PASS，使用宿主机 root-aware nsenter 路径 |
 | `DisableAttachMechanism` 参数 | PASS，正确跳过 |
 | 业务参数仅包含 `-XX:+DisableAttachMechanism` 文本 | PASS，不误判为禁用 attach |
 | 无关环境变量仅包含该文本 | PASS，不误判为禁用 attach |
@@ -238,9 +239,8 @@ attach socket 或 namespace 权限失败。这属于测试环境限制，不是 
 ## 6. 代码位置
 
 - 公共预检逻辑：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.c` 中的 `java_attach_preflight()`；
-- HotSpot 版本命令：同文件中的 `java_preflight_exec_version()`；跨 mount namespace
-  时调用 `df_enter_ns()`，通过 `exec_command()`/`popen()` 执行，完成后调用
-  `df_exit_ns()`；如果目标是没有 shell/env/timeout 的极简容器，则使用宿主机
-  `timeout/nsenter` 直接执行目标 Java；同 namespace 不切换；
+- HotSpot 版本命令：同文件中的 `java_preflight_exec_version()`；同 mount namespace
+  直接执行，跨 mount namespace 通过宿主机 `timeout/nsenter --mount --pid
+  --root=/proc/<pid>/root` 进入目标 rootfs 后执行；
 - 预检数据结构和返回值：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.h`；
 - Agent 采集结果对“主动跳过”的处理：`agent/src/ebpf/user/profile/java/collect_symbol_files.c`。

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -80,7 +80,6 @@ java_attach_preflight(pid, &info)
 7. helper 执行完成后立即退出，不需要调用 `df_exit_ns()`。目标 namespace 只存在于 helper
    和 runner 中，Agent 父进程及其后续子进程从未进入目标 namespace，因此不需要恢复或
    额外验证父进程 namespace。
-<<<<<<< HEAD
 
 父进程的等待是一个循环，不是一次阻塞等待：
 
@@ -105,8 +104,6 @@ while (helper 尚未退出 || 版本输出管道尚未关闭) {
 再 `waitpid()` 回收 helper。进程组中包括 helper 和 runner，但不包括正在运行的目标 Java
 业务进程。超时、管道错误、helper 非正常退出或版本输出无法解析时，预检统一失败并跳过
 attach。
-=======
->>>>>>> fix(java): bound namespace version probing with helper
 
 这套流程不使用 `nsenter`，不使用 `chroot`，也不需要宿主机安装额外的 namespace 工具。
 版本 helper 结束后，目标 PID/mount namespace 不会留给 Agent 后续子进程；namespace

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -152,7 +152,13 @@ HotSpot && Java 主版本 == 8 && update < 382
 避免把“检查失败”误判为“没有禁用参数”。`environ` 只保存进程启动时的环境，因此
 仍然需要同时检查 `cmdline`。
 
-`cmdline` 和 `environ` 是分块读取的，代码会保留上一块的尾部内容，因此参数即使跨越读取缓冲区边界也不会漏检。
+检查使用完整的 JVM option 边界：
+
+- `cmdline` 按 NUL 分隔的 argv 项匹配，只有完整参数等于
+  `-XX:+DisableAttachMechanism` 时才命中；例如业务参数
+  `--note=-XX:+DisableAttachMechanism` 不会命中；
+- `environ` 只解析标准 JVM 选项环境变量 `JAVA_TOOL_OPTIONS`、`_JAVA_OPTIONS`
+  和 `JDK_JAVA_OPTIONS`，并按空白分隔的完整 token 匹配；无关环境变量中的普通文本不会命中。
 
 ### 第六步：再次确认 PID 没有被复用
 
@@ -218,6 +224,9 @@ JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8173361_and_JDK-83051
 | Host 与目标跨 namespace | PASS，正确进入并恢复 namespace |
 | 极简容器缺少 shell/env/timeout | PASS，使用宿主机回退路径 |
 | `DisableAttachMechanism` 参数 | PASS，正确跳过 |
+| 业务参数仅包含 `-XX:+DisableAttachMechanism` 文本 | PASS，不误判为禁用 attach |
+| 无关环境变量仅包含该文本 | PASS，不误判为禁用 attach |
+| `JAVA_TOOL_OPTIONS` 包含完整禁用参数 | PASS，正确跳过 |
 | PID 被复用或 exe 变化 | PASS，正确跳过 |
 
 其中，`8u352` 和 `8u381` 的可执行包当前尚未取得，因此只完成版本范围推导，未做二进制压力复现。

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -81,6 +81,30 @@ java_attach_preflight(pid, &info)
    和 runner 中，Agent 父进程及其后续子进程从未进入目标 namespace，因此不需要恢复或
    额外验证父进程 namespace。
 
+父进程的等待是一个循环，不是一次阻塞等待：
+
+```text
+while (helper 尚未退出 || 版本输出管道尚未关闭) {
+    非阻塞读取 Java -version 输出；
+    waitpid(helper_pid, ..., WNOHANG) 检查 helper 是否退出；
+    检查单调时钟是否超过 5 秒 deadline；
+    poll(版本输出管道读端，最多等待 100ms)；
+}
+```
+
+这里的管道由 `pipe()` 创建：`pipe_fds[0]` 是父进程读取端，`pipe_fds[1]` 是 runner
+写入端。runner 将自己的标准输出和标准错误通过 `dup2()` 指向写入端，因此父进程的
+`poll()` 等待的是 `pipe_fds[0]` 是否有版本数据、EOF 或错误，不是等待 Java 目标进程。
+`waitpid(helper_pid, ..., WNOHANG)` 单独检查第一层 fork 创建的 helper；helper 内部会阻塞
+等待第二层 fork 创建的 runner，所以 helper 退出通常表示 runner 和 `-version` 已经结束。
+`poll()` 每次最多等待 100ms，醒来后重新检查 helper 和总 deadline，避免无输出时忙等，也
+避免任何单次等待绕过 5 秒上限。
+
+如果当前时间达到 deadline，父进程使用 `kill(-helper_pid, SIGKILL)` 终止 helper 进程组，
+再 `waitpid()` 回收 helper。进程组中包括 helper 和 runner，但不包括正在运行的目标 Java
+业务进程。超时、管道错误、helper 非正常退出或版本输出无法解析时，预检统一失败并跳过
+attach。
+
 这套流程不使用 `nsenter`，不使用 `chroot`，也不需要宿主机安装额外的 namespace 工具。
 版本 helper 结束后，目标 PID/mount namespace 不会留给 Agent 后续子进程；namespace
 切换发生在独立 helper 中，helper 退出后由内核回收其 namespace 状态。

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -1,0 +1,237 @@
+# Java attach 前置检查说明
+
+## 1. 这项检查是做什么的
+
+DeepFlow 在采集 Java 符号前，需要把一个 JVMTI Agent 加载到目标 JVM 中。这个动作叫作 `attach`。
+
+旧版 HotSpot，特别是本次客户环境中的 Java 8u342，在处理 `CompiledMethodLoad` 事件时存在已知缺陷。Agent 一旦打开这个 JVM 能力，在高频 JIT 编译、类加载和类卸载同时发生时，可能触发 JVM 崩溃。版本范围需要分段理解：`8u0–8u351` 缺少首个已知修复，`8u352–8u381` 虽然已有第一组修复但仍缺少 8u 特有的 Sweeper 保护，`8u382` 起才包含完整补丁链。当前代码使用 `8u382` 作为完整修复门禁，因此这是保守的补丁完整性判断，不是声称所有低于 8u382 的版本都已逐一复现。
+
+因此，代码现在会在 attach 之前先检查目标 JVM：
+
+```text
+检查目标进程
+    -> 判断 JVM 类型
+    -> 仅对 HotSpot 检查版本
+    -> 检查 attach 是否被禁用
+    -> 再次确认 PID 没有变化
+    -> 通过后才执行 attach
+```
+
+这项检查只读取本机的 `/proc` 文件和目标 JVM 文件，不访问第三方系统。
+
+## 2. 检查从哪里开始
+
+公共检查入口是：
+
+```c
+java_attach_preflight(pid, &info)
+```
+
+有两个地方会调用它：
+
+1. `start_java_symbol_collection()`：在创建线程池和 socket 之前检查；
+2. `java_attach()`：在准备 Agent SO、切换 namespace 和执行 jattach 之前再次检查。
+
+第二次检查是为了防止第一次检查结束后，目标 JVM 在真正 attach 前发生变化。
+
+## 3. 检查顺序
+
+### 第一步：确认进程还活着
+
+代码读取 `/proc/<pid>/stat`，确认：
+
+- PID 存在；
+- 进程不是已经退出的进程；
+- 进程不是僵尸进程；
+- 能够读取进程的启动时间和可执行文件路径。
+
+如果目标已经退出，继续 attach 没有意义，会直接跳过。
+
+### 第二步：判断 JVM 类型
+
+代码读取 `/proc/<pid>/maps`：
+
+- 找到 `libjvm.so`，认为是 HotSpot；
+- 找到 `libj9vm`，认为是 OpenJ9；
+- OpenJ9 即使同时映射了兼容性的 `libjvm.so`，也优先按 OpenJ9 处理；
+- 两种 JVM 核心库都找不到时，不确认目标是不是 Java JVM，会跳过。
+
+已经加载过 DeepFlow Agent 不会作为拒绝条件。因为合法的重复 attach 仍然可能再次调用 `Agent_OnAttach`。
+
+### 第三步：HotSpot 直接执行目标 JVM 的 `-version`
+
+只有 HotSpot 执行版本门禁，OpenJ9 等其他 JVM 不执行 Java 8u382 检查。
+
+版本获取不读取 `release` 文件，也不调用 Agent 所在环境的 `java`。代码按以下顺序执行：
+
+1. 在切换 namespace 前，从 `/proc/<pid>/exe` 获取目标 JVM 的真实可执行文件；
+2. 从目标 `/proc/<pid>/maps` 找到 `libjvm.so` 的架构目录，构造目标 JRE 的动态库路径：
+   `lib/<arch>/jli`、`lib/<arch>` 和 `lib/<arch>/server`；
+3. 如果 Agent 与目标 mount namespace 不同，当前线程通过 `df_enter_ns` 切换到目标
+   mount namespace；同时设置目标 PID namespace，使随后由 `popen` 创建的版本子进程
+   使用目标 PID namespace；同 namespace 时跳过切换；
+4. 启动一个短生命周期的版本命令，设置目标 JRE 的 `LD_LIBRARY_PATH`，从输出中的
+   `version "..."` 提取 `JAVA_VERSION`；
+5. 如果执行过 namespace 切换，通过 `df_exit_ns` 恢复当前线程的 namespace。
+
+这样 Host 使用宿主机 namespace，POD 使用容器自己的 namespace，既不会误读 Agent
+文件系统，也不会因为 `libjli.so` 不在系统默认库路径中而误判。
+
+这里的 `-version` 不是向正在运行的目标 JVM 发送命令，也不会对目标 JVM 执行 attach。
+它是在目标 namespace 中启动一个短生命周期的独立 Java 子进程，用来确认目标 Java
+启动器能够正常启动并报告版本。`popen`、`exec_command` 等外部命令接口内部同样会
+创建子进程，不能在当前 Agent 进程中直接执行 Java，否则会替换 Agent 自身。
+目标 JVM 本身不会因为这一步加载 Agent 或开启 JVMTI 回调。版本子进程结束后，
+`pclose` 会等待并回收它，不会长期占用 Agent 的线程。
+
+这一步存在以下现实限制：
+
+- 目标容器没有进入目标 namespace 的权限时，版本命令无法启动；
+- 目标 namespace 中缺少 `/bin/sh`、`env` 或 `timeout` 时，优先回退到宿主机
+  `timeout/nsenter` 直接执行；宿主机也缺少这些工具或没有 namespace 权限时才会失败；
+- 精简 JRE 缺少 `libjli.so` 或动态链接器时，版本命令可能失败；
+- 目标 JDK 文件在检查期间被替换时，子进程版本可能与原 JVM 已加载的库不一致；
+- 启动器异常或启动时间超过超时时间时，检查会失败。
+- 版本子进程会继承 Agent 的标准输入输出之外的文件描述符；如果 Agent 持有敏感
+  描述符，需要在生产环境评估这一点。
+
+因此，`-version` 失败不能被解释为“版本安全”，代码会保守跳过 attach。当前实现会在版本命令结束后重新校验 PID start time 和 `/proc/<pid>/exe`，但无法完全防止运行时文件被外部替换。
+
+如果 `-version` 执行失败或输出中没有标准版本字符串，无法确认版本，直接保守跳过 attach。
+
+#### Java 8 版本范围与 8u382 门禁
+
+版本判断首先识别 Java 8 update 所处的补丁范围：
+
+```text
+update <= 351       -> 缺少 JDK-8173361，高风险
+352 <= update <= 381 -> 已有第一组修复，但缺少 JDK-8305165，残余风险
+update >= 382       -> 两组标准 OpenJDK 修复齐全，达到当前安全基线
+```
+
+当前 attach 策略采用完整修复门禁，只允许最后一段继续执行：
+
+```text
+HotSpot && Java 主版本 == 8 && update < 382
+    -> 跳过 attach
+```
+
+例如：
+
+- `1.8.0_342`：属于缺少首个修复的高风险段，跳过 attach；
+- `1.8.0_352`：属于部分修复段，当前仍跳过 attach；
+- `1.8.0_381`：属于部分修复段，当前仍跳过 attach；
+- `1.8.0_382`：通过版本门禁；
+- `1.8.0_412`：通过版本门禁。
+
+注意：`8u352–8u381` 不是“已确认必然崩溃”的范围，而是“补丁不完整、不能仅凭版本号确认安全”的范围。若目标厂商明确证明这些构建已额外回移 JDK-8305165 或等价补丁，才能设计例外放行；当前版本命令输出不会携带补丁提交列表，代码无法仅靠 `JAVA_VERSION` 自动识别这一点。
+
+不再获取或判断 `FULL_VERSION`、`JVM_VERSION`，也不再获取和校验厂商白名单。
+
+### 第四步：OpenJ9 等非 HotSpot JVM
+
+如果识别到的是 OpenJ9：
+
+- 不执行 HotSpot 专用的 Java 版本获取和门禁；
+- 不执行 Java 8u382 门禁；
+- 只继续执行通用进程、Attach 和 PID 竞态检查。
+
+通用检查通过后，OpenJ9 可以继续原有 attach 流程。
+
+### 第五步：检查 Attach 是否被禁用
+
+代码读取目标进程的 `cmdline` 和 `environ`，查找：
+
+```text
+-XX:+DisableAttachMechanism
+```
+
+如果找到，说明 JVM 明确禁止 attach，代码会跳过，不再执行注入。
+
+如果 `cmdline` 或 `environ` 无法读取，也无法确认 Attach 能力，代码同样会保守跳过，
+避免把“检查失败”误判为“没有禁用参数”。`environ` 只保存进程启动时的环境，因此
+仍然需要同时检查 `cmdline`。
+
+`cmdline` 和 `environ` 是分块读取的，代码会保留上一块的尾部内容，因此参数即使跨越读取缓冲区边界也不会漏检。
+
+### 第六步：再次确认 PID 没有被复用
+
+检查结束前，代码重新读取：
+
+- PID start time；
+- `/proc/<pid>/exe`。
+
+如果启动时间或可执行文件发生变化，说明进程可能已经退出并被其他进程复用了，本次检查结果作废，不执行 attach。
+
+## 4. 最终判断
+
+| 情况 | 处理方式 |
+| --- | --- |
+| 进程退出或是僵尸进程 | 跳过 attach |
+| 找不到 JVM 核心库 | 跳过 attach |
+| HotSpot，`-version` 执行失败或无法解析 | 跳过 attach |
+| HotSpot，`8u0–8u351` | 缺少 JDK-8173361，跳过 attach |
+| HotSpot，`8u352–8u381` | 补丁不完整，当前跳过 attach |
+| HotSpot，版本达到 8u382 或更高 | 通过版本门禁，继续通用检查 |
+| OpenJ9 等非 HotSpot JVM | 不做版本门禁，继续通用检查 |
+| `DisableAttachMechanism` 已启用 | 跳过 attach |
+| `cmdline` 或 `environ` 无法读取 | 跳过 attach |
+| PID 在检查期间发生变化 | 跳过 attach |
+| 所有检查通过 | 才执行 attach |
+
+跳过时会输出统一日志，例如：
+
+对于低于 8u382 的 HotSpot Java 8，`reason` 统一说明：Java 程序缺失
+`JDK-8173361` 和 `JDK-8305165` 修复，存在崩溃风险，为安全起见不执行 attach。
+
+```text
+JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8173361_and_JDK-8305165_crash_risk jvm=1.8.0_212 required=8u382+
+```
+
+## 5. 本机验证结果
+
+测试均在本机隔离环境完成：
+
+### 5.1 JVM 缺陷复现测试
+
+| 测试项 | 结果 |
+|---|---|
+| 8u342 无 Agent 基线 | PASS，30 秒正常退出 |
+| 8u342 + Honest Profiler，类加载/卸载压力 | **SIGSEGV**，约 26 秒 |
+| 8u342 + DeepFlow，类加载/卸载压力 | **SIGSEGV**，约 16–17 秒 |
+| 8u342 + DeepFlow，重复 attach 60 次 | PASS，60/60 成功 |
+| 8u342 + DeepFlow，socket 背压 | PASS，300 秒正常退出 |
+| 8u382 + Honest Profiler，同等压力 300 秒 | PASS，无 SIGSEGV |
+| 8u382 + DeepFlow，同等压力 300 秒 | PASS，无 SIGSEGV |
+
+### 5.2 Attach 预检测试
+
+| 测试项 | 结果 |
+|---|---|
+| C 代码编译 | PASS |
+| `git diff --check` | PASS |
+| HotSpot 8u342 版本识别 | PASS，跳过 attach |
+| HotSpot 8u382 版本识别 | PASS，通过版本门禁 |
+| HotSpot 8u412 版本识别 | PASS，允许继续检查 |
+| POD 中 HotSpot 8u212 | PASS，正确跳过 attach |
+| Host 与目标同 namespace | PASS，不切换 namespace |
+| Host 与目标跨 namespace | PASS，正确进入并恢复 namespace |
+| 极简容器缺少 shell/env/timeout | PASS，使用宿主机回退路径 |
+| `DisableAttachMechanism` 参数 | PASS，正确跳过 |
+| PID 被复用或 exe 变化 | PASS，正确跳过 |
+
+其中，`8u352` 和 `8u381` 的可执行包当前尚未取得，因此只完成版本范围推导，未做二进制压力复现。
+
+以上远端测试只执行版本检查和 `java_attach_preflight()`，没有执行 jattach，也没有修改目标 Java 进程。
+测试机当前沙箱不具备完整 JVM attach 条件，因此 8u382 在通过预检后，实际 jattach 可能因
+attach socket 或 namespace 权限失败。这属于测试环境限制，不是 JVM 版本门禁拒绝。
+
+## 6. 代码位置
+
+- 公共预检逻辑：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.c` 中的 `java_attach_preflight()`；
+- HotSpot 版本命令：同文件中的 `java_preflight_exec_version()`；跨 mount namespace
+  时调用 `df_enter_ns()`，通过 `exec_command()`/`popen()` 执行，完成后调用
+  `df_exit_ns()`；如果目标是没有 shell/env/timeout 的极简容器，则使用宿主机
+  `timeout/nsenter` 直接执行目标 Java；同 namespace 不切换；
+- 预检数据结构和返回值：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.h`；
+- Agent 采集结果对“主动跳过”的处理：`agent/src/ebpf/user/profile/java/collect_symbol_files.c`。

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -80,6 +80,7 @@ java_attach_preflight(pid, &info)
 7. helper 执行完成后立即退出，不需要调用 `df_exit_ns()`。目标 namespace 只存在于 helper
    和 runner 中，Agent 父进程及其后续子进程从未进入目标 namespace，因此不需要恢复或
    额外验证父进程 namespace。
+<<<<<<< HEAD
 
 父进程的等待是一个循环，不是一次阻塞等待：
 
@@ -104,6 +105,8 @@ while (helper 尚未退出 || 版本输出管道尚未关闭) {
 再 `waitpid()` 回收 helper。进程组中包括 helper 和 runner，但不包括正在运行的目标 Java
 业务进程。超时、管道错误、helper 非正常退出或版本输出无法解析时，预检统一失败并跳过
 attach。
+=======
+>>>>>>> fix(java): bound namespace version probing with helper
 
 这套流程不使用 `nsenter`，不使用 `chroot`，也不需要宿主机安装额外的 namespace 工具。
 版本 helper 结束后，目标 PID/mount namespace 不会留给 Agent 后续子进程；namespace

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -58,45 +58,52 @@ java_attach_preflight(pid, &info)
 
 已经加载过 DeepFlow Agent 不会作为拒绝条件。因为合法的重复 attach 仍然可能再次调用 `Agent_OnAttach`。
 
-### 第三步：HotSpot 直接执行目标 JVM 的 `-version`
+### 第三步：HotSpot 使用 `java_mnt_ns_version` 获取版本
 
 只有 HotSpot 执行版本门禁，OpenJ9 等其他 JVM 不执行 Java 8u382 检查。
 
-版本获取不读取 `release` 文件，也不调用 Agent 所在环境的 `java`。代码按以下顺序执行：
+版本获取不读取 `release` 文件，也不调用 Agent/Host 环境中的 `java`。统一使用
+`agent/src/ebpf/tools/java_mnt_ns_version.c` 中实现的流程：
 
 1. 在切换 namespace 前，从 `/proc/<pid>/exe` 获取目标 JVM 的真实可执行文件；
-2. 从目标 `/proc/<pid>/maps` 找到 `libjvm.so` 的架构目录，构造目标 JRE 的动态库路径：
-   `lib/<arch>/jli`、`lib/<arch>` 和 `lib/<arch>/server`；
-3. 如果 Agent 与目标 mount namespace 不同，通过宿主机的 `nsenter` 进入目标 mount/PID
-   namespace，并显式指定 `--root=/proc/<pid>/root`；同 namespace 时跳过切换。`--root`
-   不能省略，因为单独进入 mount namespace 不会改变进程的 root，绝对路径仍可能指向
-   Agent/Host 文件系统；
-4. 启动一个短生命周期的版本命令，设置目标 JRE 的 `LD_LIBRARY_PATH`，从输出中的
-   `version "..."` 提取 `JAVA_VERSION`。跨 namespace 时 `env`、`timeout`、Java 可执行文件
-   和动态库都在目标 rootfs 中解析；
+2. 从 `/proc/<pid>/environ` 读取目标 Java 的 `LD_LIBRARY_PATH`、`JAVA_HOME`、`PATH`、
+   `HOME` 和 `LANG` 等必要环境变量。该文件使用 NUL 字符分隔，不能按普通文本行读取；
+3. 根据目标 Java 的 `bin/java` 路径补充对应架构的 `lib/<arch>/jli` 目录，确保启动器可以
+   找到 `libjli.so`；
+4. 保存当前 PID namespace，调用 `setns()` 设置目标 PID namespace。该调用不会改变当前
+   进程自身的 PID，只会影响之后创建的子进程；
+5. 保存当前 mount namespace，调用 `setns()` 进入目标 Java 的 mount namespace；
+6. 使用 `popen("<java路径> -version")` 创建子进程，读取标准版本输出中的
+   `version "..."`，提取 `JAVA_VERSION`；
+7. `pclose()` 回收版本子进程后，恢复原 mount namespace，并恢复后续子进程使用的原 PID
+   namespace；最后再创建验证子进程，分别核对其 PID/mount namespace 与进入前保存的
+   namespace 标识，确保后续子进程已回到原 namespace。任一恢复或核对失败，工具都返回
+   失败，不继续使用本次版本结果。
 
-这样 Host 使用宿主机 namespace，POD 使用容器自己的 namespace 和 rootfs，既不会误读
-Agent 文件系统，也不会因为 `libjli.so` 不在系统默认库路径中而误判。
+这套流程不使用 `nsenter`，不使用 `chroot`，也不需要宿主机安装额外的 namespace 工具。
+版本子进程结束后，工具不会把目标 PID/mount namespace 留给后续子进程：mount namespace
+恢复到当前进程后，后续子进程继承原 mount namespace；PID namespace 则通过保存的原
+namespace 文件描述符恢复其子进程选择，并由验证子进程再次确认。
+测试表明，即使 Host 和 POD 存在相同绝对路径但版本不同的 Java，执行结果仍来自目标 POD
+的 Java，而不是 Host Java。Java 8 使用 `-version`，不能使用 `--version`。
 
 这里的 `-version` 不是向正在运行的目标 JVM 发送命令，也不会对目标 JVM 执行 attach。
-它是在目标 namespace 中启动一个短生命周期的独立 Java 子进程，用来确认目标 Java
-启动器能够正常启动并报告版本。`popen`、`exec_command` 等外部命令接口内部同样会
-创建子进程，不能在当前 Agent 进程中直接执行 Java，否则会替换 Agent 自身。
-目标 JVM 本身不会因为这一步加载 Agent 或开启 JVMTI 回调。版本子进程结束后，
-`pclose` 会等待并回收它，不会长期占用 Agent 的线程。
+它是在目标 PID/mount namespace 中启动一个短生命周期的独立 Java 子进程，用来确认目标
+Java 启动器能够正常启动并报告版本。目标 JVM 本身不会因为这一步加载 Agent 或开启 JVMTI
+回调。版本子进程结束后，`pclose()` 会等待并回收它。
 
 这一步存在以下现实限制：
 
-- 目标容器没有进入目标 namespace 的权限时，版本命令无法启动；
-- 宿主机缺少 `env`、`timeout` 或支持 `--root` 的 `nsenter`，或者没有 namespace 权限时，
-  跨 namespace 版本检查会失败并保守跳过；
-- 精简 JRE 缺少 `libjli.so` 或动态链接器时，版本命令可能失败；
+- 目标容器没有进入目标 PID/mount namespace 的权限时，版本命令无法启动；
+- `/proc/<pid>/exe`、`/proc/<pid>/environ` 或 namespace 文件不可读时，版本检查失败；
+- 精简 JRE 缺少 `libjli.so`、动态链接器或必要运行库时，版本命令可能失败；
 - 目标 JDK 文件在检查期间被替换时，子进程版本可能与原 JVM 已加载的库不一致；
-- 启动器异常或启动时间超过超时时间时，检查会失败。
-- 版本子进程会继承 Agent 的标准输入输出之外的文件描述符；如果 Agent 持有敏感
-  描述符，需要在生产环境评估这一点。
+- 启动器异常或版本子进程未正常结束时，检查会失败；
+- 版本子进程会继承测试进程的环境和文件描述符，生产代码需要限制无关环境变量和敏感
+  文件描述符的继承。
 
-因此，`-version` 失败不能被解释为“版本安全”，代码会保守跳过 attach。当前实现会在版本命令结束后重新校验 PID start time 和 `/proc/<pid>/exe`，但无法完全防止运行时文件被外部替换。
+因此，`-version` 失败不能被解释为“版本安全”，代码会保守跳过 attach。版本命令结束后
+仍需重新校验 PID start time 和 `/proc/<pid>/exe`，但无法完全防止运行时文件被外部替换。
 
 如果 `-version` 执行失败或输出中没有标准版本字符串，无法确认版本，直接保守跳过 attach。
 
@@ -222,8 +229,9 @@ JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8173361_and_JDK-83051
 | HotSpot 8u412 版本识别 | PASS，允许继续检查 |
 | POD 中 HotSpot 8u212 | PASS，正确跳过 attach |
 | Host 与目标同 namespace | PASS，不切换 namespace |
-| Host 与目标跨 namespace | PASS，`nsenter --root` 使用目标 rootfs |
-| 极简容器缺少目标侧 shell/env/timeout | PASS，使用宿主机 root-aware nsenter 路径 |
+| Host 与目标跨 namespace | PASS，`java_mnt_ns_version` 使用目标 PID/mount namespace |
+| Host 与 POD 存在相同 Java 绝对路径 | PASS，仍获取 POD Java 的真实版本 |
+| 极简容器缺少目标侧 shell/env/timeout | PASS，不依赖 `nsenter`、`chroot` 或目标侧辅助命令 |
 | `DisableAttachMechanism` 参数 | PASS，正确跳过 |
 | 业务参数仅包含 `-XX:+DisableAttachMechanism` 文本 | PASS，不误判为禁用 attach |
 | 无关环境变量仅包含该文本 | PASS，不误判为禁用 attach |
@@ -239,8 +247,8 @@ attach socket 或 namespace 权限失败。这属于测试环境限制，不是 
 ## 6. 代码位置
 
 - 公共预检逻辑：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.c` 中的 `java_attach_preflight()`；
-- HotSpot 版本命令：同文件中的 `java_preflight_exec_version()`；同 mount namespace
-  直接执行，跨 mount namespace 通过宿主机 `timeout/nsenter --mount --pid
-  --root=/proc/<pid>/root` 进入目标 rootfs 后执行；
+- Java 版本获取工具：`agent/src/ebpf/tools/java_mnt_ns_version.c`；通过
+  `setns(PID namespace)`、`setns(mount namespace)` 和 `popen("java -version")` 获取目标
+  Java 版本，不依赖 `nsenter` 或 `chroot`；
 - 预检数据结构和返回值：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.h`；
 - Agent 采集结果对“主动跳过”的处理：`agent/src/ebpf/user/profile/java/collect_symbol_files.c`。

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -4,7 +4,7 @@
 
 DeepFlow 在采集 Java 符号前，需要把一个 JVMTI Agent 加载到目标 JVM 中。这个动作叫作 `attach`。
 
-旧版 HotSpot，特别是本次客户环境中的 Java 8u342，在处理 `CompiledMethodLoad` 事件时存在已知缺陷。Agent 一旦打开这个 JVM 能力，在高频 JIT 编译、类加载和类卸载同时发生时，可能触发 JVM 崩溃。版本范围需要分段理解：`8u0–8u351` 缺少首个已知修复，`8u352–8u381` 虽然已有第一组修复但仍缺少 8u 特有的 Sweeper 保护，`8u382` 起才包含完整补丁链。当前代码使用 `8u382` 作为完整修复门禁，因此这是保守的补丁完整性判断，不是声称所有低于 8u382 的版本都已逐一复现。
+旧版 HotSpot，特别是本次客户环境中的 Java 8u342，在处理 `CompiledMethodLoad` 事件时存在已知缺陷。Agent 一旦打开这个 JVM 能力，在高频 JIT 编译、类加载和类卸载同时发生时，可能触发 JVM 崩溃。版本范围需要分段理解：`8u0–8u351` 同时缺少 `JDK-8173361` 和 `JDK-8305165`，`8u352–8u381` 已包含前一个修复但仍缺少 `JDK-8305165`，`8u382` 起才包含完整补丁链。当前代码使用 `8u382` 作为完整修复门禁，因此这是保守的补丁完整性判断，不是声称所有低于 8u382 的版本都已逐一复现。
 
 因此，代码现在会在 attach 之前先检查目标 JVM：
 
@@ -136,8 +136,8 @@ Java 启动器能够正常启动并报告版本。目标 JVM 本身不会因为�
 版本判断首先识别 Java 8 update 所处的补丁范围：
 
 ```text
-update <= 351       -> 缺少 JDK-8173361，高风险
-352 <= update <= 381 -> 已有第一组修复，但缺少 JDK-8305165，残余风险
+update <= 351       -> 缺少 JDK-8173361 和 JDK-8305165，高风险
+352 <= update <= 381 -> 已有 JDK-8173361，但缺少 JDK-8305165，残余风险
 update >= 382       -> 两组标准 OpenJDK 修复齐全，达到当前安全基线
 ```
 
@@ -150,7 +150,7 @@ HotSpot && Java 主版本 == 8 && update < 382
 
 例如：
 
-- `1.8.0_342`：属于缺少首个修复的高风险段，跳过 attach；
+- `1.8.0_342`：属于同时缺少两个修复的高风险段，跳过 attach；
 - `1.8.0_352`：属于部分修复段，当前仍跳过 attach；
 - `1.8.0_381`：属于部分修复段，当前仍跳过 attach；
 - `1.8.0_382`：通过版本门禁；
@@ -208,8 +208,8 @@ HotSpot && Java 主版本 == 8 && update < 382
 | 进程退出或是僵尸进程 | 跳过 attach |
 | 找不到 JVM 核心库 | 跳过 attach |
 | HotSpot，`-version` 执行失败或无法解析 | 跳过 attach |
-| HotSpot，`8u0–8u351` | 缺少 JDK-8173361，跳过 attach |
-| HotSpot，`8u352–8u381` | 补丁不完整，当前跳过 attach |
+| HotSpot，`8u0–8u351` | 缺少 JDK-8173361 和 JDK-8305165，跳过 attach |
+| HotSpot，`8u352–8u381` | 缺少 JDK-8305165，当前跳过 attach |
 | HotSpot，版本达到 8u382 或更高 | 通过版本门禁，继续通用检查 |
 | OpenJ9 等非 HotSpot JVM | 不做版本门禁，继续通用检查 |
 | `DisableAttachMechanism` 已启用 | 跳过 attach |
@@ -219,11 +219,18 @@ HotSpot && Java 主版本 == 8 && update < 382
 
 跳过时会输出统一日志，例如：
 
-对于低于 8u382 的 HotSpot Java 8，`reason` 统一说明：Java 程序缺失
-`JDK-8173361` 和 `JDK-8305165` 修复，存在崩溃风险，为安全起见不执行 attach。
+对于低于 8u382 的 HotSpot Java 8，`reason` 会按版本范围说明缺失的修复：8u0–8u351
+缺少 `JDK-8173361` 和 `JDK-8305165`，8u352–8u381 缺少 `JDK-8305165`。两类版本均存在
+崩溃风险，为安全起见不执行 attach。
 
 ```text
 JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8173361_and_JDK-8305165_crash_risk jvm=1.8.0_212 required=8u382+
+```
+
+8u352–8u381 的日志示例：
+
+```text
+JAVA_ATTACH_SKIP pid=1234 reason=hotspot_java8_missing_JDK-8305165_crash_risk jvm=1.8.0_352 required=8u382+
 ```
 
 ## 5. 本机验证结果

--- a/agent/src/ebpf/docs/java-attach-preflight-guide.md
+++ b/agent/src/ebpf/docs/java-attach-preflight-guide.md
@@ -58,39 +58,39 @@ java_attach_preflight(pid, &info)
 
 已经加载过 DeepFlow Agent 不会作为拒绝条件。因为合法的重复 attach 仍然可能再次调用 `Agent_OnAttach`。
 
-### 第三步：HotSpot 使用 `java_mnt_ns_version` 获取版本
+### 第三步：HotSpot 使用 namespace helper 获取版本
 
 只有 HotSpot 执行版本门禁，OpenJ9 等其他 JVM 不执行 Java 8u382 检查。
 
-版本获取不读取 `release` 文件，也不调用 Agent/Host 环境中的 `java`。统一使用
-`agent/src/ebpf/tools/java_mnt_ns_version.c` 中实现的流程：
+版本获取不读取 `release` 文件，也不调用 Agent/Host 环境中的 `java`。生产代码使用
+`jvm_symbol_collect.c` 中的 helper/runner 流程；`agent/src/ebpf/tools/java_mnt_ns_version.c`
+提供同一 namespace 路径选择的独立验证工具：
 
 1. 在切换 namespace 前，从 `/proc/<pid>/exe` 获取目标 JVM 的真实可执行文件；
 2. 从 `/proc/<pid>/environ` 读取目标 Java 的 `LD_LIBRARY_PATH`、`JAVA_HOME`、`PATH`、
    `HOME` 和 `LANG` 等必要环境变量。该文件使用 NUL 字符分隔，不能按普通文本行读取；
 3. 根据目标 Java 的 `bin/java` 路径补充对应架构的 `lib/<arch>/jli` 目录，确保启动器可以
    找到 `libjli.so`；
-4. 保存当前 PID namespace，调用 `setns()` 设置目标 PID namespace。该调用不会改变当前
-   进程自身的 PID，只会影响之后创建的子进程；
-5. 保存当前 mount namespace，调用 `setns()` 进入目标 Java 的 mount namespace；
-6. 使用 `popen("<java路径> -version")` 创建子进程，读取标准版本输出中的
-   `version "..."`，提取 `JAVA_VERSION`；
-7. `pclose()` 回收版本子进程后，恢复原 mount namespace，并恢复后续子进程使用的原 PID
-   namespace；最后再创建验证子进程，分别核对其 PID/mount namespace 与进入前保存的
-   namespace 标识，确保后续子进程已回到原 namespace。任一恢复或核对失败，工具都返回
-   失败，不继续使用本次版本结果。
+4. 创建独立的版本探测 helper。helper 调用 `setns()` 进入目标 PID/mount namespace；
+   `setns(CLONE_NEWPID)` 不改变 helper 自身的 PID，只影响 helper 后续创建的子进程；
+5. helper 再创建 runner，runner 使用 `execve()` 直接执行目标 `/proc/<pid>/exe` 的绝对路径，
+   参数为 Java 8 兼容的 `-version`，并通过管道把标准输出和标准错误传回父进程；
+6. Agent 父进程以非阻塞方式读取版本输出，同时用单调时钟实施 5 秒超时。超时后杀掉
+   helper 所在的进程组并回收 helper，避免 Java runner 残留；
+7. helper 执行完成后立即退出，不需要调用 `df_exit_ns()`。目标 namespace 只存在于 helper
+   和 runner 中，Agent 父进程及其后续子进程从未进入目标 namespace，因此不需要恢复或
+   额外验证父进程 namespace。
 
 这套流程不使用 `nsenter`，不使用 `chroot`，也不需要宿主机安装额外的 namespace 工具。
-版本子进程结束后，工具不会把目标 PID/mount namespace 留给后续子进程：mount namespace
-恢复到当前进程后，后续子进程继承原 mount namespace；PID namespace 则通过保存的原
-namespace 文件描述符恢复其子进程选择，并由验证子进程再次确认。
+版本 helper 结束后，目标 PID/mount namespace 不会留给 Agent 后续子进程；namespace
+切换发生在独立 helper 中，helper 退出后由内核回收其 namespace 状态。
 测试表明，即使 Host 和 POD 存在相同绝对路径但版本不同的 Java，执行结果仍来自目标 POD
 的 Java，而不是 Host Java。Java 8 使用 `-version`，不能使用 `--version`。
 
 这里的 `-version` 不是向正在运行的目标 JVM 发送命令，也不会对目标 JVM 执行 attach。
 它是在目标 PID/mount namespace 中启动一个短生命周期的独立 Java 子进程，用来确认目标
 Java 启动器能够正常启动并报告版本。目标 JVM 本身不会因为这一步加载 Agent 或开启 JVMTI
-回调。版本子进程结束后，`pclose()` 会等待并回收它。
+回调。版本 helper 和 runner 结束后，父进程回收 helper。
 
 这一步存在以下现实限制：
 
@@ -98,9 +98,9 @@ Java 启动器能够正常启动并报告版本。目标 JVM 本身不会因为�
 - `/proc/<pid>/exe`、`/proc/<pid>/environ` 或 namespace 文件不可读时，版本检查失败；
 - 精简 JRE 缺少 `libjli.so`、动态链接器或必要运行库时，版本命令可能失败；
 - 目标 JDK 文件在检查期间被替换时，子进程版本可能与原 JVM 已加载的库不一致；
-- 启动器异常或版本子进程未正常结束时，检查会失败；
-- 版本子进程会继承测试进程的环境和文件描述符，生产代码需要限制无关环境变量和敏感
-  文件描述符的继承。
+- 启动器异常、5 秒内未退出或版本子进程未正常结束时，检查会失败；
+- runner 使用目标 Java 的显式运行环境白名单，但 helper/runner 仍可能继承打开的文件描述符；
+  生产代码应避免在版本探测期间持有不必要的敏感描述符。
 
 因此，`-version` 失败不能被解释为“版本安全”，代码会保守跳过 attach。版本命令结束后
 仍需重新校验 PID start time 和 `/proc/<pid>/exe`，但无法完全防止运行时文件被外部替换。
@@ -247,8 +247,10 @@ attach socket 或 namespace 权限失败。这属于测试环境限制，不是 
 ## 6. 代码位置
 
 - 公共预检逻辑：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.c` 中的 `java_attach_preflight()`；
-- Java 版本获取工具：`agent/src/ebpf/tools/java_mnt_ns_version.c`；通过
-  `setns(PID namespace)`、`setns(mount namespace)` 和 `popen("java -version")` 获取目标
-  Java 版本，不依赖 `nsenter` 或 `chroot`；
+- Java 版本获取实现：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.c`；通过独立
+  helper、`setns(PID namespace)`、`setns(mount namespace)` 和 `execve(<目标绝对路径>,
+  {<目标路径>, "-version"})` 获取目标 Java 版本，不依赖 `nsenter` 或 `chroot`；
+- 独立验证工具：`agent/src/ebpf/tools/java_mnt_ns_version.c`；用于验证目标 namespace
+  中的 Java 路径、动态库环境和 namespace 恢复行为；
 - 预检数据结构和返回值：`agent/src/ebpf/user/profile/java/jvm_symbol_collect.h`；
 - Agent 采集结果对“主动跳过”的处理：`agent/src/ebpf/user/profile/java/collect_symbol_files.c`。

--- a/agent/src/ebpf/docs/jvm-symbol-collect-agent-sigsegv-investigation.md
+++ b/agent/src/ebpf/docs/jvm-symbol-collect-agent-sigsegv-investigation.md
@@ -1,0 +1,454 @@
+# JVM `JvmtiExport::post_compiled_method_load` SIGSEGV 排查报告
+
+## 1. 报告信息
+
+| 项目 | 内容 |
+| --- | --- |
+| 排查对象 | DeepFlow Java 符号采集 JVMTI Agent |
+| 相关源码 | `agent/src/ebpf/user/profile/java/symbol_collect_agent.c` |
+| 崩溃日志 | `/root/.codex/attachments/be17d8a7-bfd4-441e-aed5-5d2e8db4e2d7/pasted-text.txt` |
+| JVM | OpenJDK 64-Bit Server VM 8u342-b07 |
+| 操作系统 | Kylin Linux Advanced Server V10，Linux 5.10，x86_64 |
+| 排查日期 | 2026-08-06 |
+| 结论置信度 | 高 |
+
+## 2. 结论摘要
+
+本次 SIGSEGV 的直接原因，高置信度属于旧版 HotSpot 的 JVMTI `CompiledMethodLoad` 已知缺陷，而不是 `symbol_collect_agent.c` 回调函数直接发生越界写或空指针访问。
+
+DeepFlow Agent 申请并启用了 `JVMTI_EVENT_COMPILED_METHOD_LOAD`，因此它是该 JVM 缺陷的触发条件。旧版 HotSpot 将待通知的 `nmethod` 放入延迟事件队列后，没有在 GC、类卸载和 CodeCache Sweeper 执行期间完整保护其方法元数据。等 `Service Thread` 处理事件时，相关 `nmethod` 可能已经被卸载、清理或转为 zombie，HotSpot 随后在构造 JVMTI 回调参数、解析内联信息时解引用失效元数据，最终访问空指针偏移 `0x8`。
+
+该问题与 OpenJDK 已知缺陷 [JDK-8173361](https://bugs.openjdk.org/browse/JDK-8173361) 的崩溃特征高度一致。它首次回移至 OpenJDK 8u352，见 [JDK-8289478](https://bugs.openjdk.org/browse/JDK-8289478)；8u 回移中与 Sweeper 保护相关的问题又在 8u382 通过 [JDK-8305165](https://bugs.openjdk.org/browse/JDK-8305165) 补齐。因此，版本范围不能简单写成“所有低于 8u382 的版本都已经复现”，而应区分“已确认缺少首个修复”和“补丁尚未完整”的版本段。对于标准 OpenJDK 8，当前完整修复基线仍是 8u382。
+
+同时，`symbol_collect_agent.c` 的 socket 发送和重复 attach 状态切换存在并发、忙等待等问题。这些问题无法解释本次发生在 `libjvm.so` 内部、进入 Agent 回调之前的空指针崩溃，但可能阻塞 JVM `Service Thread`、增加延迟事件积压，从而显著放大旧 JVM 缺陷的触发概率。
+
+## 3. 通俗版说明
+
+### 3.1 是什么问题
+
+可以把 JVM 编译出来的机器码理解成一批“临时生成的代码卡片”。每张卡片记录了代码地址、对应的 Java 方法以及方法的内联关系。
+
+DeepFlow Agent 为了把采样地址还原成 Java 方法名，会要求 JVM 在生成新卡片时通知它。JVM 没有立刻发送所有通知，而是先把一部分通知放进队列，之后由 `Service Thread` 处理。
+
+这次的问题是：某张卡片已经被 JVM 回收或清理了，通知却还留在队列中。`Service Thread` 后来处理这条旧通知时，继续读取已经失效的卡片，最终访问了空指针地址 `0x8`，导致整个 JVM 段错误退出。
+
+简单概括：
+
+> JVM 准备把一条 JIT 方法信息通知给 DeepFlow 时，这条信息已经被 JVM 自己回收，但旧版 JVM 仍继续访问它，因此崩溃。
+
+### 3.2 根因是什么
+
+根因是 OpenJDK 8u342 中 HotSpot 对 JVMTI 延迟 `CompiledMethodLoad` 事件的生命周期保护不完整。
+
+正常情况下，只要某个已编译方法的通知还在队列中，JVM 就应该保证对应的 `nmethod` 和方法元数据不能被 GC、类卸载或 CodeCache Sweeper 清理。8u342 没有完整做到这一点，因此存在以下竞态：
+
+```text
+JIT 生成 nmethod
+    -> JVM 将 CompiledMethodLoad 通知放入队列
+    -> GC、类卸载或 Sweeper 清理该 nmethod/方法元数据
+    -> Service Thread 取出旧通知
+    -> JVM 读取失效元数据
+    -> SIGSEGV
+```
+
+这是 OpenJDK 已确认并修复的缺陷，不是 Java 业务代码中的 `addAll()` 引起的，也没有证据表明是 DeepFlow 回调直接写坏了 JVM 内存。
+
+### 3.3 Agent 的触发条件是什么
+
+这是一个并发时序型 JVM 缺陷。触发崩溃需要以下几个条件在同一时间窗口内成立：
+
+1. JVM 版本存在缺陷。本次使用的是 OpenJDK 8u342，尚未包含相关 HotSpot 修复。
+2. DeepFlow Agent 已成功加载，并启用 `JVMTI_EVENT_COMPILED_METHOD_LOAD`。
+3. JVM 进行 JIT 编译，生成新的 `nmethod`，随后将方法加载通知放入 JVMTI 延迟事件队列。
+4. `Service Thread` 处理通知前，对应的 `nmethod` 或方法元数据已经失效，例如因 GC、类卸载，或者在类重定义、去优化后被 CodeCache Sweeper 清理。
+5. `Service Thread` 取出这条旧通知，HotSpot 在调用 DeepFlow 回调前继续解析失效元数据，最终发生空指针访问并触发 SIGSEGV。
+
+完整触发链如下：
+
+```text
+DeepFlow Agent 启用 CompiledMethodLoad
+    -> JIT 生成 nmethod
+    -> HotSpot 将事件放入 JVMTI 延迟队列
+    -> GC、类卸载、去优化或 Sweeper 使相关元数据失效
+    -> Service Thread 延迟处理旧事件
+    -> HotSpot 访问失效元数据
+    -> SIGSEGV
+```
+
+#### 为什么压力测试更容易触发
+
+压力测试不会产生新的根因，但会让上述事件更密集地发生，从而显著增大竞态窗口：
+
+- 热点代码执行频繁，JIT 编译量增加，产生更多 `CompiledMethodLoad` 事件；
+- CodeCache 增长更快，Sweeper 更频繁地清理旧 `nmethod`；
+- 对象分配量增加，GC 更活跃；
+- 类重定义、retransformation 和去优化会加速旧编译代码失效；
+- DeepFlow 需要发送的符号量增加，符号 socket 更容易出现背压；
+- `send_msg()` 遇到 `EAGAIN` 时无限重试，可能阻塞 `Service Thread`，造成 JVMTI 事件队列积压；
+- 多次重复 attach Agent 会增加状态切换和并发处理的复杂度。
+
+本次日志也符合这一过程：崩溃前先后出现 GC、MemCheck 类重定义、去优化和多次 `flushing nmethod`，随后 `Service Thread` 在 `post_compiled_method_load` 中崩溃。
+
+因此，只在压力测试中发现是符合预期的。非压力环境下竞态窗口较小，所以可能长时间不出现，但不代表问题不存在。DeepFlow Agent 启用了问题路径，并可能通过回调阻塞放大触发概率；真正的根因仍是旧版 HotSpot 没有正确保护延迟事件引用的 `nmethod` 生命周期。
+
+### 3.4 如何解决
+
+根本解决方案是升级或修补 JVM：
+
+1. 优先升级到厂商当前受支持的最新 JDK 8，或者升级到受支持的 JDK 11/17。
+2. 如果继续使用 JDK 8，确认厂商版本包含以下两个修复或等价补丁：
+   - `JDK-8173361`，OpenJDK 8u 首次回移到 8u352；
+   - `JDK-8305165`，在 8u382 补齐 8u 特有的 Sweeper 保护问题。
+3. 最低建议验证基线为 8u382，不建议只升级到 8u352 后就认为问题完全解决。
+4. 无法更换 JVM 二进制时，可向当前厂商 JDK 回移 OpenJDK 提交 `1b4f32d6` 和 `3147b1ba`。
+
+同时应修复 DeepFlow Agent，降低它对 JVM 内部线程的影响：
+
+- `EAGAIN` 时不能无限忙等待，应有超时和丢弃策略；
+- callback 必须有明确的最大执行时间；
+- 重复 attach 和 callback 之间需要完整的生命周期同步；
+- 修复日志发送长度越界读取和 `SIGPIPE` 处理。
+
+需要强调：只修改 Agent 的 socket 代码可以降低复现概率，但不能修复旧 JVM 对 `nmethod` 生命周期管理错误，不能作为根治方案。
+
+### 3.5 如何临时规避
+
+无法立即升级 JVM 时，可按影响从小到大选择以下措施：
+
+1. 暂停或降低 MemCheck 等 Agent 的类重定义、retransformation 频率，减少方法失效和去优化。
+2. 保证 DeepFlow 符号 socket 接收端持续、及时消费数据，避免 socket 背压阻塞 JVM `Service Thread`。
+3. 避免对同一 JVM 重复 attach DeepFlow Agent。
+4. 修改 DeepFlow Agent，不再持续启用 `JVMTI_EVENT_COMPILED_METHOD_LOAD`。这样会丢失后续新产生的 JIT 方法符号，Java profiling 结果可能出现无法符号化的地址。
+5. 最可靠的止血方案是停止向受影响 JVM 注入 DeepFlow Java symbol Agent。此时 DeepFlow 不再触发这条 JVMTI 路径，但会失去或降低 Java JIT 符号化能力。
+
+临时规避只能减少或消除触发条件，不能消除 JVM 中原有的缺陷。只要旧 JVM 上还有其他 JVMTI Agent 启用同类事件，理论上仍可能触发。
+
+## 4. 事故现象
+
+崩溃日志的核心信息如下：
+
+```text
+SIGSEGV (0xb) at pc=0x00007f9744187dfe, pid=1, tid=0x00007f9701dfd700
+JRE version: OpenJDK Runtime Environment (8.0_342-b07)
+Problematic frame:
+V  [libjvm.so+0x7fcdfe]  JvmtiExport::post_compiled_method_load(nmethod*)+0x24e
+
+Current thread:
+JavaThread "Service Thread" daemon [_thread_in_vm]
+
+siginfo:
+si_code: SEGV_MAPERR
+si_addr: 0x0000000000000008
+
+RAX=0x0000000000000000
+```
+
+崩溃指令为：
+
+```text
+48 8b 40 08    mov 0x8(%rax), ...
+```
+
+此时 `RAX=0`，所以 CPU 实际访问地址为 `NULL + 0x8`，与日志中的 `si_addr=0x8` 完全一致。这是典型的 JVM 内部对象或元数据空指针成员访问。
+
+native 调用栈为：
+
+```text
+JvmtiExport::post_compiled_method_load(nmethod*)
+ServiceThread::service_thread_entry(JavaThread*, Thread*)
+JavaThread::thread_main_inner()
+JavaThread::run()
+java_start(Thread*)
+```
+
+调用栈中没有出现以下 DeepFlow Agent 函数：
+
+```text
+cbCompiledMethodLoad()
+generate_single_entry()
+df_send_symbol()
+send_msg()
+```
+
+这说明本次崩溃发生在 HotSpot 准备和分发 JVMTI 事件的过程中，尚未进入 DeepFlow 的 `CompiledMethodLoad` 回调。
+
+## 5. 事件时间线
+
+根据 `hs_err` 日志，可整理出以下相对时间线：
+
+| JVM 运行时间 | 事件 |
+| ---: | --- |
+| 240.511 秒 | G1 GC 开始 |
+| 240.540 秒 | G1 GC 完成 |
+| 244.575 秒 | MemCheck Agent 重定义 `com.qt.memchk.MemCheck$b` |
+| 247.754 秒 | MemCheck Agent 重定义 `com.qt.memchk.common.f` |
+| 252.581 秒 | HotSpot 连续执行多次 `flushing nmethod` |
+| 252.675～252.679 秒 | JVM 继续产生新的编译事件和 `nmethod` |
+| 252.878 秒 | `Service Thread` 在 `post_compiled_method_load` 中崩溃 |
+
+崩溃前同时存在 GC、类重定义、去优化和 `nmethod` 清理活动，与已知缺陷中“延迟事件持有的 `nmethod` 在事件处理前失效”的触发条件一致。
+
+日志寄存器中出现的 `java/util/AbstractCollection.addAll` 是 HotSpot 当时正在解析的方法元数据上下文，不表示 Java 业务代码中的 `addAll()` 实现有问题。
+
+## 6. DeepFlow Agent 与崩溃路径的关系
+
+### 6.1 Agent 确实已加载
+
+进程内存映射中存在：
+
+```text
+/deepflow/df_java_agent_v2.so (deleted)
+```
+
+`(deleted)` 只表示 Agent 临时文件在 `dlopen()` 后从文件系统删除。其代码段仍保留在 JVM 地址空间且具有可执行映射，并不表示共享库已经从进程卸载，也不能据此判断为回调指针悬空。
+
+### 6.2 Agent 启用了问题事件
+
+`symbol_collect_agent.c` 中的关键调用为：
+
+1. 申请 `CompiledMethodLoad` 能力：
+
+   ```c
+   capabilities.can_generate_compiled_method_load_events = 1;
+   ```
+
+   位置：`symbol_collect_agent.c:283`
+
+2. 注册 DeepFlow 回调：
+
+   ```c
+   callbacks.CompiledMethodLoad = &cbCompiledMethodLoad;
+   ```
+
+   位置：`symbol_collect_agent.c:423`
+
+3. 启用持续通知：
+
+   ```c
+   (*jvmti)->SetEventNotificationMode(
+       jvmti, mode, JVMTI_EVENT_COMPILED_METHOD_LOAD, NULL);
+   ```
+
+   位置：`symbol_collect_agent.c:441-443`
+
+4. 回放当前已编译方法：
+
+   ```c
+   (*jvmti)->GenerateEvents(
+       jvmti, JVMTI_EVENT_COMPILED_METHOD_LOAD);
+   ```
+
+   位置：`symbol_collect_agent.c:498-499`
+
+持续通知会使新生成的 `nmethod` 通过 HotSpot 的 JVMTI 延迟事件队列交给 `Service Thread`。本次崩溃发生在 `Service Thread`，因此更符合持续编译事件的异步分发路径，而不是 `Agent_OnAttach` 线程中同步执行初始回放的路径。
+
+### 6.3 Agent 是触发者，不是本次直接崩溃点
+
+因果关系应表述为：
+
+```text
+DeepFlow Agent 启用 CompiledMethodLoad
+    -> HotSpot 将 nmethod 放入 JVMTI 延迟事件队列
+    -> GC、类卸载或 Sweeper 使 nmethod/Method 元数据失效
+    -> Service Thread 延后处理该事件
+    -> HotSpot 在调用 DeepFlow 回调前解析失效元数据
+    -> NULL + 0x8，JVM SIGSEGV
+```
+
+若不加载任何需要 `CompiledMethodLoad` 的 JVMTI Agent，这条 HotSpot 缺陷路径通常不会被触发。但这不等于 Agent 回调代码写坏了 JVM 内存。
+
+## 7. 与 OpenJDK 已知缺陷的匹配
+
+### 7.1 JDK-8173361 / JDK-8289478
+
+[JDK-8173361](https://bugs.openjdk.org/browse/JDK-8173361) 记录了 `JvmtiExport::post_compiled_method_load` 中的多种崩溃。其公开案例包含以下共同特征：
+
+- 崩溃线程为 `Service Thread`；
+- 崩溃发生在 `JvmtiExport::post_compiled_method_load` 或其内联的 `create_inline_record`、`ScopeDesc` 解析路径；
+- `nmethod` 已经被卸载，或其 `_method`、`jmethodID` 已被清空；
+- 可出现 `SEGV_MAPERR` 和访问地址 `0x8`；
+- JVMTI Agent 开启了 `COMPILED_METHOD_LOAD` 事件。
+
+OpenJDK 8u 的回移缺陷号为 [JDK-8289478](https://bugs.openjdk.org/browse/JDK-8289478)，修复进入 OpenJDK 8u352，对应提交：
+
+- [openjdk/jdk8u@1b4f32d6](https://github.com/openjdk/jdk8u/commit/1b4f32d61e3b0460c82598f24dbd5c4dd0fc3bbe)
+
+该补丁的核心目标是让 `Service Thread` 和 JVMTI 延迟队列在 GC、代码清理期间正确暴露和保护待处理的 `nmethod`，避免使用已经卸载的方法元数据。
+
+### 7.2 JDK-8305165
+
+8u352 的回移在 JDK 8 中仍存在特殊问题：`JavaThread::nmethods_do()` 不是虚函数，导致遍历 Java 线程时没有调用 `ServiceThread::nmethods_do()`，队列中的 `nmethod` 仍可能被 Sweeper 转为 zombie。
+
+该问题通过 [JDK-8305165](https://bugs.openjdk.org/browse/JDK-8305165) 在 OpenJDK 8u382 修复，对应提交：
+
+- [openjdk/jdk8u@3147b1ba](https://github.com/openjdk/jdk8u/commit/3147b1bafe12326a97269655de46f066931f3ee4)
+
+本次环境为 8u342，早于上述两个修复，因此完全处于受影响版本范围内。仅凭 `hs_err` 无法进一步确定本次失效属于类卸载还是 Sweeper zombification；二者属于同一缺陷链，处置方案一致。
+
+### 7.3 Java 8 版本范围与证据等级
+
+根据 OpenJDK 8 的发布说明和补丁回移关系，标准 OpenJDK HotSpot Java 8 应按以下三个范围理解：
+
+| Java 8 update 范围 | 补丁状态 | 结论与证据等级 |
+|---|---|---|
+| `8u0–8u351` | 尚未包含 JDK-8173361/JDK-8289478 | 高风险范围；本次客户 `8u342-b07` 属于此段，并已在相同压力模型中由 Honest Profiler 和 DeepFlow 均复现 |
+| `8u352–8u381` | 已包含 JDK-8173361，但尚未包含 JDK-8305165 | 部分修复、残余风险范围；不能称为“已确认必现”，也不能仅凭版本号称为完整安全 |
+| `8u382` 及更高 | 两个修复均已进入标准 OpenJDK 8 | 当前完整修复基线；本机 `8u382-b05` 在两种 Agent 和相同压力下均跑满 300 秒未复现 |
+
+这里的“高风险范围”表示标准 OpenJDK 发行版明确缺少对应修复，不表示每一个 update 在任何负载下都会崩溃；竞态型缺陷仍取决于 JIT、类卸载、Sweeper 和 JVMTI 事件时序。相反，`8u352–8u381` 不能因为尚未收集到每个 update 的崩溃样本就直接判定安全，原因是该段仍缺少 8u 特有的 Sweeper 保护修复。
+
+因此，当前代码中的 `update < 382` 是“补丁完整性门禁”，不是“所有低于 382 的版本都已被逐一证明必现”的结论。若要把 `8u352–8u381` 改为允许 attach，至少还需要对目标厂商的具体构建确认包含 JDK-8305165 或等价补丁，或者完成同一压力矩阵的版本级验证；仅依赖 `JAVA_VERSION` 的 update 数字无法识别厂商是否额外回移了补丁。
+
+## 8. `symbol_collect_agent.c` 中发现的风险
+
+以下问题不是本次 SIGSEGV 的直接根因，但建议同步整改。
+
+### 8.1 非阻塞 socket 遇到 `EAGAIN` 时无限忙等待
+
+代码位置：`symbol_collect_agent.c:95-101`
+
+```c
+if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+    continue;
+}
+```
+
+socket 被设置为 `O_NONBLOCK`，但出现发送背压后立即无限重试，实际效果是忙等待。对于正常的新编译事件，回调可能运行在 JVM `Service Thread` 上；一旦接收端消费较慢，该线程会长时间占用 CPU 并停止消费 JVMTI 延迟队列。
+
+这会产生两个后果：
+
+- JVM 内部服务事件处理延迟；
+- 更多 `nmethod` 长时间停留在延迟队列中，显著扩大旧版 HotSpot 生命周期缺陷的竞态窗口。
+
+建议改为有上限的重试或 `poll()` 等待，并设置严格超时；符号采集不能以无限期阻塞 JVM 内部线程为代价。达到超时后应记录丢包并返回。
+
+### 8.2 重复 attach 的全局状态切换没有统一同步
+
+代码位置：`symbol_collect_agent.c:513-548`
+
+重复 attach 时会执行：
+
+- 关闭旧 socket；
+- 禁用和重新启用 JVMTI 事件；
+- 修改 `g_jvmti`、`replay_finish`、`replay_count`；
+- 清零 `g_cached_bytes`；
+- 创建新 socket 并重新回放符号。
+
+以上操作没有全部纳入 `g_df_lock` 或独立的生命周期锁，而 JVMTI 回调可能同时在其他 JVM 线程上运行。潜在影响包括：
+
+- callback 使用已经关闭或被复用的 fd；
+- 回放缓存被并发清零，造成符号丢失或协议流损坏；
+- C 语言层面的无同步数据竞争；
+- 新旧 attach 周期的数据写入同一个新 fd。
+
+这类问题更可能表现为符号错误、socket 异常或 Agent 自身崩溃，不符合当前 `libjvm.so` 内部空指针特征。
+
+### 8.3 `df_log` 使用未截断的 `snprintf()` 返回值
+
+代码位置：`symbol_collect_agent.c:82-85`
+
+```c
+char str_buf[LOG_BUF_SZ];
+int n = snprintf(str_buf, sizeof(str_buf), format, ...);
+send_msg(perf_map_log_socket_fd, str_buf, n);
+```
+
+当输出超过 511 字节时，`snprintf()` 返回原本需要写入的长度，该长度可能大于 `str_buf`，随后 `send_msg()` 会越界读取栈内存。发送长度应限制在实际缓冲区内容范围内，并处理负返回值。
+
+### 8.4 非阻塞模式不能避免 `SIGPIPE`
+
+源码注释认为 `O_NONBLOCK` 能避免向关闭 socket 写入时产生 `SIGPIPE`，该判断不成立。非阻塞模式只改变阻塞行为，不会禁止 `SIGPIPE`。应使用 `MSG_NOSIGNAL`，或明确、审慎地管理进程级信号策略。
+
+本次信号为 `SIGSEGV`，不是 `SIGPIPE`，所以该问题与本次事故无直接关系。
+
+## 9. 根因分层
+
+| 层级 | 结论 | 说明 |
+| --- | --- | --- |
+| 直接原因 | HotSpot 解引用失效的 `nmethod`/Method 元数据 | 发生于 `post_compiled_method_load` 内部、进入 Agent 回调之前 |
+| 产品触发条件 | DeepFlow Agent 启用 `JVMTI_EVENT_COMPILED_METHOD_LOAD` | 没有该事件需求时通常不会走到问题路径 |
+| 环境根因 | OpenJDK 8u342 缺少已知修复 | 早于 8u352 和 8u382 的相关补丁 |
+| 概率放大因素 | Agent socket 忙等待、类重定义、GC、CodeCache 清理 | 延长队列停留时间或增加 nmethod 失效机会 |
+| 已排除的主要方向 | DeepFlow callback 当前栈内直接越界或空指针 | native 栈没有进入 Agent `.so` |
+
+## 10. 处置建议
+
+### 10.1 立即措施
+
+1. 将 JVM 升级到包含 `JDK-8173361` 和 `JDK-8305165` 修复的厂商版本。
+2. 对 OpenJDK 8，建议直接升级到当前受支持的最新更新版；最低验证基线应为 8u382，而不是仅停留在 8u352。
+3. 厂商 JDK 的补丁集合可能与 OpenJDK 版本号不完全一致，应向厂商确认是否包含以下修复或等价补丁：
+   - `JDK-8173361` / 提交 `1b4f32d6`；
+   - `JDK-8305165` / 提交 `3147b1ba`。
+4. 若暂时无法升级，事故止血方案是停止向受影响 JVM 注入 DeepFlow Java symbol Agent，代价是失去 JIT Java 符号化能力。
+
+### 10.2 短期代码整改
+
+1. 修复 `send_msg()` 的 `EAGAIN` 无限循环，为 JVM 回调设置有界执行时间。
+2. 为 `Agent_OnAttach`、socket fd 和回放缓存增加一致的生命周期同步。
+3. 修复 `df_log` 发送长度越界读取。
+4. 使用 `MSG_NOSIGNAL` 或等价机制处理 socket `SIGPIPE`。
+5. 增加指标：callback 耗时、发送失败数、EAGAIN 次数、符号丢弃数、重复 attach 次数。
+
+### 10.3 无法升级 JVM 时的源码回移
+
+如果必须继续使用现有厂商 8u342，可在 HotSpot 中回移以下 OpenJDK 提交并重新构建 JVM：
+
+1. `1b4f32d61e3b0460c82598f24dbd5c4dd0fc3bbe`；
+2. `3147b1bafe12326a97269655de46f066931f3ee4`。
+
+只修改 Agent 无法从根本上保证安全，因为 Agent 无权控制 HotSpot 延迟队列中 `nmethod` 的 GC 和 Sweeper 生命周期。
+
+## 11. 验证方案
+
+### 11.1 推荐 A/B 验证矩阵
+
+| 场景 | JVM | DeepFlow Agent | 预期 |
+| --- | --- | --- | --- |
+| A | 当前 8u342 | 开启 | 在高编译、类重定义、socket 背压下可能复现 |
+| B | 当前 8u342 | 关闭 | DeepFlow 触发路径消失；其他 JVMTI Agent 仍可能启用同类事件 |
+| C | 包含两个修复的新版 JDK | 开启 | 不再发生该类 `post_compiled_method_load` 崩溃 |
+| D | 新版 JDK | 开启并注入 socket 背压 | JVM 不应崩溃，但可用于暴露 Agent callback 阻塞问题 |
+
+场景 C 是验证根因和解决方案的关键。仅通过场景 B 不能证明 Agent 回调存在内存破坏，只能证明它提供了事件触发条件。
+
+### 11.2 压力条件
+
+建议组合以下负载持续验证：
+
+- 高频 JIT 编译和 CodeCache 清理；
+- G1 周期性 GC；
+- 与当前 MemCheck Agent 相同的类重定义或 retransformation；
+- DeepFlow 符号 socket 接收端限速、短时暂停或主动断开；
+- 重复执行 Agent attach；
+- 运行时间覆盖历史故障窗口，并进一步延长。
+
+### 11.3 Core dump 深度确认
+
+若保留了 `/ebcpa/core` 和完全匹配的 `/jdk8/jre/lib/amd64/server/libjvm.so`，可使用带 HotSpot 调试符号的 GDB 环境进一步确认：
+
+- `JvmtiExport::post_compiled_method_load` 的精确源码行；
+- 待通知 `nmethod` 的状态；
+- `nmethod->_method`、内联 `ScopeDesc` 或 `jmethodID` 是否已清空；
+- 该事件是否仍处于 `JvmtiDeferredEventQueue`；
+- 崩溃前是否发生 class unloading 或 Sweeper zombification。
+
+该步骤可以将“高置信度匹配已知缺陷”提升为对具体失效字段的确定性结论，但不影响当前升级 JVM 的处置建议。
+
+## 12. 验收标准
+
+完成整改后应满足：
+
+1. 生产 JVM 明确包含 `JDK-8173361` 和 `JDK-8305165` 或厂商等价修复。
+2. 压力测试期间不再出现 `JvmtiExport::post_compiled_method_load`、`create_inline_record`、`ScopeDesc` 等相关崩溃。
+3. DeepFlow JVMTI callback 在 socket 背压时有明确的最大执行时间，不无限忙等待。
+4. 重复 attach 与并发 callback 不发生 fd 复用、缓存损坏或数据竞争。
+5. 可通过指标观察符号丢弃和 socket 背压，而不是阻塞 JVM 内部线程。
+
+## 13. 最终判断
+
+本次事故应归类为：
+
+> DeepFlow Java 符号采集 Agent 启用 JVMTI `CompiledMethodLoad` 后，触发 OpenJDK 8u342 中已知的延迟 `nmethod` 生命周期缺陷；Agent 的同步发送实现可能扩大竞态窗口，但没有证据表明本次 SIGSEGV 是由 Agent 回调中的直接内存破坏造成。
+
+根本解决方案是升级或修补 HotSpot；同时应整改 Agent 的 callback 阻塞和重复 attach 并发问题，以降低对 JVM 内部服务线程的影响。

--- a/agent/src/ebpf/tools/java_mnt_ns_version.c
+++ b/agent/src/ebpf/tools/java_mnt_ns_version.c
@@ -1,31 +1,24 @@
 /*
- * 工具功能：验证跨 namespace 获取目标 Java 版本的完整流程。
+ * 工具功能：在独立 helper 子进程中进入目标 Java 的 namespace，并安全获取 Java 版本。
  *
  * 使用方式：
  *     java_mnt_ns_version <java-pid>
  *
  * 执行流程：
- * 1. 通过 /proc/<pid>/exe 读取目标 Java 的绝对路径。
- * 2. 通过 /proc/<pid>/environ 读取目标 Java 的必要运行环境，重点处理
- *    LD_LIBRARY_PATH、JAVA_HOME、PATH、HOME 和 LANG；同时根据 Java 路径
- *    补充 jli 动态库目录，确保启动器可以找到 libjli.so。
- * 3. 保存当前 PID namespace，设置后续子进程使用目标 Java 的 PID namespace。
- *    setns(CLONE_NEWPID) 不会改变当前进程自身的 PID，只影响后续创建的子进程。
- * 4. 保存当前 mount namespace，进入目标 Java 的 mount namespace。
- * 5. 使用 popen() 创建子进程，执行目标 Java 的 -version，并输出版本信息。
- * 6. 等待 Java 子进程结束，恢复当前 mount namespace 和后续子进程的 PID
- *    namespace，避免测试工具影响后续创建的子进程。
- * 7. 再创建验证子进程，确认 mount namespace 已恢复，且后续子进程已经回到
- *    原 PID namespace。
+ * 1. 读取 /proc/<pid>/exe，得到目标 Java 的绝对路径。
+ * 2. 读取 /proc/<pid>/environ 中 NUL 分隔的运行环境，并补充 libjli.so 搜索路径。
+ * 3. 主进程创建 helper，但主进程自身不调用 setns，不改变自己的 namespace。
+ * 4. helper 进入目标 PID/mount namespace，再创建 runner。
+ * 5. runner 使用 execve() 直接执行目标 Java 绝对路径的 -version。
+ * 6. 主进程非阻塞读取版本输出，5 秒超时后杀掉 helper 进程组。
+ * 7. helper 完成后立即退出，主进程验证自身及后续子进程仍处于原 namespace。
  *
  * 注意事项：
- * - 本工具只执行目标 Java 的 -version，不对目标 Java 执行 attach，也不修改
- *   目标 Java 的运行状态。
- * - /proc/<pid>/environ 使用 NUL 字符分隔环境变量，读取时必须按二进制记录解析。
- * - PID namespace 的恢复针对的是后续子进程的 namespace 选择；当前工具进程
- *   自身始终处于原 PID namespace，因此程序末尾还要验证新建子进程的 namespace。
- * - 使用本工具需要能够读取目标进程的 /proc 信息并调用 setns()，通常需要 root
- *   权限或相应的 CAP_SYS_ADMIN/CAP_SYS_PTRACE 能力。
+ * - 本工具只启动一个独立的 Java -version 子进程，不对正在运行的目标 JVM attach。
+ * - PID namespace 的 setns 只影响 helper 后续创建的 runner，不改变 helper 自身的 PID。
+ * - helper 退出后不需要调用 setns 恢复；主进程从未进入目标 namespace。
+ * - /proc/<pid>/environ 使用 NUL 分隔环境变量，不能按普通文本行解析。
+ * - 使用本工具需要读取目标进程 proc 文件并调用 setns 的权限，通常需要 root 或相应能力。
  */
 
 #define _GNU_SOURCE
@@ -33,8 +26,11 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <poll.h>
 #include <sched.h>
+#include <signal.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,21 +38,24 @@
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
-/* 保存 namespace 文件的设备号和 inode，用于进入前后做身份比对。 */
+#define JAVA_VERSION_TIMEOUT_MS 5000
+#define JAVA_VERSION_OUTPUT_SIZE 16384
+
+/* 保存 namespace 文件的设备号和 inode，用于进入前后比较。 */
 struct namespace_identity {
 	dev_t device;
 	ino_t inode;
 };
 
-/* 读取指定 namespace 文件的身份信息。 */
+/* 读取一个 namespace 文件的身份信息。 */
 static int read_namespace_identity(const char *path,
-				   struct namespace_identity *identity)
+					   struct namespace_identity *identity)
 {
 	struct stat status;
 
-	/* 检查参数，避免访问无效指针。 */
 	if (path == NULL || identity == NULL)
 		return -1;
 	if (stat(path, &status) < 0) {
@@ -68,7 +67,7 @@ static int read_namespace_identity(const char *path,
 	return 0;
 }
 
-/* 比较两个 namespace 文件是否指向同一个 namespace。 */
+/* 比较两个 namespace 身份是否相同。 */
 static bool namespace_identity_equal(
 	const struct namespace_identity *left,
 	const struct namespace_identity *right)
@@ -77,367 +76,37 @@ static bool namespace_identity_equal(
 	       left->inode == right->inode;
 }
 
-/* 读取目标进程的 Java 可执行文件绝对路径。 */
+/* 读取目标 Java 的绝对可执行文件路径。 */
 static int read_java_exe_path(pid_t pid, char *path, size_t path_size)
 {
 	char proc_path[64];
 	ssize_t length;
 	char *deleted;
 
-	/* 检查输出缓冲区，避免 readlink() 写入越界。 */
 	if (path == NULL || path_size < 2)
 		return -1;
-
-	/* 构造目标进程的 exe proc 路径。 */
 	if (snprintf(proc_path, sizeof(proc_path), "/proc/%d/exe", pid) >=
 	    (int)sizeof(proc_path))
 		return -1;
-
-	/* readlink() 不会自动补充字符串结尾的 NUL 字符。 */
 	length = readlink(proc_path, path, path_size - 1);
 	if (length < 0) {
 		fprintf(stderr, "读取 %s 失败：%s\n", proc_path, strerror(errno));
 		return -1;
 	}
 	path[length] = '\0';
-
-	/* 进程退出过程中可能出现“ (deleted)”后缀，去掉该后缀再执行。 */
 	deleted = strstr(path, " (deleted)");
 	if (deleted != NULL)
 		*deleted = '\0';
-
-	/* 目标 Java 路径必须是绝对路径。 */
 	if (path[0] != '/') {
 		fprintf(stderr, "目标 exe 路径不是绝对路径：%s\n", path);
 		return -1;
 	}
-
 	return 0;
 }
 
-/* 进入目标进程的 mount namespace，并保存当前 namespace 文件描述符。 */
-static int enter_mount_namespace(pid_t pid, int *self_fd, bool *entered)
-{
-	char target_path[64];
-	char self_path[64];
-	struct stat target_stat;
-	struct stat self_stat;
-	int target_fd;
-
-	/* 初始化输出参数，确保所有错误路径都可以安全恢复。 */
-	if (self_fd == NULL || entered == NULL)
-		return -1;
-	*self_fd = -1;
-	*entered = false;
-
-	/* 构造目标和当前进程的 mount namespace 路径。 */
-	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/mnt", pid) >=
-	    (int)sizeof(target_path) ||
-	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/mnt") >=
-	    (int)sizeof(self_path))
-		return -1;
-
-	/* 先比较 namespace 标识，避免已经在同一 namespace 时重复切换。 */
-	if (stat(target_path, &target_stat) < 0) {
-		fprintf(stderr, "stat %s 失败：%s\n", target_path, strerror(errno));
-		return -1;
-	}
-	if (stat(self_path, &self_stat) < 0) {
-		fprintf(stderr, "stat %s 失败：%s\n", self_path, strerror(errno));
-		return -1;
-	}
-	if (target_stat.st_dev == self_stat.st_dev &&
-	    target_stat.st_ino == self_stat.st_ino) {
-		printf("当前进程和目标 Java 已经处于同一个 mount namespace\n");
-		return 0;
-	}
-
-	/* 打开目标 namespace，供 setns() 使用。 */
-	target_fd = open(target_path, O_RDONLY | O_CLOEXEC);
-	if (target_fd < 0) {
-		fprintf(stderr, "打开 %s 失败：%s\n", target_path, strerror(errno));
-		return -1;
-	}
-
-	/* 打开当前 namespace，后续使用它恢复 Agent/测试程序的 namespace。 */
-	*self_fd = open(self_path, O_RDONLY | O_CLOEXEC);
-	if (*self_fd < 0) {
-		fprintf(stderr, "打开 %s 失败：%s\n", self_path, strerror(errno));
-		close(target_fd);
-		return -1;
-	}
-
-	/* 仅切换 mount namespace，不切换 root 和当前工作目录。 */
-	if (syscall(__NR_setns, target_fd, CLONE_NEWNS) < 0) {
-		fprintf(stderr, "setns(%s) 失败：%s\n", target_path, strerror(errno));
-		close(target_fd);
-		close(*self_fd);
-		*self_fd = -1;
-		return -1;
-	}
-	close(target_fd);
-	*entered = true;
-
-	printf("已经进入目标 Java 的 mount namespace\n");
-	return 0;
-}
-
-/* 设置后续子进程使用目标进程的 PID namespace，并保存原 namespace。 */
-static int enter_pid_namespace(pid_t pid, int *self_fd, bool *entered)
-{
-	char target_path[64];
-	char self_path[64];
-	struct stat target_stat;
-	struct stat self_stat;
-	int target_fd;
-
-	/* 初始化恢复参数，确保失败路径不会误关闭无效 fd。 */
-	if (self_fd == NULL || entered == NULL)
-		return -1;
-	*self_fd = -1;
-	*entered = false;
-
-	/* 构造目标 PID namespace 文件路径。 */
-	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/pid", pid) >=
-	    (int)sizeof(target_path) ||
-	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/pid") >=
-	    (int)sizeof(self_path))
-		return -1;
-
-	/* 目标 PID namespace 不存在时直接报告错误。 */
-	if (stat(target_path, &target_stat) < 0) {
-		fprintf(stderr, "stat %s 失败：%s\n", target_path, strerror(errno));
-		return -1;
-	}
-
-	/* 当前程序已经处于同一 PID namespace 时无需再次调用 setns。 */
-	if (stat(self_path, &self_stat) < 0) {
-		fprintf(stderr, "stat /proc/self/ns/pid 失败：%s\n",
-			strerror(errno));
-		return -1;
-	}
-	if (target_stat.st_dev == self_stat.st_dev &&
-	    target_stat.st_ino == self_stat.st_ino) {
-		printf("当前进程和目标 Java 已经处于同一个 PID namespace\n");
-		return 0;
-	}
-
-	/* 打开目标 PID namespace 文件描述符。 */
-	target_fd = open(target_path, O_RDONLY | O_CLOEXEC);
-	if (target_fd < 0) {
-		fprintf(stderr, "打开 %s 失败：%s\n", target_path, strerror(errno));
-		return -1;
-	}
-
-	/* 保存原 PID namespace，供 popen() 完成后恢复后续子进程的 namespace。 */
-	*self_fd = open(self_path, O_RDONLY | O_CLOEXEC);
-	if (*self_fd < 0) {
-		fprintf(stderr, "打开 %s 失败：%s\n", self_path, strerror(errno));
-		close(target_fd);
-		return -1;
-	}
-
-	/*
-	 * 对 PID namespace 调用 setns() 后，当前进程的 PID 不会改变；
-	 * 后续 fork()/popen() 创建的子进程才会进入该 PID namespace。
-	 */
-	if (syscall(__NR_setns, target_fd, CLONE_NEWPID) < 0) {
-		fprintf(stderr, "setns(%s) 失败：%s\n", target_path, strerror(errno));
-		close(target_fd);
-		close(*self_fd);
-		*self_fd = -1;
-		return -1;
-	}
-	close(target_fd);
-	*entered = true;
-
-	printf("已经设置后续子进程使用目标 Java 的 PID namespace\n");
-	return 0;
-}
-
-/* 验证 fork 出来的子进程确实继承了目标 PID namespace。 */
-static int verify_child_pid_namespace(
-	const struct namespace_identity *target_identity)
-{
-	struct namespace_identity child_identity;
-	pid_t child_pid;
-	int status;
-
-	/* PID namespace 只对后续创建的子进程生效，因此通过 fork 验证。 */
-	child_pid = fork();
-	if (child_pid < 0) {
-		fprintf(stderr, "fork() 验证 PID namespace 失败：%s\n",
-			strerror(errno));
-		return -1;
-	}
-	if (child_pid == 0) {
-		/* 子进程读取自己的 PID namespace 身份并返回比较结果。 */
-		if (read_namespace_identity("/proc/self/ns/pid", &child_identity) < 0)
-			_exit(2);
-		_exit(namespace_identity_equal(&child_identity, target_identity) ? 0 :
-		       1);
-	}
-
-	/* 父进程等待验证子进程结束，避免留下测试僵尸进程。 */
-	if (waitpid(child_pid, &status, 0) < 0) {
-		fprintf(stderr, "waitpid() 验证 PID namespace 失败：%s\n",
-			strerror(errno));
-		return -1;
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		fprintf(stderr, "后续子进程没有进入目标 PID namespace\n");
-		return -1;
-	}
-	printf("验证成功：后续子进程进入了目标 PID namespace\n");
-	return 0;
-}
-
-/* 恢复进入目标 mount namespace 之前的 namespace。 */
-static int exit_mount_namespace(int self_fd, bool entered)
-{
-	int result;
-
-	/* 如果原本就在同一个 namespace，则不需要恢复。 */
-	if (!entered)
-		return 0;
-
-	/* 使用进入前保存的 namespace 文件描述符恢复。 */
-	result = syscall(__NR_setns, self_fd, CLONE_NEWNS);
-	if (result < 0)
-		fprintf(stderr, "恢复原 mount namespace 失败：%s\n", strerror(errno));
-	close(self_fd);
-	return result;
-}
-
-/* 恢复后续子进程使用进入目标 PID namespace 之前的 namespace。 */
-static int exit_pid_namespace(int self_fd, bool entered)
-{
-	int result;
-
-	/* 如果目标 PID namespace 与当前相同，则没有需要恢复的设置。 */
-	if (!entered)
-		return 0;
-
-	/* setns(CLONE_NEWPID) 恢复的是后续子进程的 namespace 选择。 */
-	result = syscall(__NR_setns, self_fd, CLONE_NEWPID);
-	if (result < 0)
-		fprintf(stderr, "恢复后续子进程的 PID namespace 失败：%s\n",
-			strerror(errno));
-	close(self_fd);
-	return result;
-}
-
-/* 验证恢复后新创建的子进程已经回到原 PID/mount namespace。 */
-static int verify_future_child_namespaces(
-	const struct namespace_identity *original_pid,
-	const struct namespace_identity *original_mount)
-{
-	struct namespace_identity child_pid_identity;
-	struct namespace_identity child_mount_identity;
-	pid_t child_pid;
-	int status;
-
-	/* 再创建一个子进程，验证恢复操作对后续 fork() 生效。 */
-	child_pid = fork();
-	if (child_pid < 0) {
-		fprintf(stderr, "fork() 验证恢复后的 PID namespace 失败：%s\n",
-			strerror(errno));
-		return -1;
-	}
-	if (child_pid == 0) {
-		/* 子进程读取自己的 PID/mount namespace 并与原 namespace 比较。 */
-		if (read_namespace_identity("/proc/self/ns/pid", &child_pid_identity) < 0 ||
-		    read_namespace_identity("/proc/self/ns/mnt", &child_mount_identity) < 0)
-			_exit(2);
-		_exit(namespace_identity_equal(&child_pid_identity, original_pid) &&
-		       namespace_identity_equal(&child_mount_identity, original_mount) ? 0 :
-		       1);
-	}
-
-	/* 等待验证子进程，避免测试程序结束后留下僵尸。 */
-	if (waitpid(child_pid, &status, 0) < 0) {
-		fprintf(stderr, "waitpid() 验证恢复后的 PID namespace 失败：%s\n",
-			strerror(errno));
-		return -1;
-	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		fprintf(stderr,
-			"验证失败：恢复后新子进程没有回到原 PID/mount namespace\n");
-		return -1;
-	}
-	printf("验证成功：恢复后新子进程回到了原 PID/mount namespace\n");
-	return 0;
-}
-
-/* 验证测试程序已经恢复到进入 namespace 前的 mount/PID namespace。 */
-static int verify_namespace_restored(
-	const struct namespace_identity *original_mount,
-	const struct namespace_identity *original_pid)
-{
-	struct namespace_identity current_mount;
-	struct namespace_identity current_pid;
-
-	/* 检查当前 mount namespace 是否恢复为进入前保存的 namespace。 */
-	if (read_namespace_identity("/proc/self/ns/mnt", &current_mount) < 0)
-		return -1;
-	if (!namespace_identity_equal(&current_mount, original_mount)) {
-		fprintf(stderr, "验证失败：当前 mount namespace 没有恢复\n");
-		return -1;
-	}
-	printf("验证成功：已经退出目标 mount namespace\n");
-
-	/*
-	 * setns(CLONE_NEWPID) 不改变当前进程的 PID namespace，只影响后续子进程；
-	 * 当前进程仍在 original_pid，但需要单独验证后续子进程的 namespace 设置。
-	 */
-	if (read_namespace_identity("/proc/self/ns/pid", &current_pid) < 0)
-		return -1;
-	if (!namespace_identity_equal(&current_pid, original_pid)) {
-		fprintf(stderr, "验证失败：当前 PID namespace 发生了意外变化\n");
-		return -1;
-	}
-	printf("验证成功：当前进程仍处于原 PID namespace\n");
-	if (verify_future_child_namespaces(original_pid, original_mount) < 0)
-		return -1;
-	return 0;
-}
-
-/* 为 shell 命令中的 Java 路径添加单引号，避免路径字符被 shell 解释。 */
-static int shell_quote(const char *value, char *quoted, size_t quoted_size)
-{
-	size_t used = 0;
-	size_t index;
-
-	/* 预留首尾单引号和字符串结尾的 NUL 字符。 */
-	if (value == NULL || quoted == NULL || quoted_size < 3)
-		return -1;
-	quoted[used++] = '\'';
-
-	/* 逐字节复制路径，并转义路径中可能出现的单引号。 */
-	for (index = 0; value[index] != '\0'; index++) {
-		if (value[index] == '\'') {
-			if (used + 4 >= quoted_size)
-				return -1;
-			memcpy(quoted + used, "'\\''", 4);
-			used += 4;
-		} else {
-			if (used + 1 >= quoted_size)
-				return -1;
-			quoted[used++] = value[index];
-		}
-	}
-
-	/* 添加结束单引号和字符串结尾。 */
-	if (used + 2 > quoted_size)
-		return -1;
-	quoted[used++] = '\'';
-	quoted[used] = '\0';
-	return 0;
-}
-
-/* 从目标进程的 NUL 分隔 environ 中读取指定环境变量。 */
+/* 从目标进程 NUL 分隔的 environ 中读取一个变量。 */
 static int read_target_env_value(pid_t pid, const char *name, char *value,
-				 size_t value_size)
+					 size_t value_size)
 {
 	char proc_path[64];
 	char *entry = NULL;
@@ -447,16 +116,11 @@ static int read_target_env_value(pid_t pid, const char *name, char *value,
 	FILE *file;
 	int found = 0;
 
-	/* 检查参数，避免无效缓冲区导致内存访问错误。 */
 	if (name == NULL || value == NULL || value_size == 0)
 		return -1;
-
-	/* 构造目标进程的环境文件路径。 */
 	if (snprintf(proc_path, sizeof(proc_path), "/proc/%d/environ", pid) >=
 	    (int)sizeof(proc_path))
 		return -1;
-
-	/* 以二进制方式打开，保留环境变量之间的 NUL 分隔符。 */
 	file = fopen(proc_path, "rb");
 	if (file == NULL) {
 		fprintf(stderr, "打开 %s 失败：%s\n", proc_path, strerror(errno));
@@ -464,15 +128,11 @@ static int read_target_env_value(pid_t pid, const char *name, char *value,
 	}
 
 	name_len = strlen(name);
-	/* getdelim() 使用 NUL 作为分隔符，逐条读取环境变量。 */
 	while ((entry_len = getdelim(&entry, &entry_size, '\0', file)) >= 0) {
-		/* 环境变量必须以 NAME= 开头，避免误匹配同名前缀变量。 */
 		if ((size_t)entry_len <= name_len ||
 		    strncmp(entry, name, name_len) != 0 || entry[name_len] != '=')
 			continue;
-
-		/* 去除末尾的 NUL，再复制变量值。 */
-		entry_len -= 1;
+		entry_len--;
 		if ((size_t)entry_len <= name_len + 1)
 			break;
 		if ((size_t)entry_len - name_len - 1 >= value_size) {
@@ -485,8 +145,6 @@ static int read_target_env_value(pid_t pid, const char *name, char *value,
 		found = 1;
 		break;
 	}
-
-	/* 记录读取错误，但允许没有找到变量的正常情况。 */
 	if (ferror(file))
 		found = -1;
 	free(entry);
@@ -494,21 +152,18 @@ static int read_target_env_value(pid_t pid, const char *name, char *value,
 	return found;
 }
 
-/* 根据目标 Java 的 bin/java 路径构造常见的 jli 动态库目录。 */
+/* 根据目标 Java 的 bin/java 路径构造 libjli.so 目录。 */
 static int build_java_jli_path(const char *exe_path, char *path,
-			       size_t path_size)
+				       size_t path_size)
 {
 	char runtime_root[PATH_MAX];
 	char *slash;
 	int length;
 
-	/* 检查 Java 路径和输出缓冲区。 */
 	if (exe_path == NULL || path == NULL || path_size == 0)
 		return -1;
 	if (strlen(exe_path) >= sizeof(runtime_root))
 		return -1;
-
-	/* 复制路径，随后从 /bin/java 反推出 JRE 根目录。 */
 	strcpy(runtime_root, exe_path);
 	slash = strrchr(runtime_root, '/');
 	if (slash == NULL || strcmp(slash + 1, "java") != 0)
@@ -518,131 +173,362 @@ static int build_java_jli_path(const char *exe_path, char *path,
 	if (slash == NULL || strcmp(slash + 1, "bin") != 0)
 		return -1;
 	*slash = '\0';
-
-	/* 当前测试目标为 amd64，jli 目录是 Java 启动器的必要搜索路径。 */
 	length = snprintf(path, path_size, "%s/lib/amd64/jli", runtime_root);
 	if (length < 0 || (size_t)length >= path_size)
 		return -1;
 	return 0;
 }
 
-/* 复制目标 Java 的必要运行时环境，并补充 jli 动态库目录。 */
-static int apply_target_environment(pid_t pid, const char *exe_path)
+/* 读取目标环境并构造 execve() 使用的显式环境白名单。 */
+static int build_target_environment(pid_t pid, const char *exe_path,
+					 char *envp[], int envp_size,
+					 char *library_env, size_t library_env_size,
+					 char *java_home_env, size_t java_home_env_size,
+					 char *path_env, size_t path_env_size,
+					 char *home_env, size_t home_env_size,
+					 char *lang_env, size_t lang_env_size)
 {
-	static const char *const names[] = {
-		"LD_LIBRARY_PATH",
-		"JAVA_HOME",
-		"PATH",
-		"HOME",
-		"LANG",
-	};
-	char value[PATH_MAX * 2];
+	char library_path[PATH_MAX * 2] = {};
+	char java_home[PATH_MAX] = {};
+	char target_path[PATH_MAX * 2] = {};
+	char home[PATH_MAX] = {};
+	char lang[PATH_MAX] = {};
 	char jli_path[PATH_MAX];
-	char library_path[PATH_MAX * 3];
-	int result;
-	int index;
+	int value_ret;
+	int count = 0;
 
-	/* 只复制执行版本检查所需的变量，不复制 LD_PRELOAD 等危险变量。 */
-	for (index = 0; index < (int)(sizeof(names) / sizeof(names[0])); index++) {
-		result = read_target_env_value(pid, names[index], value,
-					       sizeof(value));
-		if (result < 0)
-			return -1;
-		if (result == 0)
-			continue;
-		if (setenv(names[index], value, 1) < 0) {
-			fprintf(stderr, "设置环境变量 %s 失败：%s\n", names[index],
-				strerror(errno));
-			return -1;
-		}
-		printf("复制目标环境变量：%s=%s\n", names[index], value);
-	}
-
-	/* 根据目标 Java 路径补充 jli 目录，避免启动器找不到 libjli.so。 */
+	if (envp == NULL || envp_size < 2 || library_env == NULL ||
+	    java_home_env == NULL || path_env == NULL || home_env == NULL ||
+	    lang_env == NULL)
+		return -1;
+	value_ret = read_target_env_value(pid, "LD_LIBRARY_PATH", library_path,
+						  sizeof(library_path));
+	if (value_ret < 0)
+		return -1;
+	value_ret = read_target_env_value(pid, "JAVA_HOME", java_home,
+						  sizeof(java_home));
+	if (value_ret < 0)
+		return -1;
+	value_ret = read_target_env_value(pid, "PATH", target_path,
+						  sizeof(target_path));
+	if (value_ret < 0)
+		return -1;
+	value_ret = read_target_env_value(pid, "HOME", home, sizeof(home));
+	if (value_ret < 0)
+		return -1;
+	value_ret = read_target_env_value(pid, "LANG", lang, sizeof(lang));
+	if (value_ret < 0)
+		return -1;
 	if (build_java_jli_path(exe_path, jli_path, sizeof(jli_path)) < 0)
 		return -1;
-	if (getenv("LD_LIBRARY_PATH") == NULL ||
-	    getenv("LD_LIBRARY_PATH")[0] == '\0') {
-		if (setenv("LD_LIBRARY_PATH", jli_path, 1) < 0)
+	if (library_path[0] == '\0') {
+		if (snprintf(library_path, sizeof(library_path), "%s", jli_path) >=
+		    (int)sizeof(library_path))
 			return -1;
 	} else {
-		result = snprintf(library_path, sizeof(library_path), "%s:%s",
-				  jli_path, getenv("LD_LIBRARY_PATH"));
-		if (result < 0 || (size_t)result >= sizeof(library_path))
-			return -1;
-		if (setenv("LD_LIBRARY_PATH", library_path, 1) < 0)
+		char original_library[sizeof(library_path)];
+		strcpy(original_library, library_path);
+		if (snprintf(library_path, sizeof(library_path), "%s:%s", jli_path,
+			     original_library) >= (int)sizeof(library_path))
 			return -1;
 	}
-	printf("最终 LD_LIBRARY_PATH=%s\n", getenv("LD_LIBRARY_PATH"));
+	if (target_path[0] == '\0')
+		strcpy(target_path, "/usr/bin:/bin");
+	if (home[0] == '\0')
+		strcpy(home, "/tmp");
+	if (snprintf(library_env, library_env_size, "LD_LIBRARY_PATH=%s",
+		     library_path) >= (int)library_env_size ||
+	    snprintf(java_home_env, java_home_env_size, "JAVA_HOME=%s", java_home) >=
+		    (int)java_home_env_size ||
+	    snprintf(path_env, path_env_size, "PATH=%s", target_path) >=
+		    (int)path_env_size ||
+	    snprintf(home_env, home_env_size, "HOME=%s", home) >=
+		    (int)home_env_size ||
+	    snprintf(lang_env, lang_env_size, "LANG=%s", lang) >=
+		    (int)lang_env_size)
+		return -1;
+	envp[count++] = library_env;
+	if (java_home[0] != '\0')
+		envp[count++] = java_home_env;
+	envp[count++] = path_env;
+	envp[count++] = home_env;
+	if (lang[0] != '\0')
+		envp[count++] = lang_env;
+	if (count + 1 > envp_size)
+		return -1;
+	envp[count] = NULL;
 	return 0;
 }
 
-/* 通过 popen() 执行目标 Java 的 -version，并输出完整结果。 */
-static int run_java_version(const char *exe_path)
+/* 打开目标 namespace；如果已经相同，则通过 same_namespace 返回 true。 */
+static int open_target_namespace(pid_t pid, const char *type,
+					 bool *same_namespace)
 {
-	char quoted_exe[PATH_MAX * 4 + 8];
-	char command[PATH_MAX * 4 + 32];
-	char output[4096];
-	FILE *pipe;
-	int status;
+	char target_path[64];
+	char self_path[64];
+	struct stat target_stat;
+	struct stat self_stat;
+	int fd;
 
-	/* 对目标 Java 路径进行 shell 安全转义。 */
-	if (shell_quote(exe_path, quoted_exe, sizeof(quoted_exe)) < 0)
+	if (type == NULL || same_namespace == NULL)
 		return -1;
-
-	/* 保留 stderr，因为 Java -version 通常把版本输出到 stderr。 */
-	if (snprintf(command, sizeof(command), "%s -version 2>&1", quoted_exe) >=
-	    (int)sizeof(command))
+	*same_namespace = false;
+	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/%s", pid,
+		     type) >= (int)sizeof(target_path) ||
+	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/%s", type) >=
+		    (int)sizeof(self_path))
 		return -1;
-
-	printf("执行命令：%s\n", command);
-	pipe = popen(command, "r");
-	if (pipe == NULL) {
-		fprintf(stderr, "popen() 失败：%s\n", strerror(errno));
+	if (stat(target_path, &target_stat) < 0 ||
+	    stat(self_path, &self_stat) < 0)
 		return -1;
-	}
-
-	/* 读取并打印 Java -version 输出。 */
-	while (fgets(output, sizeof(output), pipe) != NULL)
-		fputs(output, stdout);
-
-	/* 等待 shell 和 Java 子进程结束，获取命令退出状态。 */
-	status = pclose(pipe);
-	if (status < 0) {
-		fprintf(stderr, "pclose() 失败：%s\n", strerror(errno));
+	if (target_stat.st_dev == self_stat.st_dev &&
+	    target_stat.st_ino == self_stat.st_ino) {
+		*same_namespace = true;
 		return -1;
 	}
-
-	printf("pclose() 返回状态：%d\n", status);
-	return status;
+	fd = open(target_path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+	return fd;
 }
 
-/* 程序入口：读取 PID、切换 mount namespace、执行版本检查并恢复 namespace。 */
+/* 返回单调时钟毫秒值，用于父进程超时控制。 */
+static int64_t monotonic_milliseconds(void)
+{
+	struct timespec timespec_value;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &timespec_value) < 0)
+		return -1;
+	return (int64_t)timespec_value.tv_sec * 1000 +
+	       timespec_value.tv_nsec / 1000000;
+}
+
+/* runner 直接执行目标 Java 的绝对路径，不经过 shell 或 PATH 查找。 */
+static void run_java_version(const char *exe_path, char *const envp[],
+				     int output_fd)
+{
+	char *const argv[] = { (char *)exe_path, (char *)"-version", NULL };
+
+	if (dup2(output_fd, STDOUT_FILENO) < 0 ||
+	    dup2(output_fd, STDERR_FILENO) < 0)
+		_exit(125);
+	if (output_fd != STDOUT_FILENO && output_fd != STDERR_FILENO)
+		close(output_fd);
+	execve(exe_path, argv, envp);
+	_exit(127);
+}
+
+/* helper 进入目标 namespace，创建 runner，并等待 runner 结束。 */
+static void run_version_helper(const char *exe_path, char *const envp[],
+				       int pid_ns_fd, int mnt_ns_fd, int output_fd)
+{
+	pid_t runner_pid;
+	int status;
+
+	if (setpgid(0, 0) < 0)
+		_exit(124);
+#ifdef __NR_setns
+	if (pid_ns_fd >= 0 && syscall(__NR_setns, pid_ns_fd, CLONE_NEWPID) < 0)
+		_exit(124);
+	if (mnt_ns_fd >= 0 && syscall(__NR_setns, mnt_ns_fd, CLONE_NEWNS) < 0)
+		_exit(124);
+#else
+	(void)pid_ns_fd;
+	(void)mnt_ns_fd;
+	_exit(124);
+#endif
+	if (pid_ns_fd >= 0)
+		close(pid_ns_fd);
+	if (mnt_ns_fd >= 0)
+		close(mnt_ns_fd);
+	runner_pid = fork();
+	if (runner_pid < 0)
+		_exit(124);
+	if (runner_pid == 0)
+		run_java_version(exe_path, envp, output_fd);
+	close(output_fd);
+	while (waitpid(runner_pid, &status, 0) < 0) {
+		if (errno != EINTR)
+			_exit(124);
+	}
+	if (WIFEXITED(status))
+		_exit(WEXITSTATUS(status));
+	_exit(128 + WTERMSIG(status));
+}
+
+/* 非阻塞读取版本输出；超过缓冲区的尾部输出直接丢弃。 */
+static void drain_version_output(int output_fd, char *output,
+					 size_t output_size, size_t *used, bool *eof)
+{
+	char discard[1024];
+	char *buffer;
+	size_t remain;
+	ssize_t length;
+
+	while (!*eof) {
+		buffer = *used < output_size - 1 ? output + *used : discard;
+		remain = *used < output_size - 1 ? output_size - 1 - *used :
+				 sizeof(discard);
+		length = read(output_fd, buffer, remain);
+		if (length > 0) {
+			if (buffer != discard)
+				*used += (size_t)length;
+			continue;
+		}
+		if (length == 0) {
+			*eof = true;
+			break;
+		}
+		if (errno == EINTR)
+			continue;
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			break;
+		*eof = true;
+	}
+	output[*used < output_size ? *used : output_size - 1] = '\0';
+}
+
+/* 终止并回收 helper 及其进程组中的 runner。 */
+static void kill_version_helper(pid_t helper_pid, int *status)
+{
+	if (kill(-helper_pid, SIGKILL) < 0)
+		kill(helper_pid, SIGKILL);
+	while (waitpid(helper_pid, status, 0) < 0 && errno == EINTR)
+		;
+}
+
+/* 在 5 秒上限内收集 helper 输出并等待 helper 退出。 */
+static int wait_version_helper(pid_t helper_pid, int output_fd,
+				       char *output, size_t output_size)
+{
+	struct pollfd poll_fd = { .fd = output_fd, .events = POLLIN };
+	int flags;
+	int status;
+	int poll_timeout;
+	int64_t deadline;
+	int64_t now;
+	pid_t wait_result;
+	size_t used = 0;
+	bool eof = false;
+	bool exited = false;
+
+	flags = fcntl(output_fd, F_GETFL, 0);
+	if (flags < 0 || fcntl(output_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+		kill_version_helper(helper_pid, &status);
+		return -1;
+	}
+	deadline = monotonic_milliseconds();
+	if (deadline < 0) {
+		kill_version_helper(helper_pid, &status);
+		return -1;
+	}
+	deadline += JAVA_VERSION_TIMEOUT_MS;
+	while (!exited || !eof) {
+		drain_version_output(output_fd, output, output_size, &used, &eof);
+		if (!exited) {
+			wait_result = waitpid(helper_pid, &status, WNOHANG);
+			if (wait_result == helper_pid)
+				exited = true;
+			else if (wait_result < 0 && errno != EINTR) {
+				kill_version_helper(helper_pid, &status);
+				close(output_fd);
+				return -1;
+			}
+		}
+		if (exited && eof)
+			break;
+		now = monotonic_milliseconds();
+		if (now < 0 || now >= deadline) {
+			kill_version_helper(helper_pid, &status);
+			close(output_fd);
+			return -1;
+		}
+		poll_timeout = (int)(deadline - now);
+		if (poll_timeout > 100)
+			poll_timeout = 100;
+		if (poll(&poll_fd, 1, poll_timeout) < 0 && errno != EINTR) {
+			kill_version_helper(helper_pid, &status);
+			close(output_fd);
+			return -1;
+		}
+	}
+	close(output_fd);
+	if (!exited || !WIFEXITED(status))
+		return -1;
+	return WEXITSTATUS(status);
+}
+
+/* 验证主进程和后续子进程仍处于进入 helper 前的 namespace。 */
+static int verify_parent_namespace(
+	const struct namespace_identity *original_pid,
+	const struct namespace_identity *original_mount)
+{
+	struct namespace_identity current_pid;
+	struct namespace_identity current_mount;
+	struct namespace_identity child_pid;
+	struct namespace_identity child_mount;
+	pid_t child_process;
+	int status;
+
+	if (read_namespace_identity("/proc/self/ns/pid", &current_pid) < 0 ||
+	    read_namespace_identity("/proc/self/ns/mnt", &current_mount) < 0 ||
+	    !namespace_identity_equal(&current_pid, original_pid) ||
+	    !namespace_identity_equal(&current_mount, original_mount)) {
+		fprintf(stderr, "验证失败：主进程 namespace 发生变化\n");
+		return -1;
+	}
+	printf("验证成功：主进程仍处于原 PID/mount namespace\n");
+	child_process = fork();
+	if (child_process < 0)
+		return -1;
+	if (child_process == 0) {
+		if (read_namespace_identity("/proc/self/ns/pid", &child_pid) < 0 ||
+		    read_namespace_identity("/proc/self/ns/mnt", &child_mount) < 0)
+			_exit(2);
+		_exit(namespace_identity_equal(&child_pid, original_pid) &&
+		       namespace_identity_equal(&child_mount, original_mount) ? 0 : 1);
+	}
+	while (waitpid(child_process, &status, 0) < 0) {
+		if (errno != EINTR)
+			return -1;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fprintf(stderr, "验证失败：后续子进程 namespace 发生变化\n");
+		return -1;
+	}
+	printf("验证成功：后续子进程回到原 PID/mount namespace\n");
+	return 0;
+}
+
+/* 程序入口：读取目标信息，启动 helper，收集版本并验证主进程 namespace。 */
 int main(int argc, char **argv)
 {
 	char exe_path[PATH_MAX];
+	char library_env[PATH_MAX * 2 + 32];
+	char java_home_env[PATH_MAX + 16];
+	char path_env[PATH_MAX * 2 + 8];
+	char home_env[PATH_MAX + 8];
+	char lang_env[PATH_MAX + 8];
+	char *envp[6] = {};
+	char output[JAVA_VERSION_OUTPUT_SIZE] = {};
 	char *end;
 	long pid_value;
 	pid_t pid;
-	int self_fd = -1;
-	bool entered = false;
-	int pid_self_fd = -1;
-	bool pid_entered = false;
-	int command_status;
-	int restore_status;
-	int pid_restore_status;
-	int verify_status;
-	struct namespace_identity original_mount;
+	pid_t helper_pid;
+	int pid_ns_fd = -1;
+	int mnt_ns_fd = -1;
+	int pipe_fds[2] = { -1, -1 };
+	int command_status = -1;
+	int flags;
+	bool same_pid_ns = false;
+	bool same_mnt_ns = false;
 	struct namespace_identity original_pid;
-	struct namespace_identity target_pid;
+	struct namespace_identity original_mount;
 
-	/* 检查命令行参数数量。 */
 	if (argc != 2) {
 		fprintf(stderr, "用法：%s <java-pid>\n", argv[0]);
 		return EXIT_FAILURE;
 	}
-
-	/* 严格解析 PID，拒绝空字符串、非数字和超出 pid_t 范围的参数。 */
 	errno = 0;
 	pid_value = strtol(argv[1], &end, 10);
 	if (errno != 0 || *argv[1] == '\0' || *end != '\0' || pid_value <= 0 ||
@@ -651,69 +537,68 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 	pid = (pid_t)pid_value;
-
-	/* 在进入任何目标 namespace 前保存当前 mount/PID namespace 身份。 */
-	if (read_namespace_identity("/proc/self/ns/mnt", &original_mount) < 0 ||
-	    read_namespace_identity("/proc/self/ns/pid", &original_pid) < 0)
-		return EXIT_FAILURE;
-
-	/* 保存目标 PID namespace 身份，用于验证后续子进程确实进入目标空间。 */
-	{
-		char target_pid_path[64];
-		if (snprintf(target_pid_path, sizeof(target_pid_path),
-			     "/proc/%d/ns/pid", pid) >= (int)sizeof(target_pid_path) ||
-		    read_namespace_identity(target_pid_path, &target_pid) < 0)
-			return EXIT_FAILURE;
-	}
-
-	/* 在切换 namespace 前读取目标 Java 的绝对路径。 */
-	if (read_java_exe_path(pid, exe_path, sizeof(exe_path)) < 0)
+	if (read_namespace_identity("/proc/self/ns/pid", &original_pid) < 0 ||
+	    read_namespace_identity("/proc/self/ns/mnt", &original_mount) < 0 ||
+	    read_java_exe_path(pid, exe_path, sizeof(exe_path)) < 0)
 		return EXIT_FAILURE;
 	printf("目标 Java 绝对路径：%s\n", exe_path);
-
-	/* 在执行 popen() 前复制目标 Java 的运行时环境。 */
-	if (apply_target_environment(pid, exe_path) < 0)
+	if (build_target_environment(pid, exe_path, envp, 6, library_env,
+					     sizeof(library_env), java_home_env,
+					     sizeof(java_home_env), path_env, sizeof(path_env),
+					     home_env, sizeof(home_env), lang_env,
+					     sizeof(lang_env)) < 0)
 		return EXIT_FAILURE;
 
-	/* 设置 popen() 子进程使用目标 Java 的 PID namespace。 */
-	if (enter_pid_namespace(pid, &pid_self_fd, &pid_entered) < 0)
+	pid_ns_fd = open_target_namespace(pid, "pid", &same_pid_ns);
+	if (pid_ns_fd < 0 && !same_pid_ns)
 		return EXIT_FAILURE;
-	if (verify_child_pid_namespace(&target_pid) < 0) {
-		exit_pid_namespace(pid_self_fd, pid_entered);
-		return EXIT_FAILURE;
+	mnt_ns_fd = open_target_namespace(pid, "mnt", &same_mnt_ns);
+	if (mnt_ns_fd < 0 && !same_mnt_ns)
+		goto cleanup;
+	printf("版本 helper namespace：PID=%s MNT=%s\n",
+	       same_pid_ns ? "same" : "target",
+	       same_mnt_ns ? "same" : "target");
+	if (pipe(pipe_fds) < 0)
+		goto cleanup;
+	flags = fcntl(pipe_fds[0], F_GETFL, 0);
+	if (flags < 0 || fcntl(pipe_fds[0], F_SETFL, flags | O_NONBLOCK) < 0)
+		goto cleanup;
+	helper_pid = fork();
+	if (helper_pid < 0)
+		goto cleanup;
+	if (helper_pid == 0) {
+		close(pipe_fds[0]);
+		run_version_helper(exe_path, envp, pid_ns_fd, mnt_ns_fd,
+				   pipe_fds[1]);
+		_exit(124);
 	}
-
-	/* 进入目标 Java 的 mount namespace。 */
-	if (enter_mount_namespace(pid, &self_fd, &entered) < 0) {
-		exit_pid_namespace(pid_self_fd, pid_entered);
-		return EXIT_FAILURE;
+	close(pipe_fds[1]);
+	pipe_fds[1] = -1;
+	setpgid(helper_pid, helper_pid);
+	command_status = wait_version_helper(helper_pid, pipe_fds[0], output,
+					     sizeof(output));
+	pipe_fds[0] = -1;
+	if (command_status != 0) {
+		fprintf(stderr, "Java -version 执行失败或超过 %d 秒\n",
+			JAVA_VERSION_TIMEOUT_MS / 1000);
+		command_status = -1;
+		goto cleanup;
 	}
+	printf("Java -version 输出：\n%s", output);
+	if (verify_parent_namespace(&original_pid, &original_mount) < 0) {
+		command_status = -1;
+		goto cleanup;
+	}
+	printf("验证成功：helper 退出后主进程未进入目标 namespace\n");
 
-	/* 在目标 mount namespace 中执行 java -version。 */
-	command_status = run_java_version(exe_path);
-
-	/* 无论 popen() 是否成功，都尝试恢复原 mount namespace。 */
-	restore_status = exit_mount_namespace(self_fd, entered);
-	if (restore_status < 0)
-		goto restore_pid_namespace;
-
-	/* 恢复后续子进程的 PID namespace，避免影响测试程序之后的 fork/popen。 */
-	pid_restore_status = exit_pid_namespace(pid_self_fd, pid_entered);
-	if (pid_restore_status < 0)
-		return EXIT_FAILURE;
-
-	/* 在程序最后核对 mount namespace 已恢复，且 PID namespace 没有泄漏。 */
-	verify_status = verify_namespace_restored(&original_mount, &original_pid);
-	if (verify_status < 0)
-		return EXIT_FAILURE;
-
-	/* 返回 Java -version 的状态，便于脚本判断测试结果。 */
-	if (command_status < 0)
-		return EXIT_FAILURE;
-	return WIFEXITED(command_status) ? WEXITSTATUS(command_status) : EXIT_FAILURE;
-
-restore_pid_namespace:
-	/* mount namespace 恢复失败时仍要尝试恢复后续子进程的 PID namespace。 */
-	exit_pid_namespace(pid_self_fd, pid_entered);
-	return EXIT_FAILURE;
+cleanup:
+	if (pipe_fds[0] >= 0)
+		close(pipe_fds[0]);
+	if (pipe_fds[1] >= 0)
+		close(pipe_fds[1]);
+	if (pid_ns_fd >= 0)
+		close(pid_ns_fd);
+	if (mnt_ns_fd >= 0)
+		close(mnt_ns_fd);
+	return command_status < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/agent/src/ebpf/tools/java_mnt_ns_version.c
+++ b/agent/src/ebpf/tools/java_mnt_ns_version.c
@@ -1,0 +1,719 @@
+/*
+ * 工具功能：验证跨 namespace 获取目标 Java 版本的完整流程。
+ *
+ * 使用方式：
+ *     java_mnt_ns_version <java-pid>
+ *
+ * 执行流程：
+ * 1. 通过 /proc/<pid>/exe 读取目标 Java 的绝对路径。
+ * 2. 通过 /proc/<pid>/environ 读取目标 Java 的必要运行环境，重点处理
+ *    LD_LIBRARY_PATH、JAVA_HOME、PATH、HOME 和 LANG；同时根据 Java 路径
+ *    补充 jli 动态库目录，确保启动器可以找到 libjli.so。
+ * 3. 保存当前 PID namespace，设置后续子进程使用目标 Java 的 PID namespace。
+ *    setns(CLONE_NEWPID) 不会改变当前进程自身的 PID，只影响后续创建的子进程。
+ * 4. 保存当前 mount namespace，进入目标 Java 的 mount namespace。
+ * 5. 使用 popen() 创建子进程，执行目标 Java 的 -version，并输出版本信息。
+ * 6. 等待 Java 子进程结束，恢复当前 mount namespace 和后续子进程的 PID
+ *    namespace，避免测试工具影响后续创建的子进程。
+ * 7. 再创建验证子进程，确认 mount namespace 已恢复，且后续子进程已经回到
+ *    原 PID namespace。
+ *
+ * 注意事项：
+ * - 本工具只执行目标 Java 的 -version，不对目标 Java 执行 attach，也不修改
+ *   目标 Java 的运行状态。
+ * - /proc/<pid>/environ 使用 NUL 字符分隔环境变量，读取时必须按二进制记录解析。
+ * - PID namespace 的恢复针对的是后续子进程的 namespace 选择；当前工具进程
+ *   自身始终处于原 PID namespace，因此程序末尾还要验证新建子进程的 namespace。
+ * - 使用本工具需要能够读取目标进程的 /proc 信息并调用 setns()，通常需要 root
+ *   权限或相应的 CAP_SYS_ADMIN/CAP_SYS_PTRACE 能力。
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* 保存 namespace 文件的设备号和 inode，用于进入前后做身份比对。 */
+struct namespace_identity {
+	dev_t device;
+	ino_t inode;
+};
+
+/* 读取指定 namespace 文件的身份信息。 */
+static int read_namespace_identity(const char *path,
+				   struct namespace_identity *identity)
+{
+	struct stat status;
+
+	/* 检查参数，避免访问无效指针。 */
+	if (path == NULL || identity == NULL)
+		return -1;
+	if (stat(path, &status) < 0) {
+		fprintf(stderr, "stat %s 失败：%s\n", path, strerror(errno));
+		return -1;
+	}
+	identity->device = status.st_dev;
+	identity->inode = status.st_ino;
+	return 0;
+}
+
+/* 比较两个 namespace 文件是否指向同一个 namespace。 */
+static bool namespace_identity_equal(
+	const struct namespace_identity *left,
+	const struct namespace_identity *right)
+{
+	return left != NULL && right != NULL && left->device == right->device &&
+	       left->inode == right->inode;
+}
+
+/* 读取目标进程的 Java 可执行文件绝对路径。 */
+static int read_java_exe_path(pid_t pid, char *path, size_t path_size)
+{
+	char proc_path[64];
+	ssize_t length;
+	char *deleted;
+
+	/* 检查输出缓冲区，避免 readlink() 写入越界。 */
+	if (path == NULL || path_size < 2)
+		return -1;
+
+	/* 构造目标进程的 exe proc 路径。 */
+	if (snprintf(proc_path, sizeof(proc_path), "/proc/%d/exe", pid) >=
+	    (int)sizeof(proc_path))
+		return -1;
+
+	/* readlink() 不会自动补充字符串结尾的 NUL 字符。 */
+	length = readlink(proc_path, path, path_size - 1);
+	if (length < 0) {
+		fprintf(stderr, "读取 %s 失败：%s\n", proc_path, strerror(errno));
+		return -1;
+	}
+	path[length] = '\0';
+
+	/* 进程退出过程中可能出现“ (deleted)”后缀，去掉该后缀再执行。 */
+	deleted = strstr(path, " (deleted)");
+	if (deleted != NULL)
+		*deleted = '\0';
+
+	/* 目标 Java 路径必须是绝对路径。 */
+	if (path[0] != '/') {
+		fprintf(stderr, "目标 exe 路径不是绝对路径：%s\n", path);
+		return -1;
+	}
+
+	return 0;
+}
+
+/* 进入目标进程的 mount namespace，并保存当前 namespace 文件描述符。 */
+static int enter_mount_namespace(pid_t pid, int *self_fd, bool *entered)
+{
+	char target_path[64];
+	char self_path[64];
+	struct stat target_stat;
+	struct stat self_stat;
+	int target_fd;
+
+	/* 初始化输出参数，确保所有错误路径都可以安全恢复。 */
+	if (self_fd == NULL || entered == NULL)
+		return -1;
+	*self_fd = -1;
+	*entered = false;
+
+	/* 构造目标和当前进程的 mount namespace 路径。 */
+	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/mnt", pid) >=
+	    (int)sizeof(target_path) ||
+	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/mnt") >=
+	    (int)sizeof(self_path))
+		return -1;
+
+	/* 先比较 namespace 标识，避免已经在同一 namespace 时重复切换。 */
+	if (stat(target_path, &target_stat) < 0) {
+		fprintf(stderr, "stat %s 失败：%s\n", target_path, strerror(errno));
+		return -1;
+	}
+	if (stat(self_path, &self_stat) < 0) {
+		fprintf(stderr, "stat %s 失败：%s\n", self_path, strerror(errno));
+		return -1;
+	}
+	if (target_stat.st_dev == self_stat.st_dev &&
+	    target_stat.st_ino == self_stat.st_ino) {
+		printf("当前进程和目标 Java 已经处于同一个 mount namespace\n");
+		return 0;
+	}
+
+	/* 打开目标 namespace，供 setns() 使用。 */
+	target_fd = open(target_path, O_RDONLY | O_CLOEXEC);
+	if (target_fd < 0) {
+		fprintf(stderr, "打开 %s 失败：%s\n", target_path, strerror(errno));
+		return -1;
+	}
+
+	/* 打开当前 namespace，后续使用它恢复 Agent/测试程序的 namespace。 */
+	*self_fd = open(self_path, O_RDONLY | O_CLOEXEC);
+	if (*self_fd < 0) {
+		fprintf(stderr, "打开 %s 失败：%s\n", self_path, strerror(errno));
+		close(target_fd);
+		return -1;
+	}
+
+	/* 仅切换 mount namespace，不切换 root 和当前工作目录。 */
+	if (syscall(__NR_setns, target_fd, CLONE_NEWNS) < 0) {
+		fprintf(stderr, "setns(%s) 失败：%s\n", target_path, strerror(errno));
+		close(target_fd);
+		close(*self_fd);
+		*self_fd = -1;
+		return -1;
+	}
+	close(target_fd);
+	*entered = true;
+
+	printf("已经进入目标 Java 的 mount namespace\n");
+	return 0;
+}
+
+/* 设置后续子进程使用目标进程的 PID namespace，并保存原 namespace。 */
+static int enter_pid_namespace(pid_t pid, int *self_fd, bool *entered)
+{
+	char target_path[64];
+	char self_path[64];
+	struct stat target_stat;
+	struct stat self_stat;
+	int target_fd;
+
+	/* 初始化恢复参数，确保失败路径不会误关闭无效 fd。 */
+	if (self_fd == NULL || entered == NULL)
+		return -1;
+	*self_fd = -1;
+	*entered = false;
+
+	/* 构造目标 PID namespace 文件路径。 */
+	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/pid", pid) >=
+	    (int)sizeof(target_path) ||
+	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/pid") >=
+	    (int)sizeof(self_path))
+		return -1;
+
+	/* 目标 PID namespace 不存在时直接报告错误。 */
+	if (stat(target_path, &target_stat) < 0) {
+		fprintf(stderr, "stat %s 失败：%s\n", target_path, strerror(errno));
+		return -1;
+	}
+
+	/* 当前程序已经处于同一 PID namespace 时无需再次调用 setns。 */
+	if (stat(self_path, &self_stat) < 0) {
+		fprintf(stderr, "stat /proc/self/ns/pid 失败：%s\n",
+			strerror(errno));
+		return -1;
+	}
+	if (target_stat.st_dev == self_stat.st_dev &&
+	    target_stat.st_ino == self_stat.st_ino) {
+		printf("当前进程和目标 Java 已经处于同一个 PID namespace\n");
+		return 0;
+	}
+
+	/* 打开目标 PID namespace 文件描述符。 */
+	target_fd = open(target_path, O_RDONLY | O_CLOEXEC);
+	if (target_fd < 0) {
+		fprintf(stderr, "打开 %s 失败：%s\n", target_path, strerror(errno));
+		return -1;
+	}
+
+	/* 保存原 PID namespace，供 popen() 完成后恢复后续子进程的 namespace。 */
+	*self_fd = open(self_path, O_RDONLY | O_CLOEXEC);
+	if (*self_fd < 0) {
+		fprintf(stderr, "打开 %s 失败：%s\n", self_path, strerror(errno));
+		close(target_fd);
+		return -1;
+	}
+
+	/*
+	 * 对 PID namespace 调用 setns() 后，当前进程的 PID 不会改变；
+	 * 后续 fork()/popen() 创建的子进程才会进入该 PID namespace。
+	 */
+	if (syscall(__NR_setns, target_fd, CLONE_NEWPID) < 0) {
+		fprintf(stderr, "setns(%s) 失败：%s\n", target_path, strerror(errno));
+		close(target_fd);
+		close(*self_fd);
+		*self_fd = -1;
+		return -1;
+	}
+	close(target_fd);
+	*entered = true;
+
+	printf("已经设置后续子进程使用目标 Java 的 PID namespace\n");
+	return 0;
+}
+
+/* 验证 fork 出来的子进程确实继承了目标 PID namespace。 */
+static int verify_child_pid_namespace(
+	const struct namespace_identity *target_identity)
+{
+	struct namespace_identity child_identity;
+	pid_t child_pid;
+	int status;
+
+	/* PID namespace 只对后续创建的子进程生效，因此通过 fork 验证。 */
+	child_pid = fork();
+	if (child_pid < 0) {
+		fprintf(stderr, "fork() 验证 PID namespace 失败：%s\n",
+			strerror(errno));
+		return -1;
+	}
+	if (child_pid == 0) {
+		/* 子进程读取自己的 PID namespace 身份并返回比较结果。 */
+		if (read_namespace_identity("/proc/self/ns/pid", &child_identity) < 0)
+			_exit(2);
+		_exit(namespace_identity_equal(&child_identity, target_identity) ? 0 :
+		       1);
+	}
+
+	/* 父进程等待验证子进程结束，避免留下测试僵尸进程。 */
+	if (waitpid(child_pid, &status, 0) < 0) {
+		fprintf(stderr, "waitpid() 验证 PID namespace 失败：%s\n",
+			strerror(errno));
+		return -1;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fprintf(stderr, "后续子进程没有进入目标 PID namespace\n");
+		return -1;
+	}
+	printf("验证成功：后续子进程进入了目标 PID namespace\n");
+	return 0;
+}
+
+/* 恢复进入目标 mount namespace 之前的 namespace。 */
+static int exit_mount_namespace(int self_fd, bool entered)
+{
+	int result;
+
+	/* 如果原本就在同一个 namespace，则不需要恢复。 */
+	if (!entered)
+		return 0;
+
+	/* 使用进入前保存的 namespace 文件描述符恢复。 */
+	result = syscall(__NR_setns, self_fd, CLONE_NEWNS);
+	if (result < 0)
+		fprintf(stderr, "恢复原 mount namespace 失败：%s\n", strerror(errno));
+	close(self_fd);
+	return result;
+}
+
+/* 恢复后续子进程使用进入目标 PID namespace 之前的 namespace。 */
+static int exit_pid_namespace(int self_fd, bool entered)
+{
+	int result;
+
+	/* 如果目标 PID namespace 与当前相同，则没有需要恢复的设置。 */
+	if (!entered)
+		return 0;
+
+	/* setns(CLONE_NEWPID) 恢复的是后续子进程的 namespace 选择。 */
+	result = syscall(__NR_setns, self_fd, CLONE_NEWPID);
+	if (result < 0)
+		fprintf(stderr, "恢复后续子进程的 PID namespace 失败：%s\n",
+			strerror(errno));
+	close(self_fd);
+	return result;
+}
+
+/* 验证恢复后新创建的子进程已经回到原 PID/mount namespace。 */
+static int verify_future_child_namespaces(
+	const struct namespace_identity *original_pid,
+	const struct namespace_identity *original_mount)
+{
+	struct namespace_identity child_pid_identity;
+	struct namespace_identity child_mount_identity;
+	pid_t child_pid;
+	int status;
+
+	/* 再创建一个子进程，验证恢复操作对后续 fork() 生效。 */
+	child_pid = fork();
+	if (child_pid < 0) {
+		fprintf(stderr, "fork() 验证恢复后的 PID namespace 失败：%s\n",
+			strerror(errno));
+		return -1;
+	}
+	if (child_pid == 0) {
+		/* 子进程读取自己的 PID/mount namespace 并与原 namespace 比较。 */
+		if (read_namespace_identity("/proc/self/ns/pid", &child_pid_identity) < 0 ||
+		    read_namespace_identity("/proc/self/ns/mnt", &child_mount_identity) < 0)
+			_exit(2);
+		_exit(namespace_identity_equal(&child_pid_identity, original_pid) &&
+		       namespace_identity_equal(&child_mount_identity, original_mount) ? 0 :
+		       1);
+	}
+
+	/* 等待验证子进程，避免测试程序结束后留下僵尸。 */
+	if (waitpid(child_pid, &status, 0) < 0) {
+		fprintf(stderr, "waitpid() 验证恢复后的 PID namespace 失败：%s\n",
+			strerror(errno));
+		return -1;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		fprintf(stderr,
+			"验证失败：恢复后新子进程没有回到原 PID/mount namespace\n");
+		return -1;
+	}
+	printf("验证成功：恢复后新子进程回到了原 PID/mount namespace\n");
+	return 0;
+}
+
+/* 验证测试程序已经恢复到进入 namespace 前的 mount/PID namespace。 */
+static int verify_namespace_restored(
+	const struct namespace_identity *original_mount,
+	const struct namespace_identity *original_pid)
+{
+	struct namespace_identity current_mount;
+	struct namespace_identity current_pid;
+
+	/* 检查当前 mount namespace 是否恢复为进入前保存的 namespace。 */
+	if (read_namespace_identity("/proc/self/ns/mnt", &current_mount) < 0)
+		return -1;
+	if (!namespace_identity_equal(&current_mount, original_mount)) {
+		fprintf(stderr, "验证失败：当前 mount namespace 没有恢复\n");
+		return -1;
+	}
+	printf("验证成功：已经退出目标 mount namespace\n");
+
+	/*
+	 * setns(CLONE_NEWPID) 不改变当前进程的 PID namespace，只影响后续子进程；
+	 * 当前进程仍在 original_pid，但需要单独验证后续子进程的 namespace 设置。
+	 */
+	if (read_namespace_identity("/proc/self/ns/pid", &current_pid) < 0)
+		return -1;
+	if (!namespace_identity_equal(&current_pid, original_pid)) {
+		fprintf(stderr, "验证失败：当前 PID namespace 发生了意外变化\n");
+		return -1;
+	}
+	printf("验证成功：当前进程仍处于原 PID namespace\n");
+	if (verify_future_child_namespaces(original_pid, original_mount) < 0)
+		return -1;
+	return 0;
+}
+
+/* 为 shell 命令中的 Java 路径添加单引号，避免路径字符被 shell 解释。 */
+static int shell_quote(const char *value, char *quoted, size_t quoted_size)
+{
+	size_t used = 0;
+	size_t index;
+
+	/* 预留首尾单引号和字符串结尾的 NUL 字符。 */
+	if (value == NULL || quoted == NULL || quoted_size < 3)
+		return -1;
+	quoted[used++] = '\'';
+
+	/* 逐字节复制路径，并转义路径中可能出现的单引号。 */
+	for (index = 0; value[index] != '\0'; index++) {
+		if (value[index] == '\'') {
+			if (used + 4 >= quoted_size)
+				return -1;
+			memcpy(quoted + used, "'\\''", 4);
+			used += 4;
+		} else {
+			if (used + 1 >= quoted_size)
+				return -1;
+			quoted[used++] = value[index];
+		}
+	}
+
+	/* 添加结束单引号和字符串结尾。 */
+	if (used + 2 > quoted_size)
+		return -1;
+	quoted[used++] = '\'';
+	quoted[used] = '\0';
+	return 0;
+}
+
+/* 从目标进程的 NUL 分隔 environ 中读取指定环境变量。 */
+static int read_target_env_value(pid_t pid, const char *name, char *value,
+				 size_t value_size)
+{
+	char proc_path[64];
+	char *entry = NULL;
+	size_t entry_size = 0;
+	size_t name_len;
+	ssize_t entry_len;
+	FILE *file;
+	int found = 0;
+
+	/* 检查参数，避免无效缓冲区导致内存访问错误。 */
+	if (name == NULL || value == NULL || value_size == 0)
+		return -1;
+
+	/* 构造目标进程的环境文件路径。 */
+	if (snprintf(proc_path, sizeof(proc_path), "/proc/%d/environ", pid) >=
+	    (int)sizeof(proc_path))
+		return -1;
+
+	/* 以二进制方式打开，保留环境变量之间的 NUL 分隔符。 */
+	file = fopen(proc_path, "rb");
+	if (file == NULL) {
+		fprintf(stderr, "打开 %s 失败：%s\n", proc_path, strerror(errno));
+		return -1;
+	}
+
+	name_len = strlen(name);
+	/* getdelim() 使用 NUL 作为分隔符，逐条读取环境变量。 */
+	while ((entry_len = getdelim(&entry, &entry_size, '\0', file)) >= 0) {
+		/* 环境变量必须以 NAME= 开头，避免误匹配同名前缀变量。 */
+		if ((size_t)entry_len <= name_len ||
+		    strncmp(entry, name, name_len) != 0 || entry[name_len] != '=')
+			continue;
+
+		/* 去除末尾的 NUL，再复制变量值。 */
+		entry_len -= 1;
+		if ((size_t)entry_len <= name_len + 1)
+			break;
+		if ((size_t)entry_len - name_len - 1 >= value_size) {
+			fprintf(stderr, "环境变量 %s 超出缓冲区\n", name);
+			break;
+		}
+		memcpy(value, entry + name_len + 1,
+		       (size_t)entry_len - name_len - 1);
+		value[(size_t)entry_len - name_len - 1] = '\0';
+		found = 1;
+		break;
+	}
+
+	/* 记录读取错误，但允许没有找到变量的正常情况。 */
+	if (ferror(file))
+		found = -1;
+	free(entry);
+	fclose(file);
+	return found;
+}
+
+/* 根据目标 Java 的 bin/java 路径构造常见的 jli 动态库目录。 */
+static int build_java_jli_path(const char *exe_path, char *path,
+			       size_t path_size)
+{
+	char runtime_root[PATH_MAX];
+	char *slash;
+	int length;
+
+	/* 检查 Java 路径和输出缓冲区。 */
+	if (exe_path == NULL || path == NULL || path_size == 0)
+		return -1;
+	if (strlen(exe_path) >= sizeof(runtime_root))
+		return -1;
+
+	/* 复制路径，随后从 /bin/java 反推出 JRE 根目录。 */
+	strcpy(runtime_root, exe_path);
+	slash = strrchr(runtime_root, '/');
+	if (slash == NULL || strcmp(slash + 1, "java") != 0)
+		return -1;
+	*slash = '\0';
+	slash = strrchr(runtime_root, '/');
+	if (slash == NULL || strcmp(slash + 1, "bin") != 0)
+		return -1;
+	*slash = '\0';
+
+	/* 当前测试目标为 amd64，jli 目录是 Java 启动器的必要搜索路径。 */
+	length = snprintf(path, path_size, "%s/lib/amd64/jli", runtime_root);
+	if (length < 0 || (size_t)length >= path_size)
+		return -1;
+	return 0;
+}
+
+/* 复制目标 Java 的必要运行时环境，并补充 jli 动态库目录。 */
+static int apply_target_environment(pid_t pid, const char *exe_path)
+{
+	static const char *const names[] = {
+		"LD_LIBRARY_PATH",
+		"JAVA_HOME",
+		"PATH",
+		"HOME",
+		"LANG",
+	};
+	char value[PATH_MAX * 2];
+	char jli_path[PATH_MAX];
+	char library_path[PATH_MAX * 3];
+	int result;
+	int index;
+
+	/* 只复制执行版本检查所需的变量，不复制 LD_PRELOAD 等危险变量。 */
+	for (index = 0; index < (int)(sizeof(names) / sizeof(names[0])); index++) {
+		result = read_target_env_value(pid, names[index], value,
+					       sizeof(value));
+		if (result < 0)
+			return -1;
+		if (result == 0)
+			continue;
+		if (setenv(names[index], value, 1) < 0) {
+			fprintf(stderr, "设置环境变量 %s 失败：%s\n", names[index],
+				strerror(errno));
+			return -1;
+		}
+		printf("复制目标环境变量：%s=%s\n", names[index], value);
+	}
+
+	/* 根据目标 Java 路径补充 jli 目录，避免启动器找不到 libjli.so。 */
+	if (build_java_jli_path(exe_path, jli_path, sizeof(jli_path)) < 0)
+		return -1;
+	if (getenv("LD_LIBRARY_PATH") == NULL ||
+	    getenv("LD_LIBRARY_PATH")[0] == '\0') {
+		if (setenv("LD_LIBRARY_PATH", jli_path, 1) < 0)
+			return -1;
+	} else {
+		result = snprintf(library_path, sizeof(library_path), "%s:%s",
+				  jli_path, getenv("LD_LIBRARY_PATH"));
+		if (result < 0 || (size_t)result >= sizeof(library_path))
+			return -1;
+		if (setenv("LD_LIBRARY_PATH", library_path, 1) < 0)
+			return -1;
+	}
+	printf("最终 LD_LIBRARY_PATH=%s\n", getenv("LD_LIBRARY_PATH"));
+	return 0;
+}
+
+/* 通过 popen() 执行目标 Java 的 -version，并输出完整结果。 */
+static int run_java_version(const char *exe_path)
+{
+	char quoted_exe[PATH_MAX * 4 + 8];
+	char command[PATH_MAX * 4 + 32];
+	char output[4096];
+	FILE *pipe;
+	int status;
+
+	/* 对目标 Java 路径进行 shell 安全转义。 */
+	if (shell_quote(exe_path, quoted_exe, sizeof(quoted_exe)) < 0)
+		return -1;
+
+	/* 保留 stderr，因为 Java -version 通常把版本输出到 stderr。 */
+	if (snprintf(command, sizeof(command), "%s -version 2>&1", quoted_exe) >=
+	    (int)sizeof(command))
+		return -1;
+
+	printf("执行命令：%s\n", command);
+	pipe = popen(command, "r");
+	if (pipe == NULL) {
+		fprintf(stderr, "popen() 失败：%s\n", strerror(errno));
+		return -1;
+	}
+
+	/* 读取并打印 Java -version 输出。 */
+	while (fgets(output, sizeof(output), pipe) != NULL)
+		fputs(output, stdout);
+
+	/* 等待 shell 和 Java 子进程结束，获取命令退出状态。 */
+	status = pclose(pipe);
+	if (status < 0) {
+		fprintf(stderr, "pclose() 失败：%s\n", strerror(errno));
+		return -1;
+	}
+
+	printf("pclose() 返回状态：%d\n", status);
+	return status;
+}
+
+/* 程序入口：读取 PID、切换 mount namespace、执行版本检查并恢复 namespace。 */
+int main(int argc, char **argv)
+{
+	char exe_path[PATH_MAX];
+	char *end;
+	long pid_value;
+	pid_t pid;
+	int self_fd = -1;
+	bool entered = false;
+	int pid_self_fd = -1;
+	bool pid_entered = false;
+	int command_status;
+	int restore_status;
+	int pid_restore_status;
+	int verify_status;
+	struct namespace_identity original_mount;
+	struct namespace_identity original_pid;
+	struct namespace_identity target_pid;
+
+	/* 检查命令行参数数量。 */
+	if (argc != 2) {
+		fprintf(stderr, "用法：%s <java-pid>\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	/* 严格解析 PID，拒绝空字符串、非数字和超出 pid_t 范围的参数。 */
+	errno = 0;
+	pid_value = strtol(argv[1], &end, 10);
+	if (errno != 0 || *argv[1] == '\0' || *end != '\0' || pid_value <= 0 ||
+	    pid_value > INT_MAX) {
+		fprintf(stderr, "无效 PID：%s\n", argv[1]);
+		return EXIT_FAILURE;
+	}
+	pid = (pid_t)pid_value;
+
+	/* 在进入任何目标 namespace 前保存当前 mount/PID namespace 身份。 */
+	if (read_namespace_identity("/proc/self/ns/mnt", &original_mount) < 0 ||
+	    read_namespace_identity("/proc/self/ns/pid", &original_pid) < 0)
+		return EXIT_FAILURE;
+
+	/* 保存目标 PID namespace 身份，用于验证后续子进程确实进入目标空间。 */
+	{
+		char target_pid_path[64];
+		if (snprintf(target_pid_path, sizeof(target_pid_path),
+			     "/proc/%d/ns/pid", pid) >= (int)sizeof(target_pid_path) ||
+		    read_namespace_identity(target_pid_path, &target_pid) < 0)
+			return EXIT_FAILURE;
+	}
+
+	/* 在切换 namespace 前读取目标 Java 的绝对路径。 */
+	if (read_java_exe_path(pid, exe_path, sizeof(exe_path)) < 0)
+		return EXIT_FAILURE;
+	printf("目标 Java 绝对路径：%s\n", exe_path);
+
+	/* 在执行 popen() 前复制目标 Java 的运行时环境。 */
+	if (apply_target_environment(pid, exe_path) < 0)
+		return EXIT_FAILURE;
+
+	/* 设置 popen() 子进程使用目标 Java 的 PID namespace。 */
+	if (enter_pid_namespace(pid, &pid_self_fd, &pid_entered) < 0)
+		return EXIT_FAILURE;
+	if (verify_child_pid_namespace(&target_pid) < 0) {
+		exit_pid_namespace(pid_self_fd, pid_entered);
+		return EXIT_FAILURE;
+	}
+
+	/* 进入目标 Java 的 mount namespace。 */
+	if (enter_mount_namespace(pid, &self_fd, &entered) < 0) {
+		exit_pid_namespace(pid_self_fd, pid_entered);
+		return EXIT_FAILURE;
+	}
+
+	/* 在目标 mount namespace 中执行 java -version。 */
+	command_status = run_java_version(exe_path);
+
+	/* 无论 popen() 是否成功，都尝试恢复原 mount namespace。 */
+	restore_status = exit_mount_namespace(self_fd, entered);
+	if (restore_status < 0)
+		goto restore_pid_namespace;
+
+	/* 恢复后续子进程的 PID namespace，避免影响测试程序之后的 fork/popen。 */
+	pid_restore_status = exit_pid_namespace(pid_self_fd, pid_entered);
+	if (pid_restore_status < 0)
+		return EXIT_FAILURE;
+
+	/* 在程序最后核对 mount namespace 已恢复，且 PID namespace 没有泄漏。 */
+	verify_status = verify_namespace_restored(&original_mount, &original_pid);
+	if (verify_status < 0)
+		return EXIT_FAILURE;
+
+	/* 返回 Java -version 的状态，便于脚本判断测试结果。 */
+	if (command_status < 0)
+		return EXIT_FAILURE;
+	return WIFEXITED(command_status) ? WEXITSTATUS(command_status) : EXIT_FAILURE;
+
+restore_pid_namespace:
+	/* mount namespace 恢复失败时仍要尝试恢复后续子进程的 PID namespace。 */
+	exit_pid_namespace(pid_self_fd, pid_entered);
+	return EXIT_FAILURE;
+}

--- a/agent/src/ebpf/user/profile/java/collect_symbol_files.c
+++ b/agent/src/ebpf/user/profile/java/collect_symbol_files.c
@@ -64,9 +64,15 @@ void collect_java_symbols(int pid, int *ret_val, bool error_occurred)
 	}
 
 	*ret_val = JAVA_SYMS_COLLECT_OK;
-	bool is_new_collector;
+	bool is_new_collector = false;
 	u64 start_time = gettime(CLOCK_MONOTONIC, TIME_TYPE_NAN);
-	if (update_java_symbol_file(pid, &is_new_collector))
+	int update_ret = update_java_symbol_file(pid, &is_new_collector);
+	if (update_ret == JAVA_ATTACH_SKIPPED_UNSUPPORTED_JVM) {
+		/* The preflight policy decided this skip; it is not a transient attach failure. */
+		*ret_val = JAVA_CREATE_COLLECTOR_SKIPPED;
+		return;
+	}
+	if (update_ret)
 		goto error;
 	u64 end_time = gettime(CLOCK_MONOTONIC, TIME_TYPE_NAN);
 
@@ -160,7 +166,8 @@ void java_syms_update_main(void *arg)
 				collect_java_symbols(p->pid, &ret,
 						     p->gen_java_syms_file_err);
 				if (ret != JAVA_SYMS_COLLECT_ERR
-				    && ret != JAVA_CREATE_COLLECTOR_ERR) {
+				    && ret != JAVA_CREATE_COLLECTOR_ERR
+				    && ret != JAVA_CREATE_COLLECTOR_SKIPPED) {
 					if (ret == JAVA_SYMS_NEED_UPDATE
 					    || ret == JAVA_SYMS_NEW_COLLECTOR)
 						p->cache_need_update = true;
@@ -178,9 +185,12 @@ void java_syms_update_main(void *arg)
 					 * Mark an error occurred when creating collector,
 					 * no further symbol collection for this process.
 					 */
-					if (ret == JAVA_CREATE_COLLECTOR_ERR)
+					if (ret == JAVA_CREATE_COLLECTOR_ERR ||
+					    ret == JAVA_CREATE_COLLECTOR_SKIPPED)
 						p->gen_java_syms_file_err =
 						    true;
+					if (ret == JAVA_CREATE_COLLECTOR_SKIPPED)
+						p->need_new_symbol_collector = false;
 
 					p->cache_need_update = false;
 				}

--- a/agent/src/ebpf/user/profile/java/collect_symbol_files.h
+++ b/agent/src/ebpf/user/profile/java/collect_symbol_files.h
@@ -22,6 +22,8 @@
 #define JAVA_CREATE_COLLECTOR_ERR	2
 #define JAVA_SYMS_NEED_UPDATE		3
 #define JAVA_SYMS_NEW_COLLECTOR		4
+/* Attach was proactively skipped by the JVM/JVMTI preflight gate. */
+#define JAVA_CREATE_COLLECTOR_SKIPPED	5
 
 struct java_syms_update_task {
 	struct list_head list;

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -910,12 +910,11 @@ static bool java_preflight_parse_version(const char *version, int *major,
  *    bounded timeout; the helper exits after the runner finishes, so the Agent
  *    process and its later children never enter the target namespaces. Skip
  *    conservatively when namespace setup, command execution, timeout, or
- *    version parsing fails. Skip HotSpot Java 8 updates below 352 because
- *    the first fix is missing; also skip 352-381 because the 8u-specific Sweeper
- *    protection is incomplete. Only 382 and newer meet the current complete-fix
- *    baseline. This is a patch completeness gate, not a claim that every update
- *    below 382 reproduced the crash. Non-HotSpot JVMs do not run these
- *    specialized checks.
+ *    version parsing fails. Skip HotSpot Java 8 updates below 352 because both
+ *    known fixes are missing; also skip 352-381 because JDK-8305165 is missing.
+ *    Only 382 and newer meet the current complete-fix baseline. This is a patch
+ *    completeness gate, not a claim that every update below 382 reproduced the
+ *    crash. Non-HotSpot JVMs do not run these specialized checks.
  *
  * 4. Attach capability check: read the target cmdline and environ. Match the
  *    complete JVM option token in cmdline, and match whitespace-delimited
@@ -993,14 +992,15 @@ java_preflight_result_t java_attach_preflight(pid_t pid,
 	}
 	if (info->is_hotspot && info->major_version == 8 &&
 	    info->update_version < JAVA_ATTACH_JAVA8_COMPLETE_FIX_UPDATE) {
-		/*
-		 * The attach baseline requires both standard fixes. Every Java 8 update
-		 * below 8u382 is conservatively treated as missing the complete fix set,
-		 * and one unified reason is used instead of classifying the update range.
-		 */
-		java_preflight_set_reason(
-			info,
-			"hotspot_java8_missing_JDK-8173361_and_JDK-8305165_crash_risk");
+		/* 8u0-8u351 miss both fixes; 8u352-8u381 miss the second fix. */
+		if (info->update_version < JAVA_ATTACH_JAVA8_FIRST_FIX_UPDATE)
+			java_preflight_set_reason(
+				info,
+				"hotspot_java8_missing_JDK-8173361_and_JDK-8305165_crash_risk");
+		else
+			java_preflight_set_reason(
+				info,
+				"hotspot_java8_missing_JDK-8305165_crash_risk");
 		return JAVA_PREFLIGHT_SKIP;
 	}
 	start_after = get_process_starttime_and_comm(pid, NULL, 0);

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <sys/epoll.h>
+#include <sys/wait.h>
 #include <dlfcn.h>
 #include <dirent.h>
 #include "../../config.h"
@@ -317,117 +318,249 @@ static bool java_preflight_shell_quote(const char *value, char *quoted,
 	return true;
 }
 
-/* Find a command in the Agent/host rootfs for target-root execution. */
-static const char *java_preflight_host_command(const char *name)
+/* Read one NUL-separated environment variable from the target process. */
+static int java_preflight_read_env(pid_t pid, const char *name, char *value,
+					   size_t value_len)
 {
-	static const char *const env_paths[] = { "/usr/bin/env", "/bin/env" };
-	static const char *const timeout_paths[] = {
-		"/usr/bin/timeout", "/bin/timeout"
-	};
-	static const char *const nsenter_paths[] = {
-		"/usr/bin/nsenter", "/bin/nsenter"
-	};
-	const char *const *paths;
-	size_t count;
-	size_t i;
+	char path[64];
+	char *entry = NULL;
+	size_t entry_len = 0;
+	size_t name_len;
+	ssize_t length;
+	FILE *fp;
+	int found = 0;
 
-	if (strcmp(name, "env") == 0) {
-		paths = env_paths;
-		count = sizeof(env_paths) / sizeof(env_paths[0]);
-	} else if (strcmp(name, "timeout") == 0) {
-		paths = timeout_paths;
-		count = sizeof(timeout_paths) / sizeof(timeout_paths[0]);
-	} else {
-		paths = nsenter_paths;
-		count = sizeof(nsenter_paths) / sizeof(nsenter_paths[0]);
+	if (name == NULL || value == NULL || value_len == 0)
+		return -1;
+	snprintf(path, sizeof(path), "/proc/%d/environ", pid);
+	fp = fopen(path, "rb");
+	if (fp == NULL)
+		return -1;
+	name_len = strlen(name);
+	while ((length = getdelim(&entry, &entry_len, '\0', fp)) >= 0) {
+		if ((size_t)length <= name_len ||
+		    strncmp(entry, name, name_len) != 0 || entry[name_len] != '=')
+			continue;
+		if (length > 0 && entry[length - 1] == '\0')
+			length -= 1;
+		if ((size_t)length < name_len + 1 ||
+		    (size_t)length - name_len - 1 >= value_len) {
+			free(entry);
+			fclose(fp);
+			return -1;
+		}
+		memcpy(value, entry + name_len + 1,
+		       (size_t)length - name_len - 1);
+		value[(size_t)length - name_len - 1] = '\0';
+		found = 1;
+		break;
 	}
-	for (i = 0; i < count; i++) {
-		if (access(paths[i], X_OK) == 0)
-			return paths[i];
-	}
-	return NULL;
+	if (ferror(fp))
+		found = -1;
+	free(entry);
+	fclose(fp);
+	return found;
 }
 
-/* Execute the target JVM -version in its PID/mount namespace and capture output. */
+/* Append a target environment value to the Java command when it is present. */
+static bool java_preflight_append_env(char *command, size_t command_len,
+					      const char *name, const char *value)
+{
+	char quoted[PATH_MAX * 8 + 8];
+	size_t used;
+	size_t remain;
+	int length;
+
+	if (value == NULL || value[0] == '\0')
+		return true;
+	if (!java_preflight_shell_quote(value, quoted, sizeof(quoted)))
+		return false;
+	used = strlen(command);
+	if (used >= command_len)
+		return false;
+	remain = command_len - used;
+	length = snprintf(command + used, remain, "%s=%s ", name, quoted);
+	return length >= 0 && (size_t)length < remain;
+}
+
+/* Append one dynamic-library directory without truncating the target path. */
+static bool java_preflight_append_library_path(char *path, size_t path_len,
+						 const char *directory)
+{
+	size_t used;
+	size_t remain;
+	int length;
+
+	if (directory == NULL || directory[0] == '\0')
+		return true;
+	used = strlen(path);
+	if (used >= path_len)
+		return false;
+	remain = path_len - used;
+	length = snprintf(path + used, remain, "%s%s", used ? ":" : "",
+				  directory);
+	return length >= 0 && (size_t)length < remain;
+}
+
+/* Compare two namespace identities using the stat result for the ns files. */
+static bool java_preflight_same_namespace(const struct stat *left,
+						 const struct stat *right)
+{
+	return left != NULL && right != NULL && left->st_dev == right->st_dev &&
+	       left->st_ino == right->st_ino;
+}
+
+/* Verify that current and future children use the original namespaces. */
+static bool java_preflight_verify_namespace_restore(const struct stat *pid_ns,
+						    const struct stat *mnt_ns)
+{
+	struct stat current_pid_ns;
+	struct stat current_mnt_ns;
+	struct stat child_pid_ns;
+	struct stat child_mnt_ns;
+	pid_t child_pid;
+	int status;
+
+	if (stat("/proc/self/ns/pid", &current_pid_ns) < 0 ||
+	    stat("/proc/self/ns/mnt", &current_mnt_ns) < 0 ||
+	    !java_preflight_same_namespace(&current_pid_ns, pid_ns) ||
+	    !java_preflight_same_namespace(&current_mnt_ns, mnt_ns))
+		return false;
+
+	/* CLONE_NEWPID affects future children, so verify one after restoration. */
+	child_pid = fork();
+	if (child_pid < 0)
+		return false;
+	if (child_pid == 0) {
+		if (stat("/proc/self/ns/pid", &child_pid_ns) < 0 ||
+		    stat("/proc/self/ns/mnt", &child_mnt_ns) < 0)
+			_exit(2);
+		_exit(java_preflight_same_namespace(&child_pid_ns, pid_ns) &&
+		       java_preflight_same_namespace(&child_mnt_ns, mnt_ns) ? 0 : 1);
+	}
+	if (waitpid(child_pid, &status, 0) < 0)
+		return false;
+	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+/* Execute the target JVM -version after entering its PID/mount namespaces. */
 static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 					java_preflight_info_t *info)
 {
 	char library_path[PATH_MAX * 2] = {};
-	char quoted_library[PATH_MAX * 8 + 8] = {};
+	char target_library_path[PATH_MAX * 2] = {};
+	char target_java_home[PATH_MAX] = {};
+	char target_path[PATH_MAX * 2] = {};
+	char target_home[PATH_MAX] = {};
+	char target_lang[PATH_MAX] = {};
 	char quoted_exe[PATH_MAX * 4 + 8] = {};
-	char command_args[PATH_MAX * 12 + 256] = {};
+	char command[PATH_MAX * 16 + 512] = {};
 	char output[16384] = {};
-	bool version_ok = false;
-	bool same_mntns;
-	bool use_host_nsenter = false;
-	const char *env_path;
-	const char *host_timeout = NULL;
-	const char *host_nsenter = NULL;
+	struct stat original_pid_ns;
+	struct stat original_mnt_ns;
+	int pid_self_fd = -1;
+	int mnt_self_fd = -1;
+	int pid_ns_ret;
+	int mnt_ns_ret;
 	int command_ret;
+	int value_ret;
+	bool version_ok = false;
 
 	if (exe_path == NULL || exe_path[0] != '/' || info == NULL)
 		return false;
+	if (stat("/proc/self/ns/pid", &original_pid_ns) < 0 ||
+	    stat("/proc/self/ns/mnt", &original_mnt_ns) < 0)
+		return false;
 	java_preflight_build_library_path(pid, exe_path, library_path,
 						  sizeof(library_path));
-	/* Check the mount namespace before selecting the rootfs execution path. */
-	same_mntns = is_same_mntns(pid);
-	/*
-	 * setns changes namespaces but does not change the calling thread's root. For
-	 * a different mount namespace, use host nsenter with --root so every absolute
-	 * path (env, Java, and LD_LIBRARY_PATH) resolves inside the target rootfs.
-	 * This also avoids changing the Agent thread's namespace while popen() runs.
-	 */
-	use_host_nsenter = !same_mntns;
-	if (use_host_nsenter) {
-		/* All helper commands execute before nsenter changes root; they must be
-		 * available in the Agent/host rootfs. */
-		env_path = java_preflight_host_command("env");
-		host_timeout = java_preflight_host_command("timeout");
-		host_nsenter = java_preflight_host_command("nsenter");
-		if (env_path == NULL || host_timeout == NULL || host_nsenter == NULL)
-			return false;
-		ebpf_info(JAVA_LOG_TAG
-			  "JAVA_VERSION_NSENTER_ROOT pid=%d root=/proc/%d/root\n",
-			  pid, pid);
-	} else {
-		/* The same mount namespace can use the Agent's helper path directly. */
-		if (access("/usr/bin/env", X_OK) == 0)
-			env_path = "/usr/bin/env";
-		else if (access("/bin/env", X_OK) == 0)
-			env_path = "/bin/env";
-		else
-			return false;
-	}
-	if (!java_preflight_shell_quote(library_path, quoted_library,
-					 sizeof(quoted_library)) ||
-	    !java_preflight_shell_quote(exe_path, quoted_exe,
-					 sizeof(quoted_exe)))
+	value_ret = java_preflight_read_env(pid, "LD_LIBRARY_PATH",
+					     target_library_path,
+					     sizeof(target_library_path));
+	if (value_ret < 0)
 		return false;
-	/*
-	 * exec_command uses popen(). The outer env sanitizes the Agent environment,
-	 * timeout imposes a five-second limit, and LD_LIBRARY_PATH points to the
-	 * target JVM library directory. In the cross-namespace path nsenter changes
-	 * root before Java resolves these absolute paths.
-	 */
-	if (use_host_nsenter) {
-		/* --root is essential: --mount/--pid alone do not change the process root. */
-		snprintf(command_args, sizeof(command_args),
-			 "-i PATH=/usr/bin:/bin HOME=/tmp LD_LIBRARY_PATH=%s %s 5 "
-			 "%s --target %d --mount --pid --root=/proc/%d/root --no-fork -- %s "
-			 "-version 2>&1",
-			 quoted_library, host_timeout, host_nsenter, pid, pid,
-			 quoted_exe);
-	} else {
-		snprintf(command_args, sizeof(command_args),
-			 "-i PATH=/usr/bin:/bin HOME=/tmp timeout 5 %s -i "
-			 "PATH=/usr/bin:/bin HOME=/tmp LD_LIBRARY_PATH=%s %s -version 2>&1",
-			 env_path, quoted_library, quoted_exe);
+	value_ret = java_preflight_read_env(pid, "JAVA_HOME", target_java_home,
+					     sizeof(target_java_home));
+	if (value_ret < 0)
+		return false;
+	value_ret = java_preflight_read_env(pid, "PATH", target_path,
+					     sizeof(target_path));
+	if (value_ret < 0)
+		return false;
+	value_ret = java_preflight_read_env(pid, "HOME", target_home,
+					     sizeof(target_home));
+	if (value_ret < 0)
+		return false;
+	value_ret = java_preflight_read_env(pid, "LANG", target_lang,
+					     sizeof(target_lang));
+	if (value_ret < 0)
+		return false;
+
+	/* Prefer the mapped JVM directories and retain the target environment path. */
+	if (!java_preflight_append_library_path(target_library_path,
+						 sizeof(target_library_path), library_path))
+		return false;
+	if (target_path[0] == '\0')
+		snprintf(target_path, sizeof(target_path), "/usr/bin:/bin");
+	if (target_home[0] == '\0')
+		snprintf(target_home, sizeof(target_home), "/tmp");
+
+	/* Set PID namespace first so popen() children inherit it. */
+	pid_ns_ret = df_enter_ns(pid, "pid", &pid_self_fd);
+	if (pid_ns_ret < 0)
+		return false;
+	mnt_ns_ret = df_enter_ns(pid, "mnt", &mnt_self_fd);
+	if (mnt_ns_ret < 0) {
+		df_exit_ns(pid_self_fd);
+		return false;
 	}
-	command_ret = exec_command(env_path, command_args, output,
-					 sizeof(output));
+
+	if (!java_preflight_shell_quote(exe_path, quoted_exe,
+					       sizeof(quoted_exe)))
+		goto restore_ns;
+	if (!java_preflight_append_env(command, sizeof(command),
+					       "LD_LIBRARY_PATH",
+					       target_library_path) ||
+	    !java_preflight_append_env(command, sizeof(command), "JAVA_HOME",
+					       target_java_home) ||
+	    !java_preflight_append_env(command, sizeof(command), "PATH",
+					       target_path) ||
+	    !java_preflight_append_env(command, sizeof(command), "HOME",
+					       target_home) ||
+	    !java_preflight_append_env(command, sizeof(command), "LANG",
+					       target_lang))
+		goto restore_ns;
+	{
+		size_t used = strlen(command);
+		size_t remain = sizeof(command) - used;
+		int length;
+
+		if (used >= sizeof(command))
+			goto restore_ns;
+		length = snprintf(command + used, remain, "%s -version 2>&1",
+				  quoted_exe);
+		if (length < 0 || (size_t)length >= remain)
+			goto restore_ns;
+	}
+
+	ebpf_info(JAVA_LOG_TAG
+		  "JAVA_VERSION_SETNS pid=%d pid_ns=%d mnt_ns=%d\n", pid,
+		  pid_ns_ret, mnt_ns_ret);
+	command_ret = exec_command(command, "", output, sizeof(output));
 	if (command_ret == 0) {
 		java_preflight_parse_version_output(output, info);
 		version_ok = info->java_version[0] != '\0';
+	}
+
+restore_ns:
+	/* Restore in reverse order so later Agent children keep the original
+	 * namespaces. */
+	df_exit_ns(mnt_self_fd);
+	df_exit_ns(pid_self_fd);
+	if (!java_preflight_verify_namespace_restore(&original_pid_ns,
+						    &original_mnt_ns)) {
+		ebpf_warning(JAVA_LOG_TAG
+			     "JAVA_VERSION_NS_RESTORE_FAILED pid=%d\n", pid);
+		return false;
 	}
 	return version_ok;
 }
@@ -628,13 +761,12 @@ static bool java_preflight_parse_version(const char *version, int *major,
  *    may call Agent_OnAttach again.
  *
  * 3. Target JVM version check: obtain -version only for HotSpot. Read the
- *    target exe and maps first; when the target and Agent use different mount
- *    namespaces, run the short-lived child through host nsenter with
- *    --mount --pid --root=/proc/<pid>/root. This is required because setns()
- *    alone does not change the process root, and absolute paths could otherwise
- *    resolve from the Agent/Host rootfs. Do not switch namespaces when they are
- *    the same. Skip conservatively when the root-aware command fails or the Java
- *    version cannot be parsed. Skip HotSpot Java 8 updates below 352 because
+ *    target exe, maps and NUL-separated environ first; build the target
+ *    LD_LIBRARY_PATH, then setns into the target PID/mount namespaces before
+ *    popen() creates the short-lived Java child. Restore both namespace
+ *    selections after pclose(), and verify that later children use the original
+ *    namespaces. Skip conservatively when namespace setup, command execution,
+ *    or version parsing fails. Skip HotSpot Java 8 updates below 352 because
  *    the first fix is missing; also skip 352-381 because the 8u-specific Sweeper
  *    protection is incomplete. Only 382 and newer meet the current complete-fix
  *    baseline. This is a patch completeness gate, not a claim that every update

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -317,39 +317,7 @@ static bool java_preflight_shell_quote(const char *value, char *quoted,
 	return true;
 }
 
-/* Check whether the target namespace has the minimal environment required by popen. */
-static bool java_preflight_target_command_env(pid_t pid)
-{
-	static const char *required[] = {
-		"/bin/sh",
-		"/usr/bin/env",
-		"/bin/env",
-		"/usr/bin/timeout",
-		"/bin/timeout",
-	};
-	char path[PATH_MAX + 64];
-	bool has_shell = false;
-	bool has_env = false;
-	bool has_timeout = false;
-	size_t i;
-
-	for (i = 0; i < sizeof(required) / sizeof(required[0]); i++) {
-		snprintf(path, sizeof(path), "/proc/%d/root%s", pid, required[i]);
-		if (access(path, X_OK) != 0)
-			continue;
-		if (strcmp(required[i], "/bin/sh") == 0)
-			has_shell = true;
-		if (strcmp(required[i], "/usr/bin/env") == 0 ||
-		    strcmp(required[i], "/bin/env") == 0)
-			has_env = true;
-		if (strcmp(required[i], "/usr/bin/timeout") == 0 ||
-		    strcmp(required[i], "/bin/timeout") == 0)
-			has_timeout = true;
-	}
-	return has_shell && has_env && has_timeout;
-}
-
-/* Find a command in the current namespace for the minimal-namespace fallback. */
+/* Find a command in the Agent/host rootfs for target-root execution. */
 static const char *java_preflight_host_command(const char *name)
 {
 	static const char *const env_paths[] = { "/usr/bin/env", "/bin/env" };
@@ -393,76 +361,62 @@ static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 	bool same_mntns;
 	bool use_host_nsenter = false;
 	const char *env_path;
-	const char *host_timeout;
-	const char *host_nsenter;
+	const char *host_timeout = NULL;
+	const char *host_nsenter = NULL;
 	int command_ret;
-	int ns_ret;
-	int pid_self_fd = -1;
-	int mnt_self_fd = -1;
 
 	if (exe_path == NULL || exe_path[0] != '/' || info == NULL)
 		return false;
 	java_preflight_build_library_path(pid, exe_path, library_path,
 						  sizeof(library_path));
-	/* Check the mount namespace first; do not setns or restore for the same namespace. */
+	/* Check the mount namespace before selecting the rootfs execution path. */
 	same_mntns = is_same_mntns(pid);
-	/* If a minimal POD lacks shell/env/timeout, use host nsenter to run Java directly. */
-	if (!same_mntns && !java_preflight_target_command_env(pid))
-		use_host_nsenter = true;
 	/*
-	 * The normal path enters the target PID/mount namespace before calling
-	 * exec_command. setns changes only this thread, so other Agent threads are
-	 * unaffected; the popen child created by exec_command inherits the target
-	 * namespace and resolves the Java path inside the POD. If the minimal target
-	 * namespace has no /bin/sh, host nsenter creates the Java child instead.
+	 * setns changes namespaces but does not change the calling thread's root. For
+	 * a different mount namespace, use host nsenter with --root so every absolute
+	 * path (env, Java, and LD_LIBRARY_PATH) resolves inside the target rootfs.
+	 * This also avoids changing the Agent thread's namespace while popen() runs.
 	 */
-	if (!same_mntns && !use_host_nsenter) {
-		/* The PID namespace affects only children; return 0 may still mean the
-		 * target PID could not be read. */
-		ns_ret = df_enter_ns(pid, "pid", &pid_self_fd);
-		if (ns_ret < 0)
-			goto restore_ns;
-		ns_ret = df_enter_ns(pid, "mnt", &mnt_self_fd);
-		/* A different mount namespace without a saved restore fd means switching failed. */
-		if (ns_ret < 0 || mnt_self_fd < 0)
-			goto restore_ns;
-	}
+	use_host_nsenter = !same_mntns;
 	if (use_host_nsenter) {
-		/* The target namespace lacks shell/env/timeout, so popen cannot run there. */
+		/* All helper commands execute before nsenter changes root; they must be
+		 * available in the Agent/host rootfs. */
 		env_path = java_preflight_host_command("env");
 		host_timeout = java_preflight_host_command("timeout");
 		host_nsenter = java_preflight_host_command("nsenter");
 		if (env_path == NULL || host_timeout == NULL || host_nsenter == NULL)
-			goto restore_ns;
+			return false;
 		ebpf_info(JAVA_LOG_TAG
-			  "JAVA_VERSION_NSENTER_FALLBACK pid=%d reason=target_runtime_helper_missing\n",
-			  pid);
+			  "JAVA_VERSION_NSENTER_ROOT pid=%d root=/proc/%d/root\n",
+			  pid, pid);
 	} else {
-		/* The target container may place env in /usr/bin or /bin. */
+		/* The same mount namespace can use the Agent's helper path directly. */
 		if (access("/usr/bin/env", X_OK) == 0)
 			env_path = "/usr/bin/env";
 		else if (access("/bin/env", X_OK) == 0)
 			env_path = "/bin/env";
 		else
-			goto restore_ns;
+			return false;
 	}
 	if (!java_preflight_shell_quote(library_path, quoted_library,
 					 sizeof(quoted_library)) ||
 	    !java_preflight_shell_quote(exe_path, quoted_exe,
 					 sizeof(quoted_exe)))
-		goto restore_ns;
+		return false;
 	/*
-	 * exec_command uses popen(), so the command inherits the namespace entered by
-	 * this thread. The outer env sanitizes the Agent environment, timeout imposes
-	 * a five-second limit, and the inner env sets the target Java library path.
+	 * exec_command uses popen(). The outer env sanitizes the Agent environment,
+	 * timeout imposes a five-second limit, and LD_LIBRARY_PATH points to the
+	 * target JVM library directory. In the cross-namespace path nsenter changes
+	 * root before Java resolves these absolute paths.
 	 */
 	if (use_host_nsenter) {
-		/* Host env sanitizes the environment; nsenter enters the target namespace
-		 * and directly execs Java. */
+		/* --root is essential: --mount/--pid alone do not change the process root. */
 		snprintf(command_args, sizeof(command_args),
 			 "-i PATH=/usr/bin:/bin HOME=/tmp LD_LIBRARY_PATH=%s %s 5 "
-			 "%s --target %d --mount --pid -- %s -version 2>&1",
-			 quoted_library, host_timeout, host_nsenter, pid, quoted_exe);
+			 "%s --target %d --mount --pid --root=/proc/%d/root --no-fork -- %s "
+			 "-version 2>&1",
+			 quoted_library, host_timeout, host_nsenter, pid, pid,
+			 quoted_exe);
 	} else {
 		snprintf(command_args, sizeof(command_args),
 			 "-i PATH=/usr/bin:/bin HOME=/tmp timeout 5 %s -i "
@@ -474,14 +428,6 @@ static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 	if (command_ret == 0) {
 		java_preflight_parse_version_output(output, info);
 		version_ok = info->java_version[0] != '\0';
-	}
-
-restore_ns:
-	/* Restore this thread's namespace only when crossing mount namespaces. */
-	if (!same_mntns && !use_host_nsenter) {
-		/* Restore this thread's namespaces in reverse entry order. */
-		df_exit_ns(mnt_self_fd);
-		df_exit_ns(pid_self_fd);
 	}
 	return version_ok;
 }
@@ -683,16 +629,17 @@ static bool java_preflight_parse_version(const char *version, int *major,
  *
  * 3. Target JVM version check: obtain -version only for HotSpot. Read the
  *    target exe and maps first; when the target and Agent use different mount
- *    namespaces, enter the target PID/mount namespace with df_enter_ns, launch
- *    a short-lived version child, then restore with df_exit_ns. Do not switch
- *    namespaces when they are the same. This makes Host/POD checks use the
- *    target filesystem without relying on a release file. Skip conservatively
- *    when the command fails or the Java version cannot be parsed. Skip HotSpot
- *    Java 8 updates below 352 because the first fix is missing; also skip
- *    352-381 because the 8u-specific Sweeper protection is incomplete. Only
- *    382 and newer meet the current complete-fix baseline. This is a patch
- *    completeness gate, not a claim that every update below 382 reproduced the
- *    crash. Non-HotSpot JVMs do not run these specialized checks.
+ *    namespaces, run the short-lived child through host nsenter with
+ *    --mount --pid --root=/proc/<pid>/root. This is required because setns()
+ *    alone does not change the process root, and absolute paths could otherwise
+ *    resolve from the Agent/Host rootfs. Do not switch namespaces when they are
+ *    the same. Skip conservatively when the root-aware command fails or the Java
+ *    version cannot be parsed. Skip HotSpot Java 8 updates below 352 because
+ *    the first fix is missing; also skip 352-381 because the 8u-specific Sweeper
+ *    protection is incomplete. Only 382 and newer meet the current complete-fix
+ *    baseline. This is a patch completeness gate, not a claim that every update
+ *    below 382 reproduced the crash. Non-HotSpot JVMs do not run these
+ *    specialized checks.
  *
  * 4. Attach capability check: read the target cmdline and environ. Match the
  *    complete JVM option token in cmdline, and match whitespace-delimited

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -486,47 +486,132 @@ restore_ns:
 	return version_ok;
 }
 
-/* Find a JVM option in NUL-separated cmdline or environ data. */
+/* Check whether an environment variable is a standard JVM option carrier. */
+static bool java_preflight_is_jvm_option_env(const char *name)
+{
+	return strcmp(name, "JAVA_TOOL_OPTIONS") == 0 ||
+	       strcmp(name, "_JAVA_OPTIONS") == 0 ||
+	       strcmp(name, "JDK_JAVA_OPTIONS") == 0;
+}
+
+/* Match a complete NUL-separated argv token in /proc/<pid>/cmdline. */
+static int java_preflight_cmdline_contains_option(FILE *fp,
+						 const char *needle,
+						 size_t needle_len)
+{
+	size_t token_len = 0;
+	bool token_match = true;
+	int c;
+
+	while ((c = fgetc(fp)) != EOF) {
+		if (c == '\0') {
+			if (token_match && token_len == needle_len)
+				return 1;
+			token_len = 0;
+			token_match = true;
+			continue;
+		}
+		if (token_len >= needle_len ||
+		    c != (unsigned char)needle[token_len])
+			token_match = false;
+		token_len++;
+	}
+	if (ferror(fp))
+		return -1;
+	/* Accept a final record without a trailing NUL for completeness. */
+	return token_match && token_len == needle_len;
+}
+
+/* Match a whitespace-delimited option in standard JVM option environment variables. */
+static int java_preflight_environ_contains_option(FILE *fp,
+						  const char *needle,
+						  size_t needle_len)
+{
+	char env_name[64];
+	size_t env_name_len = 0, token_len = 0;
+	bool env_name_valid = true, option_env = false;
+	bool token_match = true, in_value = false;
+	int c;
+
+	while ((c = fgetc(fp)) != EOF) {
+		if (c == '\0') {
+			if (in_value && option_env && token_match &&
+			    token_len == needle_len)
+				return 1;
+			env_name_len = 0;
+			env_name_valid = true;
+			option_env = false;
+			token_len = 0;
+			token_match = true;
+			in_value = false;
+			continue;
+		}
+		if (!in_value) {
+			if (c == '=') {
+				env_name[env_name_len] = '\0';
+				option_env = env_name_valid &&
+					java_preflight_is_jvm_option_env(env_name);
+				in_value = true;
+				token_len = 0;
+				token_match = true;
+				continue;
+			}
+			if (env_name_len + 1 < sizeof(env_name))
+				env_name[env_name_len++] = (char)c;
+			else
+				env_name_valid = false;
+			continue;
+		}
+		if (!option_env)
+			continue;
+		if (isspace((unsigned char)c)) {
+			if (token_match && token_len == needle_len)
+				return 1;
+			token_len = 0;
+			token_match = true;
+			continue;
+		}
+		if (token_len >= needle_len ||
+		    c != (unsigned char)needle[token_len])
+			token_match = false;
+		token_len++;
+	}
+	if (ferror(fp))
+		return -1;
+	if (in_value && option_env && token_match && token_len == needle_len)
+		return 1;
+	return 0;
+}
+
+/* Find a real JVM option without matching arbitrary substrings in /proc data. */
 /* Return 1 if found, 0 if absent, and -1 if reading failed. */
 static int java_preflight_proc_contains(pid_t pid, const char *name,
 					       const char *needle)
 {
-	char path[64], buf[4096];
+	char path[64];
 	FILE *fp;
-	size_t n, total, carry, needle_len, i;
+	size_t needle_len;
+	int result;
 
 	snprintf(path, sizeof(path), "/proc/%d/%s", pid, name);
 	fp = fopen(path, "rb");
 	if (fp == NULL)
 		return -1;
 	needle_len = strlen(needle);
-	if (needle_len == 0 || needle_len >= sizeof(buf)) {
+	if (needle_len == 0) {
 		fclose(fp);
 		return 0;
 	}
-	/* Keep the previous chunk tail so options crossing an fread() boundary are found. */
-	carry = 0;
-	while ((n = fread(buf + carry, 1, sizeof(buf) - 1 - carry, fp)) > 0) {
-		total = carry + n;
-		/* cmdline and environ use NUL separators; byte comparison covers every option. */
-		for (i = 0; i + needle_len <= total; i++) {
-			if (memcmp(buf + i, needle, needle_len) == 0) {
-				fclose(fp);
-				return 1;
-			}
-		}
-		carry = needle_len - 1;
-		if (carry > total)
-			carry = total;
-		if (carry > 0)
-			memmove(buf, buf + total - carry, carry);
-	}
-	if (ferror(fp)) {
-		fclose(fp);
-		return -1;
-	}
+	if (strcmp(name, "cmdline") == 0)
+		result = java_preflight_cmdline_contains_option(fp, needle,
+								 needle_len);
+	else if (strcmp(name, "environ") == 0)
+		result = java_preflight_environ_contains_option(fp, needle,
+								  needle_len);
+	else
+		result = -1;
 	fclose(fp);
-	return 0;
+	return result;
 }
 
 /* Parse the Java version and extract the Java 8 update number. */
@@ -609,7 +694,9 @@ static bool java_preflight_parse_version(const char *version, int *major,
  *    completeness gate, not a claim that every update below 382 reproduced the
  *    crash. Non-HotSpot JVMs do not run these specialized checks.
  *
- * 4. Attach capability check: read the target cmdline and environ. Skip when
+ * 4. Attach capability check: read the target cmdline and environ. Match the
+ *    complete JVM option token in cmdline, and match whitespace-delimited
+ *    tokens only in the standard JVM option environment variables. Skip when
  *    -XX:+DisableAttachMechanism is present to avoid an injection that must
  *    fail; if either file cannot be read, capability cannot be confirmed and
  *    the result is also a conservative skip.

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -15,17 +15,22 @@
  */
 
 #include <pthread.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <poll.h>
+#include <signal.h>
+#include <sched.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <sys/epoll.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <dlfcn.h>
 #include <dirent.h>
 #include "../../config.h"
@@ -37,6 +42,7 @@
 #include "jvm_symbol_collect.h"
 
 #define SYM_COLLECT_MAX_EVENTS 4
+#define JAVA_PREFLIGHT_VERSION_TIMEOUT_MS 5000
 
 // Use thread pool to manage threads for obtaining Java symbols.
 symbol_collect_thread_pool_t *g_collect_pool;
@@ -288,36 +294,6 @@ static void java_preflight_build_library_path(pid_t pid,
 	}
 }
 
-/* Single-quote shell arguments so special characters in Java paths are inert. */
-static bool java_preflight_shell_quote(const char *value, char *quoted,
-					       size_t quoted_len)
-{
-	size_t used = 0;
-	size_t i;
-
-	if (value == NULL || quoted == NULL || quoted_len < 3)
-		return false;
-	quoted[used++] = '\'';
-	for (i = 0; value[i] != '\0'; i++) {
-		if (value[i] == '\'') {
-			/* A shell single quote must be encoded as '\'' . */
-			if (used + 4 >= quoted_len)
-				return false;
-			memcpy(quoted + used, "'\\''", 4);
-			used += 4;
-		} else {
-			if (used + 1 >= quoted_len)
-				return false;
-			quoted[used++] = value[i];
-		}
-	}
-	if (used + 2 > quoted_len)
-		return false;
-	quoted[used++] = '\'';
-	quoted[used] = '\0';
-	return true;
-}
-
 /* Read one NUL-separated environment variable from the target process. */
 static int java_preflight_read_env(pid_t pid, const char *name, char *value,
 					   size_t value_len)
@@ -361,28 +337,6 @@ static int java_preflight_read_env(pid_t pid, const char *name, char *value,
 	fclose(fp);
 	return found;
 }
-
-/* Append a target environment value to the Java command when it is present. */
-static bool java_preflight_append_env(char *command, size_t command_len,
-					      const char *name, const char *value)
-{
-	char quoted[PATH_MAX * 8 + 8];
-	size_t used;
-	size_t remain;
-	int length;
-
-	if (value == NULL || value[0] == '\0')
-		return true;
-	if (!java_preflight_shell_quote(value, quoted, sizeof(quoted)))
-		return false;
-	used = strlen(command);
-	if (used >= command_len)
-		return false;
-	remain = command_len - used;
-	length = snprintf(command + used, remain, "%s=%s ", name, quoted);
-	return length >= 0 && (size_t)length < remain;
-}
-
 /* Append one dynamic-library directory without truncating the target path. */
 static bool java_preflight_append_library_path(char *path, size_t path_len,
 						 const char *directory)
@@ -410,40 +364,208 @@ static bool java_preflight_same_namespace(const struct stat *left,
 	       left->st_ino == right->st_ino;
 }
 
-/* Verify that current and future children use the original namespaces. */
-static bool java_preflight_verify_namespace_restore(const struct stat *pid_ns,
-						    const struct stat *mnt_ns)
+/* Open a target namespace fd, or report that the current namespace is equal. */
+static int java_preflight_open_namespace(pid_t pid, const char *type,
+						 bool *same_namespace)
 {
-	struct stat current_pid_ns;
-	struct stat current_mnt_ns;
-	struct stat child_pid_ns;
-	struct stat child_mnt_ns;
-	pid_t child_pid;
-	int status;
+	char target_path[64];
+	char self_path[64];
+	struct stat target_stat;
+	struct stat self_stat;
+	int fd;
 
-	if (stat("/proc/self/ns/pid", &current_pid_ns) < 0 ||
-	    stat("/proc/self/ns/mnt", &current_mnt_ns) < 0 ||
-	    !java_preflight_same_namespace(&current_pid_ns, pid_ns) ||
-	    !java_preflight_same_namespace(&current_mnt_ns, mnt_ns))
-		return false;
-
-	/* CLONE_NEWPID affects future children, so verify one after restoration. */
-	child_pid = fork();
-	if (child_pid < 0)
-		return false;
-	if (child_pid == 0) {
-		if (stat("/proc/self/ns/pid", &child_pid_ns) < 0 ||
-		    stat("/proc/self/ns/mnt", &child_mnt_ns) < 0)
-			_exit(2);
-		_exit(java_preflight_same_namespace(&child_pid_ns, pid_ns) &&
-		       java_preflight_same_namespace(&child_mnt_ns, mnt_ns) ? 0 : 1);
+	if (same_namespace == NULL || type == NULL)
+		return -1;
+	*same_namespace = false;
+	if (snprintf(target_path, sizeof(target_path), "/proc/%d/ns/%s", pid,
+		     type) >= (int)sizeof(target_path) ||
+	    snprintf(self_path, sizeof(self_path), "/proc/self/ns/%s", type) >=
+		    (int)sizeof(self_path))
+		return -1;
+	if (stat(target_path, &target_stat) < 0 ||
+	    stat(self_path, &self_stat) < 0)
+		return -1;
+	if (java_preflight_same_namespace(&target_stat, &self_stat)) {
+		*same_namespace = true;
+		return -1;
 	}
-	if (waitpid(child_pid, &status, 0) < 0)
-		return false;
-	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
+	fd = open(target_path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return -1;
+	return fd;
 }
 
-/* Execute the target JVM -version after entering its PID/mount namespaces. */
+/* Return a monotonic clock value in milliseconds for the parent timeout. */
+static int64_t java_preflight_monotonic_ms(void)
+{
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_MONOTONIC, &ts) < 0)
+		return -1;
+	return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* Execute Java directly in the helper's target namespaces. */
+static void java_preflight_version_runner(const char *exe_path,
+						 char *const envp[], int output_fd)
+{
+	char *const argv[] = { (char *)exe_path, (char *)"-version", NULL };
+
+	if (dup2(output_fd, STDOUT_FILENO) < 0 ||
+	    dup2(output_fd, STDERR_FILENO) < 0)
+		_exit(125);
+	if (output_fd != STDOUT_FILENO && output_fd != STDERR_FILENO)
+		close(output_fd);
+	execve(exe_path, argv, envp);
+	_exit(127);
+}
+
+/* Enter target namespaces, fork the runner, and wait for its exit status. */
+static void java_preflight_version_helper(const char *exe_path,
+						 char *const envp[], int pid_ns_fd,
+						 int mnt_ns_fd, int output_fd)
+{
+	pid_t runner_pid;
+	int status;
+
+	/* Isolate helper and runner so a timeout can terminate both processes. */
+	if (setpgid(0, 0) < 0)
+		_exit(124);
+#ifdef __NR_setns
+	if (pid_ns_fd >= 0 && syscall(__NR_setns, pid_ns_fd, CLONE_NEWPID) < 0)
+		_exit(124);
+	if (mnt_ns_fd >= 0 && syscall(__NR_setns, mnt_ns_fd, CLONE_NEWNS) < 0)
+		_exit(124);
+#else
+	(void)pid_ns_fd;
+	(void)mnt_ns_fd;
+	_exit(124);
+#endif
+	if (pid_ns_fd >= 0)
+		close(pid_ns_fd);
+	if (mnt_ns_fd >= 0)
+		close(mnt_ns_fd);
+
+	/* PID namespace changes apply to children created after setns(). */
+	runner_pid = fork();
+	if (runner_pid < 0)
+		_exit(124);
+	if (runner_pid == 0)
+		java_preflight_version_runner(exe_path, envp, output_fd);
+	close(output_fd);
+	while (waitpid(runner_pid, &status, 0) < 0) {
+		if (errno != EINTR)
+			_exit(124);
+	}
+	if (WIFEXITED(status))
+		_exit(WEXITSTATUS(status));
+	_exit(128 + WTERMSIG(status));
+}
+
+/* Drain version output without allowing a full pipe to block the runner. */
+static void java_preflight_drain_output(int fd, char *output,
+						size_t output_len, size_t *used,
+						 bool *eof)
+{
+	char discard[1024];
+	char *buffer;
+	ssize_t length;
+	size_t remain;
+
+	while (!*eof) {
+		buffer = *used < output_len - 1 ? output + *used : discard;
+		remain = *used < output_len - 1 ? output_len - 1 - *used :
+				 sizeof(discard);
+		length = read(fd, buffer, remain);
+		if (length > 0) {
+			if (buffer != discard)
+				*used += (size_t)length;
+			continue;
+		}
+		if (length == 0) {
+			*eof = true;
+			break;
+		}
+		if (errno == EINTR)
+			continue;
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			break;
+		*eof = true;
+	}
+	if (output_len > 0)
+		output[*used < output_len ? *used : output_len - 1] = '\0';
+}
+
+/* Terminate and reap a helper together with its Java runner process group. */
+static void java_preflight_kill_helper(pid_t helper_pid, int *status)
+{
+	if (kill(-helper_pid, SIGKILL) < 0)
+		kill(helper_pid, SIGKILL);
+	while (waitpid(helper_pid, status, 0) < 0 && errno == EINTR)
+		;
+}
+
+/* Wait for the helper with a bounded timeout and collect its output. */
+static bool java_preflight_wait_helper(pid_t helper_pid, int output_fd,
+						 char *output, size_t output_len)
+{
+	struct pollfd poll_fd = { .fd = output_fd, .events = POLLIN };
+	int flags;
+	int status;
+	int poll_timeout;
+	int64_t deadline;
+	int64_t now;
+	pid_t wait_result;
+	size_t used = 0;
+	bool eof = false;
+	bool exited = false;
+
+	flags = fcntl(output_fd, F_GETFL, 0);
+	if (flags < 0 || fcntl(output_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+		java_preflight_kill_helper(helper_pid, &status);
+		return false;
+	}
+	deadline = java_preflight_monotonic_ms();
+	if (deadline < 0) {
+		java_preflight_kill_helper(helper_pid, &status);
+		return false;
+	}
+	deadline += JAVA_PREFLIGHT_VERSION_TIMEOUT_MS;
+	while (!exited || !eof) {
+		java_preflight_drain_output(output_fd, output, output_len, &used,
+						&eof);
+		if (!exited) {
+			wait_result = waitpid(helper_pid, &status, WNOHANG);
+			if (wait_result == helper_pid)
+				exited = true;
+			else if (wait_result < 0 && errno != EINTR) {
+				java_preflight_kill_helper(helper_pid, &status);
+				close(output_fd);
+				return false;
+			}
+		}
+		if (exited && eof)
+			break;
+		now = java_preflight_monotonic_ms();
+		if (now < 0 || now >= deadline) {
+			java_preflight_kill_helper(helper_pid, &status);
+			close(output_fd);
+			return false;
+		}
+		poll_timeout = (int)(deadline - now);
+		if (poll_timeout > 100)
+			poll_timeout = 100;
+		if (poll(&poll_fd, 1, poll_timeout) < 0 && errno != EINTR) {
+			java_preflight_kill_helper(helper_pid, &status);
+			close(output_fd);
+			return false;
+		}
+	}
+	close(output_fd);
+	return exited && WIFEXITED(status) && WEXITSTATUS(status) == 0;
+}
+
+/* Execute the target JVM -version in a bounded helper process. */
 static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 					java_preflight_info_t *info)
 {
@@ -453,23 +575,25 @@ static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 	char target_path[PATH_MAX * 2] = {};
 	char target_home[PATH_MAX] = {};
 	char target_lang[PATH_MAX] = {};
-	char quoted_exe[PATH_MAX * 4 + 8] = {};
-	char command[PATH_MAX * 16 + 512] = {};
 	char output[16384] = {};
-	struct stat original_pid_ns;
-	struct stat original_mnt_ns;
-	int pid_self_fd = -1;
-	int mnt_self_fd = -1;
-	int pid_ns_ret;
-	int mnt_ns_ret;
-	int command_ret;
+	char env_library[PATH_MAX * 2 + 32];
+	char env_java_home[PATH_MAX + 16];
+	char env_path[PATH_MAX * 2 + 8];
+	char env_home[PATH_MAX + 8];
+	char env_lang[PATH_MAX + 8];
+	char *envp[6] = {};
+	int env_count = 0;
+	int pid_ns_fd = -1;
+	int mnt_ns_fd = -1;
+	int pipe_fds[2] = { -1, -1 };
+	int flags;
+	pid_t helper_pid;
 	int value_ret;
+	bool same_pid_ns = false;
+	bool same_mnt_ns = false;
 	bool version_ok = false;
 
 	if (exe_path == NULL || exe_path[0] != '/' || info == NULL)
-		return false;
-	if (stat("/proc/self/ns/pid", &original_pid_ns) < 0 ||
-	    stat("/proc/self/ns/mnt", &original_mnt_ns) < 0)
 		return false;
 	java_preflight_build_library_path(pid, exe_path, library_path,
 						  sizeof(library_path));
@@ -503,65 +627,82 @@ static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
 		snprintf(target_path, sizeof(target_path), "/usr/bin:/bin");
 	if (target_home[0] == '\0')
 		snprintf(target_home, sizeof(target_home), "/tmp");
-
-	/* Set PID namespace first so popen() children inherit it. */
-	pid_ns_ret = df_enter_ns(pid, "pid", &pid_self_fd);
-	if (pid_ns_ret < 0)
+	if (snprintf(env_library, sizeof(env_library), "LD_LIBRARY_PATH=%s",
+		     target_library_path) >= (int)sizeof(env_library) ||
+	    snprintf(env_path, sizeof(env_path), "PATH=%s", target_path) >=
+		    (int)sizeof(env_path) ||
+	    snprintf(env_home, sizeof(env_home), "HOME=%s", target_home) >=
+		    (int)sizeof(env_home))
 		return false;
-	mnt_ns_ret = df_enter_ns(pid, "mnt", &mnt_self_fd);
-	if (mnt_ns_ret < 0) {
-		df_exit_ns(pid_self_fd);
+	envp[env_count++] = env_library;
+	if (target_java_home[0] != '\0') {
+		if (snprintf(env_java_home, sizeof(env_java_home), "JAVA_HOME=%s",
+			     target_java_home) >= (int)sizeof(env_java_home))
+			return false;
+		envp[env_count++] = env_java_home;
+	}
+	envp[env_count++] = env_path;
+	envp[env_count++] = env_home;
+	if (target_lang[0] != '\0') {
+		if (snprintf(env_lang, sizeof(env_lang), "LANG=%s", target_lang) >=
+		    (int)sizeof(env_lang))
+			return false;
+		envp[env_count++] = env_lang;
+	}
+	envp[env_count] = NULL;
+
+	pid_ns_fd = java_preflight_open_namespace(pid, "pid", &same_pid_ns);
+	if (pid_ns_fd < 0 && !same_pid_ns)
+		return false;
+	mnt_ns_fd = java_preflight_open_namespace(pid, "mnt", &same_mnt_ns);
+	if (mnt_ns_fd < 0 && !same_mnt_ns) {
+		if (pid_ns_fd >= 0)
+			close(pid_ns_fd);
 		return false;
 	}
-
-	if (!java_preflight_shell_quote(exe_path, quoted_exe,
-					       sizeof(quoted_exe)))
-		goto restore_ns;
-	if (!java_preflight_append_env(command, sizeof(command),
-					       "LD_LIBRARY_PATH",
-					       target_library_path) ||
-	    !java_preflight_append_env(command, sizeof(command), "JAVA_HOME",
-					       target_java_home) ||
-	    !java_preflight_append_env(command, sizeof(command), "PATH",
-					       target_path) ||
-	    !java_preflight_append_env(command, sizeof(command), "HOME",
-					       target_home) ||
-	    !java_preflight_append_env(command, sizeof(command), "LANG",
-					       target_lang))
-		goto restore_ns;
-	{
-		size_t used = strlen(command);
-		size_t remain = sizeof(command) - used;
-		int length;
-
-		if (used >= sizeof(command))
-			goto restore_ns;
-		length = snprintf(command + used, remain, "%s -version 2>&1",
-				  quoted_exe);
-		if (length < 0 || (size_t)length >= remain)
-			goto restore_ns;
+	if (pipe(pipe_fds) < 0)
+		goto cleanup_fds;
+	flags = fcntl(pipe_fds[0], F_GETFL, 0);
+	if (flags < 0 || fcntl(pipe_fds[0], F_SETFL, flags | O_NONBLOCK) < 0)
+		goto cleanup_fds;
+	helper_pid = fork();
+	if (helper_pid < 0)
+		goto cleanup_fds;
+	if (helper_pid == 0) {
+		close(pipe_fds[0]);
+		java_preflight_version_helper(exe_path, envp, pid_ns_fd,
+						      mnt_ns_fd, pipe_fds[1]);
+		_exit(124);
 	}
-
-	ebpf_info(JAVA_LOG_TAG
-		  "JAVA_VERSION_SETNS pid=%d pid_ns=%d mnt_ns=%d\n", pid,
-		  pid_ns_ret, mnt_ns_ret);
-	command_ret = exec_command(command, "", output, sizeof(output));
-	if (command_ret == 0) {
-		java_preflight_parse_version_output(output, info);
-		version_ok = info->java_version[0] != '\0';
-	}
-
-restore_ns:
-	/* Restore in reverse order so later Agent children keep the original
-	 * namespaces. */
-	df_exit_ns(mnt_self_fd);
-	df_exit_ns(pid_self_fd);
-	if (!java_preflight_verify_namespace_restore(&original_pid_ns,
-						    &original_mnt_ns)) {
+	close(pipe_fds[1]);
+	pipe_fds[1] = -1;
+	setpgid(helper_pid, helper_pid);
+	if (!java_preflight_wait_helper(helper_pid, pipe_fds[0], output,
+						 sizeof(output))) {
 		ebpf_warning(JAVA_LOG_TAG
-			     "JAVA_VERSION_NS_RESTORE_FAILED pid=%d\n", pid);
-		return false;
+			     "JAVA_VERSION_HELPER_FAILED_OR_TIMEOUT pid=%d "
+			     "timeout=%dms\n", pid,
+			     JAVA_PREFLIGHT_VERSION_TIMEOUT_MS);
+		pipe_fds[0] = -1;
+		goto cleanup_fds;
 	}
+	pipe_fds[0] = -1;
+	java_preflight_parse_version_output(output, info);
+	version_ok = info->java_version[0] != '\0';
+	ebpf_info(JAVA_LOG_TAG
+		  "JAVA_VERSION_HELPER pid=%d pid_ns=%s mnt_ns=%s\n", pid,
+		  same_pid_ns ? "same" : "target",
+		  same_mnt_ns ? "same" : "target");
+
+cleanup_fds:
+	if (pipe_fds[0] >= 0)
+		close(pipe_fds[0]);
+	if (pipe_fds[1] >= 0)
+		close(pipe_fds[1]);
+	if (pid_ns_fd >= 0)
+		close(pid_ns_fd);
+	if (mnt_ns_fd >= 0)
+		close(mnt_ns_fd);
 	return version_ok;
 }
 
@@ -760,13 +901,16 @@ static bool java_preflight_parse_version(const char *version, int *major,
  *    already loaded Agent is not a rejection condition because a valid reattach
  *    may call Agent_OnAttach again.
  *
+
  * 3. Target JVM version check: obtain -version only for HotSpot. Read the
  *    target exe, maps and NUL-separated environ first; build the target
- *    LD_LIBRARY_PATH, then setns into the target PID/mount namespaces before
- *    popen() creates the short-lived Java child. Restore both namespace
- *    selections after pclose(), and verify that later children use the original
- *    namespaces. Skip conservatively when namespace setup, command execution,
- *    or version parsing fails. Skip HotSpot Java 8 updates below 352 because
+ *    LD_LIBRARY_PATH, then fork a short-lived helper. The helper enters the
+ *    target PID/mount namespaces and forks a runner that directly execve()s
+ *    the target Java executable. The parent drains the output and applies a
+ *    bounded timeout; the helper exits after the runner finishes, so the Agent
+ *    process and its later children never enter the target namespaces. Skip
+ *    conservatively when namespace setup, command execution, timeout, or
+ *    version parsing fails. Skip HotSpot Java 8 updates below 352 because
  *    the first fix is missing; also skip 352-381 because the 8u-specific Sweeper
  *    protection is incomplete. Only 382 and newer meet the current complete-fix
  *    baseline. This is a patch completeness gate, not a claim that every update

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.c
@@ -17,7 +17,9 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <sys/select.h>
+#include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -47,6 +49,681 @@ static __thread java_unload_addr_str_t *unload_addrs;
 extern int jattach(int pid, int argc, char **argv, int print_output);
 static int create_symbol_collect_task(pid_t pid, options_t * opts,
 				      bool is_same_mntns);
+
+/* Set a readable failure reason for the preflight result. */
+static void java_preflight_set_reason(java_preflight_info_t *info,
+					      const char *reason)
+{
+	if (info == NULL)
+		return;
+	if (reason == NULL)
+		reason = "unknown";
+	strncpy(info->reason, reason, sizeof(info->reason) - 1);
+	info->reason[sizeof(info->reason) - 1] = '\0';
+}
+
+/* Read the target executable path and strip the exit marker. */
+static bool java_preflight_readlink(pid_t pid, char *path, size_t path_len)
+{
+	char proc_path[64];
+	ssize_t len;
+
+	if (path == NULL || path_len < 2)
+		return false;
+	snprintf(proc_path, sizeof(proc_path), "/proc/%d/exe", pid);
+	len = readlink(proc_path, path, path_len - 1);
+	if (len < 0)
+		return false;
+	path[len] = '\0';
+	/* readlink may return a path with the deleted suffix while a process exits. */
+	char *deleted = strstr(path, " (deleted)");
+	if (deleted != NULL)
+		*deleted = '\0';
+	return path[0] == '/';
+}
+
+/* Check whether the target process has exited or entered the zombie state. */
+static bool java_preflight_process_is_zombie(pid_t pid)
+{
+	char path[64], line[4096];
+	FILE *fp;
+	char *right_paren;
+
+	snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+	fp = fopen(path, "r");
+	if (fp == NULL)
+		return true;
+	if (fgets(line, sizeof(line), fp) == NULL) {
+		fclose(fp);
+		return true;
+	}
+	fclose(fp);
+
+	/* comm may contain spaces and parentheses; the state follows the last ')'. */
+	right_paren = strrchr(line, ')');
+	if (right_paren == NULL || right_paren[1] != ' ' || right_paren[2] == '\0')
+		return true;
+	return right_paren[2] == 'Z' || right_paren[2] == 'X';
+}
+
+/* Extract a mapped file path from a maps line and strip an exit-time deleted marker. */
+static bool java_preflight_map_path(const char *line, char *path,
+					    size_t path_len)
+{
+	char *deleted;
+	char *end;
+	int parsed;
+
+	if (line == NULL || path == NULL || path_len < 2)
+		return false;
+	parsed = sscanf(line, "%*s %*s %*s %*s %*s %4095[^\n]", path);
+	if (parsed != 1)
+		return false;
+	path[path_len - 1] = '\0';
+	deleted = strstr(path, " (deleted)");
+	if (deleted != NULL)
+		*deleted = '\0';
+	end = path + strlen(path);
+	while (end > path && isspace((unsigned char)end[-1]))
+		*--end = '\0';
+	return path[0] == '/';
+}
+
+/* Check whether a maps filename is an OpenJ9 VM core library. */
+static bool java_preflight_is_openj9_library(const char *name)
+{
+	const char *suffix;
+
+	if (name == NULL || strncmp(name, "libj9vm", 7) != 0)
+		return false;
+	suffix = name + 7;
+	if (*suffix == '.')
+		return strcmp(suffix, ".so") == 0;
+	while (isdigit((unsigned char)*suffix))
+		suffix++;
+	return strcmp(suffix, ".so") == 0;
+}
+
+/* Scan the target maps and distinguish HotSpot from other known JVMs. */
+static bool java_preflight_maps(pid_t pid, java_preflight_info_t *info)
+{
+	char maps_path[64], line[PATH_MAX + 256];
+	char mapped_path[PATH_MAX];
+	FILE *fp;
+	bool found_libjvm = false;
+	bool found_other_jvm = false;
+
+	snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
+	fp = fopen(maps_path, "r");
+	if (fp == NULL)
+		return false;
+	while (fgets(line, sizeof(line), fp) != NULL) {
+		char *slash;
+
+		if (!java_preflight_map_path(line, mapped_path,
+					     sizeof(mapped_path)))
+			continue;
+		slash = strrchr(mapped_path, '/');
+		if (slash == NULL)
+			slash = mapped_path;
+		else
+			slash++;
+		if (java_preflight_is_openj9_library(slash)) {
+			/* OpenJ9 may also map a compatibility libjvm.so; prefer libj9vm. */
+			found_other_jvm = true;
+			continue;
+		}
+		if (strcmp(slash, "libjvm.so") == 0) {
+			found_libjvm = true;
+		}
+	}
+	fclose(fp);
+	if (found_other_jvm) {
+		info->is_other_jvm = true;
+		return true;
+	}
+	if (found_libjvm) {
+		info->is_hotspot = true;
+		return true;
+	}
+	return false;
+}
+
+/* Copy a selected range from -version output without relying on release format. */
+static void java_preflight_copy_range(const char *start, const char *end,
+					      char *dst, size_t dst_len)
+{
+	size_t len;
+
+	if (start == NULL || end == NULL || dst == NULL || dst_len == 0 ||
+	    end < start) {
+		return;
+	}
+	len = (size_t)(end - start);
+	if (len >= dst_len)
+		len = dst_len - 1;
+	memcpy(dst, start, len);
+	dst[len] = '\0';
+}
+
+/* Parse JAVA_VERSION from the target JVM -version output. */
+static void java_preflight_parse_version_output(const char *output,
+						java_preflight_info_t *info)
+{
+	const char *start;
+	const char *end;
+
+	if (output == NULL || info == NULL)
+		return;
+	/* The standard first output line looks like openjdk version "1.8.0_412". */
+	start = strstr(output, "version \"");
+	if (start == NULL)
+		return;
+	start += strlen("version \"");
+	end = strchr(start, '"');
+	java_preflight_copy_range(start, end, info->java_version,
+				  sizeof(info->java_version));
+}
+
+/* Derive the search path for JVM libraries such as libjli.so from maps and exe. */
+static void java_preflight_build_library_path(pid_t pid,
+					       const char *exe_path, char *path,
+					       size_t path_len)
+{
+	char maps_path[64], line[PATH_MAX + 256], mapped_path[PATH_MAX];
+	FILE *fp;
+
+	if (path == NULL || path_len == 0)
+		return;
+	path[0] = '\0';
+	snprintf(maps_path, sizeof(maps_path), "/proc/%d/maps", pid);
+	fp = fopen(maps_path, "r");
+	if (fp != NULL) {
+		while (fgets(line, sizeof(line), fp) != NULL) {
+			char *slash;
+			if (!java_preflight_map_path(line, mapped_path,
+					     sizeof(mapped_path)))
+				continue;
+			slash = strrchr(mapped_path, '/');
+			if (slash == NULL)
+				continue;
+			if (strcmp(slash + 1, "libjvm.so") != 0)
+				continue;
+			*slash = '\0';
+			slash = strrchr(mapped_path, '/');
+			if (slash == NULL || strcmp(slash + 1, "server") != 0)
+				continue;
+			*slash = '\0';
+			snprintf(path, path_len, "%s/jli:%s:%s/server", mapped_path,
+				 mapped_path, mapped_path);
+			break;
+		}
+		fclose(fp);
+	}
+	if (path[0] != '\0')
+		return;
+
+	/* If maps cannot be read, derive common architecture directories from the
+	 * standard <jre>/bin/java layout. */
+	if (exe_path != NULL && exe_path[0] == '/') {
+		char runtime_root[PATH_MAX];
+		char *slash = strrchr(exe_path, '/');
+		if (slash != NULL) {
+			size_t len = (size_t)(slash - exe_path);
+			if (len >= sizeof(runtime_root))
+				len = sizeof(runtime_root) - 1;
+			memcpy(runtime_root, exe_path, len);
+			runtime_root[len] = '\0';
+			slash = strrchr(runtime_root, '/');
+			if (slash != NULL && strcmp(slash + 1, "bin") == 0) {
+				*slash = '\0';
+				snprintf(path, path_len,
+					 "%s/lib/amd64/jli:%s/lib/amd64:%s/lib/amd64/server:"
+					 "%s/lib/aarch64/jli:%s/lib/aarch64:%s/lib/aarch64/server",
+					 runtime_root, runtime_root, runtime_root,
+					 runtime_root, runtime_root, runtime_root);
+			}
+		}
+	}
+}
+
+/* Single-quote shell arguments so special characters in Java paths are inert. */
+static bool java_preflight_shell_quote(const char *value, char *quoted,
+					       size_t quoted_len)
+{
+	size_t used = 0;
+	size_t i;
+
+	if (value == NULL || quoted == NULL || quoted_len < 3)
+		return false;
+	quoted[used++] = '\'';
+	for (i = 0; value[i] != '\0'; i++) {
+		if (value[i] == '\'') {
+			/* A shell single quote must be encoded as '\'' . */
+			if (used + 4 >= quoted_len)
+				return false;
+			memcpy(quoted + used, "'\\''", 4);
+			used += 4;
+		} else {
+			if (used + 1 >= quoted_len)
+				return false;
+			quoted[used++] = value[i];
+		}
+	}
+	if (used + 2 > quoted_len)
+		return false;
+	quoted[used++] = '\'';
+	quoted[used] = '\0';
+	return true;
+}
+
+/* Check whether the target namespace has the minimal environment required by popen. */
+static bool java_preflight_target_command_env(pid_t pid)
+{
+	static const char *required[] = {
+		"/bin/sh",
+		"/usr/bin/env",
+		"/bin/env",
+		"/usr/bin/timeout",
+		"/bin/timeout",
+	};
+	char path[PATH_MAX + 64];
+	bool has_shell = false;
+	bool has_env = false;
+	bool has_timeout = false;
+	size_t i;
+
+	for (i = 0; i < sizeof(required) / sizeof(required[0]); i++) {
+		snprintf(path, sizeof(path), "/proc/%d/root%s", pid, required[i]);
+		if (access(path, X_OK) != 0)
+			continue;
+		if (strcmp(required[i], "/bin/sh") == 0)
+			has_shell = true;
+		if (strcmp(required[i], "/usr/bin/env") == 0 ||
+		    strcmp(required[i], "/bin/env") == 0)
+			has_env = true;
+		if (strcmp(required[i], "/usr/bin/timeout") == 0 ||
+		    strcmp(required[i], "/bin/timeout") == 0)
+			has_timeout = true;
+	}
+	return has_shell && has_env && has_timeout;
+}
+
+/* Find a command in the current namespace for the minimal-namespace fallback. */
+static const char *java_preflight_host_command(const char *name)
+{
+	static const char *const env_paths[] = { "/usr/bin/env", "/bin/env" };
+	static const char *const timeout_paths[] = {
+		"/usr/bin/timeout", "/bin/timeout"
+	};
+	static const char *const nsenter_paths[] = {
+		"/usr/bin/nsenter", "/bin/nsenter"
+	};
+	const char *const *paths;
+	size_t count;
+	size_t i;
+
+	if (strcmp(name, "env") == 0) {
+		paths = env_paths;
+		count = sizeof(env_paths) / sizeof(env_paths[0]);
+	} else if (strcmp(name, "timeout") == 0) {
+		paths = timeout_paths;
+		count = sizeof(timeout_paths) / sizeof(timeout_paths[0]);
+	} else {
+		paths = nsenter_paths;
+		count = sizeof(nsenter_paths) / sizeof(nsenter_paths[0]);
+	}
+	for (i = 0; i < count; i++) {
+		if (access(paths[i], X_OK) == 0)
+			return paths[i];
+	}
+	return NULL;
+}
+
+/* Execute the target JVM -version in its PID/mount namespace and capture output. */
+static bool java_preflight_exec_version(pid_t pid, const char *exe_path,
+					java_preflight_info_t *info)
+{
+	char library_path[PATH_MAX * 2] = {};
+	char quoted_library[PATH_MAX * 8 + 8] = {};
+	char quoted_exe[PATH_MAX * 4 + 8] = {};
+	char command_args[PATH_MAX * 12 + 256] = {};
+	char output[16384] = {};
+	bool version_ok = false;
+	bool same_mntns;
+	bool use_host_nsenter = false;
+	const char *env_path;
+	const char *host_timeout;
+	const char *host_nsenter;
+	int command_ret;
+	int ns_ret;
+	int pid_self_fd = -1;
+	int mnt_self_fd = -1;
+
+	if (exe_path == NULL || exe_path[0] != '/' || info == NULL)
+		return false;
+	java_preflight_build_library_path(pid, exe_path, library_path,
+						  sizeof(library_path));
+	/* Check the mount namespace first; do not setns or restore for the same namespace. */
+	same_mntns = is_same_mntns(pid);
+	/* If a minimal POD lacks shell/env/timeout, use host nsenter to run Java directly. */
+	if (!same_mntns && !java_preflight_target_command_env(pid))
+		use_host_nsenter = true;
+	/*
+	 * The normal path enters the target PID/mount namespace before calling
+	 * exec_command. setns changes only this thread, so other Agent threads are
+	 * unaffected; the popen child created by exec_command inherits the target
+	 * namespace and resolves the Java path inside the POD. If the minimal target
+	 * namespace has no /bin/sh, host nsenter creates the Java child instead.
+	 */
+	if (!same_mntns && !use_host_nsenter) {
+		/* The PID namespace affects only children; return 0 may still mean the
+		 * target PID could not be read. */
+		ns_ret = df_enter_ns(pid, "pid", &pid_self_fd);
+		if (ns_ret < 0)
+			goto restore_ns;
+		ns_ret = df_enter_ns(pid, "mnt", &mnt_self_fd);
+		/* A different mount namespace without a saved restore fd means switching failed. */
+		if (ns_ret < 0 || mnt_self_fd < 0)
+			goto restore_ns;
+	}
+	if (use_host_nsenter) {
+		/* The target namespace lacks shell/env/timeout, so popen cannot run there. */
+		env_path = java_preflight_host_command("env");
+		host_timeout = java_preflight_host_command("timeout");
+		host_nsenter = java_preflight_host_command("nsenter");
+		if (env_path == NULL || host_timeout == NULL || host_nsenter == NULL)
+			goto restore_ns;
+		ebpf_info(JAVA_LOG_TAG
+			  "JAVA_VERSION_NSENTER_FALLBACK pid=%d reason=target_runtime_helper_missing\n",
+			  pid);
+	} else {
+		/* The target container may place env in /usr/bin or /bin. */
+		if (access("/usr/bin/env", X_OK) == 0)
+			env_path = "/usr/bin/env";
+		else if (access("/bin/env", X_OK) == 0)
+			env_path = "/bin/env";
+		else
+			goto restore_ns;
+	}
+	if (!java_preflight_shell_quote(library_path, quoted_library,
+					 sizeof(quoted_library)) ||
+	    !java_preflight_shell_quote(exe_path, quoted_exe,
+					 sizeof(quoted_exe)))
+		goto restore_ns;
+	/*
+	 * exec_command uses popen(), so the command inherits the namespace entered by
+	 * this thread. The outer env sanitizes the Agent environment, timeout imposes
+	 * a five-second limit, and the inner env sets the target Java library path.
+	 */
+	if (use_host_nsenter) {
+		/* Host env sanitizes the environment; nsenter enters the target namespace
+		 * and directly execs Java. */
+		snprintf(command_args, sizeof(command_args),
+			 "-i PATH=/usr/bin:/bin HOME=/tmp LD_LIBRARY_PATH=%s %s 5 "
+			 "%s --target %d --mount --pid -- %s -version 2>&1",
+			 quoted_library, host_timeout, host_nsenter, pid, quoted_exe);
+	} else {
+		snprintf(command_args, sizeof(command_args),
+			 "-i PATH=/usr/bin:/bin HOME=/tmp timeout 5 %s -i "
+			 "PATH=/usr/bin:/bin HOME=/tmp LD_LIBRARY_PATH=%s %s -version 2>&1",
+			 env_path, quoted_library, quoted_exe);
+	}
+	command_ret = exec_command(env_path, command_args, output,
+					 sizeof(output));
+	if (command_ret == 0) {
+		java_preflight_parse_version_output(output, info);
+		version_ok = info->java_version[0] != '\0';
+	}
+
+restore_ns:
+	/* Restore this thread's namespace only when crossing mount namespaces. */
+	if (!same_mntns && !use_host_nsenter) {
+		/* Restore this thread's namespaces in reverse entry order. */
+		df_exit_ns(mnt_self_fd);
+		df_exit_ns(pid_self_fd);
+	}
+	return version_ok;
+}
+
+/* Find a JVM option in NUL-separated cmdline or environ data. */
+/* Return 1 if found, 0 if absent, and -1 if reading failed. */
+static int java_preflight_proc_contains(pid_t pid, const char *name,
+					       const char *needle)
+{
+	char path[64], buf[4096];
+	FILE *fp;
+	size_t n, total, carry, needle_len, i;
+
+	snprintf(path, sizeof(path), "/proc/%d/%s", pid, name);
+	fp = fopen(path, "rb");
+	if (fp == NULL)
+		return -1;
+	needle_len = strlen(needle);
+	if (needle_len == 0 || needle_len >= sizeof(buf)) {
+		fclose(fp);
+		return 0;
+	}
+	/* Keep the previous chunk tail so options crossing an fread() boundary are found. */
+	carry = 0;
+	while ((n = fread(buf + carry, 1, sizeof(buf) - 1 - carry, fp)) > 0) {
+		total = carry + n;
+		/* cmdline and environ use NUL separators; byte comparison covers every option. */
+		for (i = 0; i + needle_len <= total; i++) {
+			if (memcmp(buf + i, needle, needle_len) == 0) {
+				fclose(fp);
+				return 1;
+			}
+		}
+		carry = needle_len - 1;
+		if (carry > total)
+			carry = total;
+		if (carry > 0)
+			memmove(buf, buf + total - carry, carry);
+	}
+	if (ferror(fp)) {
+		fclose(fp);
+		return -1;
+	}
+	fclose(fp);
+	return 0;
+}
+
+/* Parse the Java version and extract the Java 8 update number. */
+static bool java_preflight_parse_version(const char *version, int *major,
+						 int *update)
+{
+	const char *p = version;
+	char *end;
+	long first, second = -1;
+
+	if (version == NULL || major == NULL || update == NULL || *version == '\0')
+		return false;
+	if (!isdigit((unsigned char)*p))
+		return false;
+	first = strtol(p, &end, 10);
+	if (end == p || first < 0 || first > INT_MAX)
+		return false;
+	if (*end == '.' && end[1] != '\0' && isdigit((unsigned char)end[1])) {
+		second = strtol(end + 1, &end, 10);
+	}
+	if (first == 1 && second >= 0) {
+		*major = (int)second;
+	} else {
+		*major = (int)first;
+	}
+	*update = -1;
+	if (*major == 8) {
+		const char *u = strchr(version, '_');
+		long parsed;
+		if (u == NULL)
+			u = strchr(version, 'u');
+		if (u != NULL && isdigit((unsigned char)u[1])) {
+			parsed = strtol(u + 1, &end, 10);
+			if (parsed < 0 || parsed > INT_MAX)
+				return false;
+			if (*end != '\0' && *end != '-' && *end != '+')
+				return false;
+			*update = (int)parsed;
+		} else if (first == 8 && *end == '.' &&
+			   isdigit((unsigned char)end[1])) {
+			/* Also accept version strings in the 8.0.382 form. */
+			parsed = strtol(end + 1, &end, 10);
+			if (parsed < 0 || parsed > INT_MAX)
+				return false;
+			*update = (int)parsed;
+			if (*end != '\0' && *end != '-' && *end != '+')
+				return false;
+		}
+		if (*update < 0)
+			return false;
+	}
+	return true;
+}
+
+/*
+ * Core JVM attach preflight entry point.
+ *
+ * This is the shared version gate for the main Agent and deepflow-jattach.
+ * The checks run in the following order:
+ *
+ * 1. Process state check: read /proc/<pid>/stat and exclude exited or zombie
+ *    processes. Record the PID start time and exe for later PID-reuse checks.
+ *
+ * 2. JVM map check: read /proc/<pid>/maps and identify HotSpot libjvm.so or
+ *    another known JVM core library, such as OpenJ9 libj9vm. If neither is
+ *    found, the target is not a recognizable JVM and the result is skip. An
+ *    already loaded Agent is not a rejection condition because a valid reattach
+ *    may call Agent_OnAttach again.
+ *
+ * 3. Target JVM version check: obtain -version only for HotSpot. Read the
+ *    target exe and maps first; when the target and Agent use different mount
+ *    namespaces, enter the target PID/mount namespace with df_enter_ns, launch
+ *    a short-lived version child, then restore with df_exit_ns. Do not switch
+ *    namespaces when they are the same. This makes Host/POD checks use the
+ *    target filesystem without relying on a release file. Skip conservatively
+ *    when the command fails or the Java version cannot be parsed. Skip HotSpot
+ *    Java 8 updates below 352 because the first fix is missing; also skip
+ *    352-381 because the 8u-specific Sweeper protection is incomplete. Only
+ *    382 and newer meet the current complete-fix baseline. This is a patch
+ *    completeness gate, not a claim that every update below 382 reproduced the
+ *    crash. Non-HotSpot JVMs do not run these specialized checks.
+ *
+ * 4. Attach capability check: read the target cmdline and environ. Skip when
+ *    -XX:+DisableAttachMechanism is present to avoid an injection that must
+ *    fail; if either file cannot be read, capability cannot be confirmed and
+ *    the result is also a conservative skip.
+ *
+ * 5. Race recheck: read the PID start time and exe again. If the process exits,
+ *    the PID is reused, or the exe changes during the check, discard the result
+ *    instead of applying it to another process.
+ *
+ * Return JAVA_PREFLIGHT_ALLOW only after every check passes. Only then may the
+ * caller create a socket, copy the Agent SO, and invoke jattach; every skip
+ * result must stop the injection flow.
+ */
+java_preflight_result_t java_attach_preflight(pid_t pid,
+					      java_preflight_info_t *info)
+{
+	char exe_before[PATH_MAX], exe_after[PATH_MAX];
+	u64 start_before, start_after;
+	int cmdline_check;
+	int environ_check;
+
+	if (info == NULL)
+		return JAVA_PREFLIGHT_ERROR;
+	memset(info, 0, sizeof(*info));
+	info->update_version = -1;
+	if (pid <= 0) {
+		java_preflight_set_reason(info, "invalid_pid");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (java_preflight_process_is_zombie(pid)) {
+		java_preflight_set_reason(info, "zombie_or_exited");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	start_before = get_process_starttime_and_comm(pid, NULL, 0);
+	if (start_before == 0 || !java_preflight_readlink(pid, exe_before,
+							 sizeof(exe_before))) {
+		java_preflight_set_reason(info, "process_not_readable");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (!java_preflight_maps(pid, info)) {
+		java_preflight_set_reason(info, "jvm_not_mapped");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (info->is_hotspot &&
+	    !java_preflight_exec_version(pid, exe_before, info)) {
+		/* A failed version check cannot verify the 8u382 gate; skip attach. */
+		java_preflight_set_reason(info, "version_command_failed");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (info->is_hotspot) {
+		if (info->java_version[0] == '\0' ||
+		    !java_preflight_parse_version(info->java_version,
+						   &info->major_version,
+						   &info->update_version)) {
+			java_preflight_set_reason(info, "unrecognized_java_version");
+			return JAVA_PREFLIGHT_SKIP;
+		}
+	}
+	cmdline_check = java_preflight_proc_contains(
+		pid, "cmdline", "-XX:+DisableAttachMechanism");
+	environ_check = java_preflight_proc_contains(
+		pid, "environ", "-XX:+DisableAttachMechanism");
+	if (cmdline_check < 0 || environ_check < 0) {
+		/* Unreadable JVM options prevent confirming attach capability; skip. */
+		java_preflight_set_reason(info, "attach_options_unreadable");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (cmdline_check > 0 || environ_check > 0) {
+		info->attach_disabled = true;
+		java_preflight_set_reason(info, "attach_disabled");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	if (info->is_hotspot && info->major_version == 8 &&
+	    info->update_version < JAVA_ATTACH_JAVA8_COMPLETE_FIX_UPDATE) {
+		/*
+		 * The attach baseline requires both standard fixes. Every Java 8 update
+		 * below 8u382 is conservatively treated as missing the complete fix set,
+		 * and one unified reason is used instead of classifying the update range.
+		 */
+		java_preflight_set_reason(
+			info,
+			"hotspot_java8_missing_JDK-8173361_and_JDK-8305165_crash_risk");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+	start_after = get_process_starttime_and_comm(pid, NULL, 0);
+	if (start_after == 0 || start_after != start_before ||
+	    !java_preflight_readlink(pid, exe_after, sizeof(exe_after)) ||
+	    strcmp(exe_before, exe_after) != 0) {
+		java_preflight_set_reason(info, "pid_reused_or_exe_changed");
+		return JAVA_PREFLIGHT_SKIP;
+	}
+
+	java_preflight_set_reason(info, "allowed");
+	return JAVA_PREFLIGHT_ALLOW;
+}
+
+/* Convert the preflight result to Agent state and emit the common log. */
+static int java_preflight_status(pid_t pid,
+				 java_preflight_result_t result,
+				 const java_preflight_info_t *info)
+{
+	const char *required;
+
+	if (result == JAVA_PREFLIGHT_ALLOW)
+		return 0;
+	if (info != NULL) {
+		required = info->is_hotspot ? "8u382+" : "none";
+		ebpf_warning(JAVA_LOG_TAG
+			     "JAVA_ATTACH_SKIP pid=%d reason=%s jvm=%s required=%s\n", pid,
+			     info->reason[0] ? info->reason : "unknown",
+			     info->java_version[0] ? info->java_version : "unknown",
+			     required);
+	}
+	return JAVA_ATTACH_SKIPPED_UNSUPPORTED_JVM;
+}
 
 bool test_dl_open(const char *so_lib_file_path)
 {
@@ -920,6 +1597,13 @@ static int create_symbol_collect_task(pid_t pid, options_t * opts,
 	int ret = -1;
 	symbol_collect_task_t *task = NULL;
 	int map_socket = -1, log_socket = -1;
+	java_preflight_info_t preflight_info;
+	java_preflight_result_t preflight_result;
+
+	/* The second check covers the window between process discovery and task creation. */
+	preflight_result = java_attach_preflight(pid, &preflight_info);
+	if (preflight_result != JAVA_PREFLIGHT_ALLOW)
+		return java_preflight_status(pid, preflight_result, &preflight_info);
 
 	// make the sockets accessable from unprivileged user in container
 	umask(0);
@@ -976,6 +1660,11 @@ static int create_symbol_collect_task(pid_t pid, options_t * opts,
 	memset(ret_buf, 0, sizeof(ret_buf));
 	ret =
 	    exec_command(DF_JAVA_ATTACH_CMD, buffer, ret_buf, sizeof(ret_buf));
+	/* deepflow-jattach is a separate process; negative skip codes become 254/253
+	 * through the shell, so restore the original policy result for structured logs. */
+	if (ret != 0 && strstr(ret_buf, "JAVA_ATTACH_SKIP") != NULL) {
+		ret = JAVA_ATTACH_SKIPPED_UNSUPPORTED_JVM;
+	}
 	if (ret != 0) {
 		ebpf_warning(JAVA_LOG_TAG "ret %d: %s", ret, ret_buf);
 	}
@@ -1092,8 +1781,20 @@ static symbol_collect_task_t *get_task_by_pid(pid_t pid)
 	return task;
 }
 
+/*
+ * First gate for the main Agent: it must run before the thread pool, socket,
+ * and collector are created.
+ */
 int start_java_symbol_collection(pid_t pid, const char *opts)
 {
+	java_preflight_info_t preflight_info;
+	java_preflight_result_t preflight_result;
+
+	/* If the JVM is rejected, do not initialize the collector or create a socket. */
+	preflight_result = java_attach_preflight(pid, &preflight_info);
+	if (preflight_result != JAVA_PREFLIGHT_ALLOW)
+		return java_preflight_status(pid, preflight_result, &preflight_info);
+
 	// Initialize a thread pool for managing Java symbols.
 	if (g_collect_pool == NULL) {
 		if (symbol_collect_thread_pool_init()) {
@@ -1412,9 +2113,22 @@ static int attach(pid_t pid, char *opts)
 	return ret;
 }
 
+/*
+ * Second gate for deepflow-jattach: it must run before namespace switching,
+ * SO preparation, and jattach invocation to avoid a check race between the
+ * main Agent and the standalone tool.
+ */
 int java_attach(pid_t pid)
 {
 	int ret = -1;
+	java_preflight_info_t preflight_info;
+	java_preflight_result_t preflight_result;
+
+	/* Defense in depth: run the check again immediately before preparing jattach. */
+	preflight_result = java_attach_preflight(pid, &preflight_info);
+	if (preflight_result != JAVA_PREFLIGHT_ALLOW)
+		return java_preflight_status(pid, preflight_result, &preflight_info);
+
 	bool is_same_mnt = is_same_mntns(pid);
 	if (is_same_mnt) {
 		ret = prepare_for_attach_same_ns(pid);

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
@@ -24,6 +24,68 @@
 
 #define DF_JAVA_ATTACH_CMD "/usr/bin/deepflow-jattach"
 
+/* Complete fix update boundary for standard OpenJDK 8u. */
+#define JAVA_ATTACH_JAVA8_COMPLETE_FIX_UPDATE 382
+
+/*
+ * Standard OpenJDK Java 8u0-8u351 lacks JDK-8173361, while 8u352-8u381
+ * still lacks JDK-8305165. Neither range can be considered safe from the
+ * version alone. The complete-fix baseline is 8u382; HotSpot versions below
+ * this baseline are not injected by the profiling agent. Keep the policy here
+ * so the Agent and standalone attach tool use the same decision.
+ */
+#define JAVA_ATTACH_SKIPPED_UNSUPPORTED_JVM (-2)
+#define JAVA_PREFLIGHT_VERSION_LEN 128
+
+typedef enum {
+	JAVA_PREFLIGHT_ALLOW = 0,
+	JAVA_PREFLIGHT_SKIP = 1,
+	JAVA_PREFLIGHT_ERROR = 2,
+} java_preflight_result_t;
+
+typedef struct {
+	int major_version; /**< Java major version. */
+	int update_version; /**< Java 8 update version. */
+	bool is_hotspot; /**< Whether a HotSpot libjvm.so was detected. */
+	bool is_other_jvm; /**< Whether another known JVM, such as OpenJ9, was detected. */
+	bool attach_disabled; /**< Whether DisableAttachMechanism is set. */
+	char java_version[JAVA_PREFLIGHT_VERSION_LEN]; /**< JAVA_VERSION value. */
+	char reason[JAVA_PREFLIGHT_VERSION_LEN]; /**< Preflight result reason. */
+} java_preflight_info_t;
+
+/**
+ * Core JVM attach preflight entry point.
+ *
+ * The check must finish before creating a socket, copying the Agent SO, or
+ * calling jattach, and it cannot use the Attach API. Therefore this function
+ * must not call jcmd, jinfo, or jattach, or load code into the target process.
+ * When the target JVM runs on the Host or in a POD with a different mount
+ * namespace, run the version command in the target PID/mount namespace rather
+ * than using the Agent filesystem; in the same namespace, use the target exe.
+ *
+ * The result has the following meaning:
+ * - Process check failure: the target exited, is a zombie, or its PID is unreadable;
+ *   skip attach.
+ * - JVM map check failure: neither HotSpot libjvm.so nor another known JVM core
+ *   library was found; the target cannot be identified as a JVM, so skip attach.
+ * - Non-HotSpot JVM: for example, OpenJ9 skips the HotSpot version gate and is
+ *   allowed after the common safety checks.
+ * - HotSpot: execute the target JVM's own -version in the target namespace,
+ *   without relying on a release file; parse JAVA_VERSION for Java 8 update.
+ *   Do not switch namespaces when both processes already share one.
+ * - HotSpot Java 8 update below 352: the first known fix is missing; skip attach.
+ * - HotSpot Java 8 update 352-381: partial fixes are present, but the 8u-specific
+ *   Sweeper protection is missing; skip attach under the current policy.
+ * - HotSpot Java 8 update 382 or newer: both standard OpenJDK fixes are present;
+ *   continue with the remaining checks.
+ * - Attach is disabled, cmdline/environ cannot be read, or the PID is reused
+ *   during the check: skip attach without injection.
+ * - All checks pass: return allow so the caller may create the socket, copy the
+ *   Agent SO, and invoke jattach.
+ */
+java_preflight_result_t java_attach_preflight(pid_t pid,
+					      java_preflight_info_t *info);
+
 /*
  * The address range of the 64-bit user space is from 0x0000000000000000
  * to 0x00007fffffffffff, which effectively uses only 48 bits. We use 13

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
@@ -25,14 +25,15 @@
 #define DF_JAVA_ATTACH_CMD "/usr/bin/deepflow-jattach"
 
 /* Complete fix update boundary for standard OpenJDK 8u. */
+#define JAVA_ATTACH_JAVA8_FIRST_FIX_UPDATE 352
 #define JAVA_ATTACH_JAVA8_COMPLETE_FIX_UPDATE 382
 
 /*
- * Standard OpenJDK Java 8u0-8u351 lacks JDK-8173361, while 8u352-8u381
- * still lacks JDK-8305165. Neither range can be considered safe from the
- * version alone. The complete-fix baseline is 8u382; HotSpot versions below
- * this baseline are not injected by the profiling agent. Keep the policy here
- * so the Agent and standalone attach tool use the same decision.
+ * Standard OpenJDK Java 8u0-8u351 lacks both JDK-8173361 and JDK-8305165,
+ * while 8u352-8u381 still lacks JDK-8305165. Neither range can be considered
+ * safe from the version alone. The complete-fix baseline is 8u382; HotSpot
+ * versions below this baseline are not injected by the profiling agent. Keep
+ * the policy here so the Agent and standalone attach tool use the same decision.
  */
 #define JAVA_ATTACH_SKIPPED_UNSUPPORTED_JVM (-2)
 #define JAVA_PREFLIGHT_VERSION_LEN 128
@@ -74,9 +75,9 @@ typedef struct {
  * - HotSpot: execute the target JVM's own -version in the target namespace,
  *   without relying on a release file; parse JAVA_VERSION for Java 8 update.
  *   Do not switch namespaces when both processes already share one.
- * - HotSpot Java 8 update below 352: the first known fix is missing; skip attach.
- * - HotSpot Java 8 update 352-381: partial fixes are present, but the 8u-specific
- *   Sweeper protection is missing; skip attach under the current policy.
+ * - HotSpot Java 8 update below 352: both known fixes are missing; skip attach.
+ * - HotSpot Java 8 update 352-381: JDK-8173361 is present, but JDK-8305165 is
+ *   missing; skip attach under the current policy.
  * - HotSpot Java 8 update 382 or newer: both standard OpenJDK fixes are present;
  *   continue with the remaining checks.
  * - Attach is disabled, cmdline/environ cannot be read, or the PID is reused

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
@@ -59,9 +59,10 @@ typedef struct {
  * The check must finish before creating a socket, copying the Agent SO, or
  * calling jattach, and it cannot use the Attach API. Therefore this function
  * must not call jcmd, jinfo, or jattach, or load code into the target process.
- * Run the version command with the target Java executable and environment after
- * entering the target PID/mount namespaces; restore both namespace selections
- * before returning so later Agent children keep the original namespaces.
+ * Run the version command with the target Java executable and environment in a
+ * short-lived helper after it enters the target PID/mount namespaces. The
+ * caller remains in its original namespaces because the helper exits after the
+ * version command completes.
  *
  * The result has the following meaning:
  * - Process check failure: the target exited, is a zombie, or its PID is unreadable;

--- a/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
+++ b/agent/src/ebpf/user/profile/java/jvm_symbol_collect.h
@@ -59,9 +59,9 @@ typedef struct {
  * The check must finish before creating a socket, copying the Agent SO, or
  * calling jattach, and it cannot use the Attach API. Therefore this function
  * must not call jcmd, jinfo, or jattach, or load code into the target process.
- * When the target JVM runs on the Host or in a POD with a different mount
- * namespace, run the version command in the target PID/mount namespace rather
- * than using the Agent filesystem; in the same namespace, use the target exe.
+ * Run the version command with the target Java executable and environment after
+ * entering the target PID/mount namespaces; restore both namespace selections
+ * before returning so later Agent children keep the original namespaces.
  *
  * The result has the following meaning:
  * - Process check failure: the target exited, is a zombie, or its PID is unreadable;

--- a/agent/src/ebpf/user/utils.c
+++ b/agent/src/ebpf/user/utils.c
@@ -1201,12 +1201,39 @@ int exec_command(const char *cmd, const char *args,
 {
 	FILE *fp;
 	int rc = 0;
-	char cmd_buf[PERF_PATH_SZ * 2];
-	snprintf(cmd_buf, sizeof(cmd_buf), "%s %s", cmd, args);
+	char *cmd_buf;
+	size_t cmd_len;
+	size_t args_len;
+	size_t cmd_buf_size;
+
+	/* 按实际命令和参数长度分配缓冲区，避免固定缓存导致命令被截断。 */
+	if (cmd == NULL)
+		return -1;
+	if (args == NULL)
+		args = "";
+	cmd_len = strlen(cmd);
+	args_len = strlen(args);
+	if (cmd_len > SIZE_MAX - args_len ||
+	    cmd_len + args_len > SIZE_MAX - 2) {
+		ebpf_warning("%s command length overflow\n", __func__);
+		return -1;
+	}
+	cmd_buf_size = cmd_len + args_len + 2;
+	cmd_buf = malloc(cmd_buf_size);
+	if (cmd_buf == NULL) {
+		ebpf_warning("%s command buffer allocation failed, size %zu\n",
+			     __func__, cmd_buf_size);
+		return -1;
+	}
+	if (snprintf(cmd_buf, cmd_buf_size, "%s %s", cmd, args) < 0) {
+		free(cmd_buf);
+		return -1;
+	}
 	fp = popen(cmd_buf, "r");
 	if (NULL == fp) {
 		ebpf_warning("%s '%s' execute error,[%s]\n",
 			     __func__, cmd_buf, strerror(errno));
+		free(cmd_buf);
 		return -1;
 	}
 
@@ -1230,9 +1257,13 @@ int exec_command(const char *cmd, const char *args,
 	if (-1 == rc) {
 		ebpf_warning("pclose error, '%s' error:%s\n",
 			     cmd_buf, strerror(errno));
+		free(cmd_buf);
+		return -1;
 	} else {
 		if (WIFEXITED(rc)) {
-			return WEXITSTATUS(rc);
+			int exit_status = WEXITSTATUS(rc);
+			free(cmd_buf);
+			return exit_status;
 		} else if (WIFSIGNALED(rc)) {
 			ebpf_info
 			    ("'%s' abnormal termination,signal number %d\n",
@@ -1243,6 +1274,7 @@ int exec_command(const char *cmd, const char *args,
 		}
 	}
 
+	free(cmd_buf);
 	return -1;
 }
 

--- a/agent/src/ebpf/user/utils.c
+++ b/agent/src/ebpf/user/utils.c
@@ -1162,6 +1162,7 @@ int df_enter_ns(int pid, const char *type, int *self_fd)
 			if (*self_fd < 0) {
 				ebpf_warning("open() failed with %s(%d)\n",
 					     strerror(errno), errno);
+				close(newns);
 				return -1;
 			}
 			// Some ancient Linux distributions do not have setns() function


### PR DESCRIPTION

Add a shared java_attach_preflight() gate used by both the Java symbol collector and deepflow-jattach before socket creation, Agent SO copying, or injection.

The preflight validates process liveness and zombie state, identifies HotSpot/OpenJ9 from the target maps, executes the target JVM's -version in the correct Host/POD namespace, and rechecks PID start time and executable path to detect reuse.

For HotSpot Java 8, distinguish the 8u0-351 range missing JDK-8173361 from the 8u352-381 range missing the 8u-specific JDK-8305165 follow-up; keep 8u382 as the complete-fix attach baseline and log the two skip reasons separately. Also reject DisableAttachMechanism and unreadable attach options, harden command/output buffers, and add the local release-check script plus investigation and operator documentation.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
### Affected branches
- v6.6

### 5.1 JVM 缺陷复现测试

| 测试项 | 结果 |
|---|---|
| 8u342 无 Agent 基线 | PASS，30 秒正常退出 |
| 8u342 + Honest Profiler，类加载/卸载压力 | **SIGSEGV**，约 26 秒 |
| 8u342 + DeepFlow，类加载/卸载压力 | **SIGSEGV**，约 16–17 秒 |
| 8u342 + DeepFlow，重复 attach 60 次 | PASS，60/60 成功 |
| 8u342 + DeepFlow，socket 背压 | PASS，300 秒正常退出 |
| 8u382 + Honest Profiler，同等压力 300 秒 | PASS，无 SIGSEGV |
| 8u382 + DeepFlow，同等压力 300 秒 | PASS，无 SIGSEGV |

### 5.2 Attach 预检测试

| 测试项 | 结果 |
|---|---|
| C 代码编译 | PASS |
| `git diff --check` | PASS |
| HotSpot 8u342 版本识别 | PASS，跳过 attach |
| HotSpot 8u382 版本识别 | PASS，通过版本门禁 |
| HotSpot 8u412 版本识别 | PASS，允许继续检查 |
| POD 中 HotSpot 8u212 | PASS，正确跳过 attach |
| Host 与目标同 namespace | PASS，不切换 namespace |
| Host 与目标跨 namespace | PASS，正确进入并恢复 namespace |
| 极简容器缺少 shell/env/timeout | PASS，使用宿主机回退路径 |
| `DisableAttachMechanism` 参数 | PASS，正确跳过 |
| PID 被复用或 exe 变化 | PASS，正确跳过 |


<img width="1894" height="234" alt="image" src="https://github.com/user-attachments/assets/f79085b5-5f97-40f8-986d-76369c3c34ed" />

