### PR TITLE
fix(java): bound symbol send retries and bump agent version

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -102,7 +102,7 @@ OBJS := user/elf.o \
 	user/profile/java/collect_symbol_files.o
 
 JAVA_TOOL := deepflow-jattach
-JAVA_AGENT_VERSION := 3.1
+JAVA_AGENT_VERSION := 3.2
 JAVA_NS_TOOL := tools/java_mnt_ns_version
 JAVA_AGENT_GNU_SO := df_java_agent_v$(JAVA_AGENT_VERSION).so
 JAVA_AGENT_MUSL_SO := df_java_agent_musl_v$(JAVA_AGENT_VERSION).so

--- a/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
+++ b/agent/src/ebpf/user/profile/java/symbol_collect_agent.c
@@ -43,6 +43,7 @@
 #include "config.h"
 
 #define LOG_BUF_SZ 512
+#define DF_SYMBOL_SEND_EAGAIN_THRESHOLD 30U
 
 /*
  * HotSpot JVM does not support agent unloading. However, you
@@ -64,6 +65,8 @@ char perf_log_socket_path[128];
 
 int perf_map_socket_fd = -1;
 int perf_map_log_socket_fd = -1;
+static unsigned int perf_map_send_eagain_count;
+static unsigned int perf_log_send_eagain_count;
 
 // Cache symbols for batch sending
 char g_symbol_buffer[STRING_BUFFER_SIZE * 4];
@@ -89,10 +92,16 @@ jint close_files(void);
 	}  \
   } while (0)
 
-inline int send_msg(int sock_fd, const char *buf, size_t len)
+static inline int send_msg(int sock_fd, const char *buf, size_t len)
 {
 	int send_bytes = 0;
 	int n = 0;		// Initialize n
+	unsigned int *eagain_count = NULL;
+
+	if (sock_fd == perf_map_socket_fd)
+		eagain_count = &perf_map_send_eagain_count;
+	else if (sock_fd == perf_map_log_socket_fd)
+		eagain_count = &perf_log_send_eagain_count;
 
 	do {
 		/*
@@ -101,9 +110,17 @@ inline int send_msg(int sock_fd, const char *buf, size_t len)
 		 */
 		n = send(sock_fd, buf + send_bytes, len - send_bytes, MSG_NOSIGNAL);
 		if (n == -1) {
-			if (errno == EINTR || errno == EAGAIN
-			    || errno == EWOULDBLOCK) {
-				// Retry on interrupt or temporary failure
+			if (errno == EINTR) {
+				/* Retry an interrupted send without changing the backpressure count. */
+				continue;
+			}
+			if (errno == EAGAIN || errno == EWOULDBLOCK) {
+				/* Bound non-blocking retries across callbacks to avoid a busy loop. */
+				if (eagain_count == NULL ||
+				    ++(*eagain_count) >= DF_SYMBOL_SEND_EAGAIN_THRESHOLD) {
+					close_files_locked();
+					break;
+				}
 				continue;
 			} else {
 				close_files_locked();	// Example function call, define as needed
@@ -113,6 +130,9 @@ inline int send_msg(int sock_fd, const char *buf, size_t len)
 			// Connection closed by peer
 			close_files_locked();	// Example function call, define as needed
 			break;
+		} else if (eagain_count != NULL) {
+			/* A successful send clears consecutive backpressure. */
+			*eagain_count = 0;
 		}
 
 		send_bytes += n;
@@ -226,6 +246,8 @@ static jint close_files_locked(void)
 
 	perf_map_socket_fd = -1;
 	perf_map_log_socket_fd = -1;
+	perf_map_send_eagain_count = 0;
+	perf_log_send_eagain_count = 0;
 
 	if (perf_fd > 0) {
 		close(perf_fd);


### PR DESCRIPTION
(https://github.com/deepflowio/deepflow/pull/11852/changes/76e2fef51f481c17f569aa2320270c058ba458f1)
Add a consecutive EAGAIN threshold for non-blocking Java Agent sockets and close the communication channels after 30 retries to avoid an endless busy loop in JVM callbacks.

Bump JAVA_AGENT_VERSION from 3.1 to 3.2 for the updated GNU and musl Agent artifacts.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
- [ ] Verified eBPF program runs successfully on linux 4.14.x.
- [ ] Verified eBPF program runs successfully on linux 4.19.x.
- [ ] Verified eBPF program runs successfully on linux 5.2.x.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->

### Affected branches
- v6.6
