### PR TITLE
fix: auto_service_type omitted from exports for pod_group and pod_cluster endpoints

### DIFF
--- a/server/ingester/exporters/universal_tag/universal_tag.go
+++ b/server/ingester/exporters/universal_tag/universal_tag.go
@@ -149,8 +149,22 @@ const (
 	TYPE_NAT_GATEWAY    DeviceType = 16
 	TYPE_POD_GROUP      DeviceType = 101
 	TYPE_SERVICE        DeviceType = 102
+	TYPE_POD_CLUSTER    DeviceType = 103
+	TYPE_CUSTOM_SERVICE DeviceType = 104
 	TYPE_GPROCESS       DeviceType = 120
-	TYPE_IP             DeviceType = 255
+
+	// common.GetAutoService returns a workload controller's own subtype, not
+	// TYPE_POD_GROUP, whenever auto_service resolves to a pod_group — so these
+	// have to resolve here too. flow_tag.node_type_map maps all six to
+	// "pod_group" (see tagrecorder's RESOURCE_TYPE_TO_NODE_TYPE).
+	TYPE_POD_GROUP_DEPLOYMENT            DeviceType = 130
+	TYPE_POD_GROUP_STATEFULSET           DeviceType = 131
+	TYPE_POD_GROUP_RC                    DeviceType = 132
+	TYPE_POD_GROUP_DAEMON_SET            DeviceType = 133
+	TYPE_POD_GROUP_REPLICASET_CONTROLLER DeviceType = 134
+	TYPE_POD_GROUP_CLONESET              DeviceType = 135
+
+	TYPE_IP DeviceType = 255
 )
 
 // from clickhouse flow_tag.node_type_map
@@ -169,8 +183,22 @@ var deviceTypeStrings = []string{
 	TYPE_NAT_GATEWAY:    "natgw",
 	TYPE_POD_GROUP:      "pod_group",
 	TYPE_SERVICE:        "service",
+	TYPE_POD_CLUSTER:    "pod_cluster",
+	TYPE_CUSTOM_SERVICE: "custom_service",
 	TYPE_GPROCESS:       "gprocess",
-	TYPE_IP:             "ip",
+
+	// Every pod_group subtype resolves to "pod_group", matching the dictionary.
+	// Leaving these unset made auto_service_type serialize empty — and drop out
+	// of the exported JSON entirely — for every pod endpoint without a
+	// pod_service, which is the majority of them.
+	TYPE_POD_GROUP_DEPLOYMENT:            "pod_group",
+	TYPE_POD_GROUP_STATEFULSET:           "pod_group",
+	TYPE_POD_GROUP_RC:                    "pod_group",
+	TYPE_POD_GROUP_DAEMON_SET:            "pod_group",
+	TYPE_POD_GROUP_REPLICASET_CONTROLLER: "pod_group",
+	TYPE_POD_GROUP_CLONESET:              "pod_group",
+
+	TYPE_IP: "ip",
 }
 
 func (t DeviceType) String() string {

--- a/server/ingester/exporters/universal_tag/universal_tag_test.go
+++ b/server/ingester/exporters/universal_tag/universal_tag_test.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package universal_tag
+
+import (
+	"testing"
+)
+
+// Every device type common.GetAutoService can return has to resolve to a
+// non-empty string, because the exporter serializes auto_service_type from this
+// table and an empty value drops the tag out of the exported JSON entirely.
+// The pod_group subtypes and pod_cluster used to be missing, which silently
+// removed auto_service_type from every pod endpoint with no pod_service in
+// front of it and from every pod_node endpoint.
+func TestDeviceTypeStringCoversAutoServiceTypes(t *testing.T) {
+	// Mirrors flow_tag.node_type_map (tagrecorder's RESOURCE_TYPE_TO_NODE_TYPE).
+	for _, tt := range []struct {
+		deviceType DeviceType
+		want       string
+	}{
+		{TYPE_CUSTOM_SERVICE, "custom_service"},
+		{TYPE_POD_SERVICE, "pod_service"},
+		{TYPE_POD_GROUP, "pod_group"},
+		{TYPE_POD_GROUP_DEPLOYMENT, "pod_group"},
+		{TYPE_POD_GROUP_STATEFULSET, "pod_group"},
+		{TYPE_POD_GROUP_RC, "pod_group"},
+		{TYPE_POD_GROUP_DAEMON_SET, "pod_group"},
+		{TYPE_POD_GROUP_REPLICASET_CONTROLLER, "pod_group"},
+		{TYPE_POD_GROUP_CLONESET, "pod_group"},
+		{TYPE_GPROCESS, "gprocess"},
+		{TYPE_POD_CLUSTER, "pod_cluster"},
+		{TYPE_VM, "chost"},
+		{TYPE_POD, "pod"},
+		{TYPE_POD_NODE, "pod_node"},
+		{TYPE_LB, "lb"},
+		{TYPE_NAT_GATEWAY, "natgw"},
+		{TYPE_RDS_INSTANCE, "rds"},
+		{TYPE_REDIS_INSTANCE, "redis"},
+		{TYPE_INTERNET, "internet_ip"},
+		{TYPE_IP, "ip"},
+	} {
+		if got := tt.deviceType.String(); got != tt.want {
+			t.Errorf("DeviceType(%d).String() = %q, want %q", tt.deviceType, got, tt.want)
+		}
+	}
+}
+
+// makeManagerWithPodGroup builds a manager whose org=1 device map holds one
+// pod_group, keyed by the controller subtype the platform data uses. Built
+// in-package so the test does not go through the production constructor, which
+// starts a gRPC session and registers debug handlers.
+func makeManagerWithPodGroup(deviceType DeviceType, deviceID uint32, name string) *UniversalTagsManager {
+	u := &UniversalTagsManager{}
+	u.universalTagMaps[1] = &UniversalTagMaps{
+		deviceMap: map[uint64]string{
+			uint64(deviceType)<<32 | uint64(deviceID): name,
+		},
+		regionMap:     map[uint16]string{},
+		azMap:         map[uint16]string{},
+		podNodeMap:    map[uint32]string{},
+		podNsMap:      map[uint16]string{},
+		podGroupMap:   map[uint32]string{},
+		podMap:        map[uint32]string{},
+		podClusterMap: map[uint16]string{},
+		l3EpcMap:      map[uint32]string{},
+		subnetMap:     map[uint16]string{},
+		gprocessMap:   map[uint32]string{},
+		vtapMap:       map[uint16]string{},
+	}
+	return u
+}
+
+// A pod with no pod_service in front of it: GetAutoService returns the workload
+// controller's own subtype (134, a ReplicaSet controller), so auto_service_type
+// has to come out as "pod_group" while the name still resolves from the device
+// map keyed by that same subtype. Before the table was completed, the name
+// resolved and the type came out empty.
+func TestQueryUniversalTagsPodGroupAutoServiceType(t *testing.T) {
+	u := makeManagerWithPodGroup(TYPE_POD_GROUP_REPLICASET_CONTROLLER, 777, "some-workload")
+	tags := u.QueryUniversalTags(
+		1,                   // orgId
+		0, 0, 0, 0, 0, 0, 0, // regionID, azID, hostID, podNsID, podClusterID, subnetID, agentID
+		uint8(TYPE_VM), // l3DeviceType (the chost the pod sits on)
+		uint8(TYPE_POD_GROUP_REPLICASET_CONTROLLER), // autoServiceType
+		uint8(TYPE_POD),  // autoInstanceType
+		0,                // l3DeviceID
+		777,              // autoServiceID
+		0,                // autoInstanceID
+		0, 0, 0, 0, 0, 0, // podNodeID, podGroupID, podID, l3EpcID, gprocessID, serviceID
+		true, 0, nil,
+	)
+	if tags[AutoServiceType] != "pod_group" {
+		t.Errorf("pod_group auto_service_type = %q, want \"pod_group\"", tags[AutoServiceType])
+	}
+	if tags[AutoService] != "some-workload" {
+		t.Errorf("pod_group auto_service = %q, want \"some-workload\"", tags[AutoService])
+	}
+}
+
+// pod_node endpoints land on PodClusterType (103) via GetAutoService's
+// podClusterID branch, which was the other hole in the table.
+func TestQueryUniversalTagsPodClusterAutoServiceType(t *testing.T) {
+	u := makeManagerWithPodGroup(TYPE_POD_CLUSTER, 42, "some-cluster")
+	tags := u.QueryUniversalTags(
+		1,
+		0, 0, 0, 0, 0, 0, 0,
+		uint8(TYPE_VM),
+		uint8(TYPE_POD_CLUSTER), // autoServiceType
+		uint8(TYPE_POD_NODE),    // autoInstanceType
+		0,
+		42, // autoServiceID
+		0,
+		0, 0, 0, 0, 0, 0,
+		true, 0, nil,
+	)
+	if tags[AutoServiceType] != "pod_cluster" {
+		t.Errorf("pod_node auto_service_type = %q, want \"pod_cluster\"", tags[AutoServiceType])
+	}
+}

--- a/server/ingester/exporters/universal_tag/universal_tag_test.go
+++ b/server/ingester/exporters/universal_tag/universal_tag_test.go
@@ -111,6 +111,30 @@ func TestQueryUniversalTagsPodGroupAutoServiceType(t *testing.T) {
 	}
 }
 
+// The third branch this fix covers: a custom service (104), from
+// GetAutoService's customServiceID branch.
+func TestQueryUniversalTagsCustomServiceAutoServiceType(t *testing.T) {
+	u := makeManagerWithPodGroup(TYPE_CUSTOM_SERVICE, 555, "some-custom-service")
+	tags := u.QueryUniversalTags(
+		1,
+		0, 0, 0, 0, 0, 0, 0,
+		uint8(TYPE_VM),
+		uint8(TYPE_CUSTOM_SERVICE), // autoServiceType
+		uint8(TYPE_POD),            // autoInstanceType
+		0,
+		555, // autoServiceID
+		0,
+		0, 0, 0, 0, 0, 0,
+		true, 0, nil,
+	)
+	if tags[AutoServiceType] != "custom_service" {
+		t.Errorf("custom_service auto_service_type = %q, want \"custom_service\"", tags[AutoServiceType])
+	}
+	if tags[AutoService] != "some-custom-service" {
+		t.Errorf("custom_service auto_service = %q, want \"some-custom-service\"", tags[AutoService])
+	}
+}
+
 // pod_node endpoints land on PodClusterType (103) via GetAutoService's
 // podClusterID branch, which was the other hole in the table.
 func TestQueryUniversalTagsPodClusterAutoServiceType(t *testing.T) {


### PR DESCRIPTION
### This PR is for:

Server

### Fixes #11874 — `auto_service_type_{0,1}` is omitted from exported flow logs for pod_group and pod_cluster endpoints

#### Steps to reproduce the bug

- Enable a flow-log exporter (Kafka or OTLP) with `auto_service_type` among the
  exported tags.
- Send L7 traffic to a pod that is **not** fronted by a Kubernetes Service, so
  `common.GetAutoService` takes the `podGroupID > 0` branch.
- Inspect an exported document: `auto_service_1` carries the workload name,
  `auto_service_type_1` is absent. A pod_node destination reproduces it the same
  way through the `podClusterID > 0` branch.
- On our export, the tag was missing from 8,049 of 14,911 sampled L7 documents
  (54%), and the absences fell exactly on `pod` and `pod_node` endpoints.

#### Changes to fix the bug

- `common.GetAutoService` returns a workload controller's own subtype for a
  pod_group (`VIF_DEVICE_TYPE_POD_GROUP_*`, 130-135) and `PodClusterType` (103)
  for a pod_node, but `deviceTypeStrings` only defined
  `0, 1, 5, 6, 9-16, 101, 102, 120, 255`. `DeviceType.String()` indexes that
  slice directly, so those types resolved to `""` and the tag was omitted from
  the serialized output. The name survived because it comes from
  `deviceMap[type<<32|id]`, whose keys do include 130-135 — hence name present,
  type absent.
- Complete the table from the dictionary the comment above it already points at,
  `flow_tag.node_type_map` (generated from tagrecorder's
  `RESOURCE_TYPE_TO_NODE_TYPE`): all six pod_group subtypes → `"pod_group"`,
  103 → `"pod_cluster"`, 104 → `"custom_service"`. Values match the querier
  side of the same data, so exported tags and ClickHouse tags now agree.
- Add `TestDeviceTypeStringCoversAutoServiceTypes`, which pins every type
  `GetAutoService` can return to a non-empty string. A future enum addition on
  one side now fails loudly instead of silently emptying a tag — that is the
  test that would have caught this.
- Two `QueryUniversalTags` tests cover the pod_group and pod_cluster paths
  end to end, asserting the type resolves while the name still comes from the
  device map keyed by the subtype.

No behaviour change for any type that already resolved; this only fills holes
that previously produced an empty string.

#### Affected branches

- main

#### Checklist

- [x] Added unit test to verify the fix.
- [ ] ~Verified eBPF program runs successfully on linux 4.14.x.~ — n/a, server-side exporter change only, no agent or eBPF code touched.
- [ ] ~Verified eBPF program runs successfully on linux 4.19.x.~ — n/a
- [ ] ~Verified eBPF program runs successfully on linux 5.2.x.~ — n/a

Fixes #11874
