### PR TITLE
fix(ebpf): support TCP option process tracking

### DIFF
--- a/agent/src/ebpf/kernel/include/bpf_base.h
+++ b/agent/src/ebpf/kernel/include/bpf_base.h
@@ -77,6 +77,9 @@ static long
     (void *)16;
 static __u64 __attribute__ ((__unused__)) (*bpf_get_current_task) (void) =
     (void *)35;
+static __u64
+    __attribute__ ((__unused__)) (*bpf_get_socket_cookie) (void *ctx) =
+    (void *)46;
 static long
     __attribute__ ((__unused__)) (*bpf_perf_event_output) (void *ctx, void *map,
 							   __u64 flags,

--- a/agent/src/ebpf/kernel/include/kernel.h
+++ b/agent/src/ebpf/kernel/include/kernel.h
@@ -54,6 +54,10 @@ typedef struct {
 	void *net;
 } possible_net_t;
 
+typedef struct {
+	long long counter;
+} atomic64_t;
+
 struct sock_common {
 	union {
 		__addrpair skc_addrpair;
@@ -90,6 +94,7 @@ struct sock_common {
 	possible_net_t skc_net;
 	struct in6_addr skc_v6_daddr;
 	struct in6_addr skc_v6_rcv_saddr;
+	atomic64_t skc_cookie;
 };
 
 struct socket;
@@ -190,6 +195,7 @@ struct files_struct {
 
 struct task_struct {
 	struct files_struct *files;
+	__u32 tgid;
 };
 
 struct tcp_sock {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes missing kernel declarations required by TCP option process attribution

#### Steps to reproduce the bug

- TCP option write callbacks can execute in softirq context, where the current task does not reliably identify the process that owns the transmission.
- Associating a socket cookie with the sender TGID requires access to `sock_common.skc_cookie`, `task_struct.tgid`, and the `bpf_get_socket_cookie` helper.
- The minimal v6.6 eBPF kernel definitions do not currently expose them.

#### Changes to fix the bug

- Declare the `bpf_get_socket_cookie` BPF helper.
- Add the minimal `atomic64_t` and `sock_common.skc_cookie` definitions used by BTF CO-RE relocation.
- Add `task_struct.tgid` for BTF CO-RE TGID lookup.

#### Affected branches

- v6.6

#### Checklist

- [ ] Added unit test to verify the fix. (The change only extends minimal kernel definitions.)
- [ ] Verified eBPF program runs successfully on linux 4.14.x. (TCP option tracing requires Linux 5.10+.)
- [ ] Verified eBPF program runs successfully on linux 4.19.x. (TCP option tracing requires Linux 5.10+.)
- [ ] Verified eBPF program runs successfully on linux 5.2.x. (TCP option tracing requires Linux 5.10+.)

#### Verification

- `cargo build --release`
- Loaded and attached the TCP option tracing programs on Linux `6.6.0-119.0.0.122.x86_64`.
- Stable reproduction: `total=20 correct=20 noise=0 zero=0 other=0`.
