### PR TITLE
deps: bump requests to 2.33.0 in automation_test (fix PYSEC-2026-1872, PYSEC-2026-2275)

### DIFF
--- a/automation_test/requirements.txt
+++ b/automation_test/requirements.txt
@@ -1,2 +1,2 @@
 python-socketio==5.8.0
-requests==2.32.3
+requests==2.33.0


### PR DESCRIPTION
Bumps `requests` from 2.32.3 to 2.33.0 in `automation_test/requirements.txt`.

Fixes:
- PYSEC-2026-1872 (.netrc credentials leak via malicious URLs, fixed 2.32.4)
- PYSEC-2026-2275 (fixed 2.33.0)

Local verification:
- pip-audit before: requests 2.32.3 flagged with PYSEC-2026-1872, PYSEC-2026-2275
- pip-audit after with this pin: no findings for requests
- pip install -r automation_test/requirements.txt OK, socketio.Client() instantiates OK with requests 2.33.0

Note: python-socketio 5.8.0 has PYSEC-2026-1854 (fixed 5.14.0), left untouched to keep the diff minimal.