### PR TITLE
fix(agent): preserve GPID during L7 session merge

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -3096,16 +3096,30 @@ mod tests {
         }
         flow_map.flush_queue(&module_config.flow, timestamp.add(Duration::from_secs(120)));
 
-        let response = (0..4).find_map(|_| {
+        let mut request = None;
+        let mut response = None;
+        for _ in 0..4 {
             let AppProto::MetaAppProto(log) =
-                app_proto_log_receiver.recv(Some(DEFAULT_DURATION)).ok()?
+                app_proto_log_receiver.recv(Some(DEFAULT_DURATION)).unwrap()
             else {
-                return None;
+                continue;
             };
-            log.is_response().then_some(log)
-        });
-        let response = response.expect("expected HTTP response log");
+            if log.is_request() {
+                request = Some(log);
+            } else if log.is_response() {
+                response = Some(log);
+            }
+            if request.is_some() && response.is_some() {
+                break;
+            }
+        }
+        let mut request = request.expect("expected HTTP request log");
+        let mut response = response.expect("expected HTTP response log");
+        assert_eq!(request.base_info.gpid_1, 0);
         assert_eq!(response.base_info.gpid_1, SERVER_GPID);
+
+        request.session_merge(&mut response).unwrap();
+        assert_eq!(request.base_info.gpid_1, SERVER_GPID);
     }
 
     #[test]

--- a/agent/src/flow_generator/protocol_logs.rs
+++ b/agent/src/flow_generator/protocol_logs.rs
@@ -312,6 +312,15 @@ impl AppProtoLogsBaseInfo {
         if self.head.proto != log.head.proto {
             self.head.proto = log.head.proto;
         }
+        // TCP Option 中的进程信息可能直到首个响应包才出现。请求日志先进入
+        // session 聚合时 GPID 仍为 0，需要用响应日志中已经解析出的值补齐。
+        // 已存在的非零值保持不变，避免后续报文覆盖已确定的进程归属。
+        if self.gpid_0 == 0 {
+            self.gpid_0 = log.gpid_0;
+        }
+        if self.gpid_1 == 0 {
+            self.gpid_1 = log.gpid_1;
+        }
         if log.process_id_0 > 0 {
             self.process_id_0 = log.process_id_0;
             std::mem::swap(&mut self.process_kname_0, &mut log.process_kname_0);


### PR DESCRIPTION
**复现步骤**

1. 使用 #11883 的首包 GPID 修复。
2. 建立一次请求、一次响应后立即关闭的 HTTP 短连接。
3. 服务端 PID 首次出现在响应数据包 TCP Option 中；响应 AppProto 已有服务端 GPID，但最终合并调用日志的 `gprocess_id_1` 仍为 0。

**原因和解决方案**

`AppProtoLogsBaseInfo::merge()` 没有合并 `gpid_0/gpid_1`。请求日志先以 GPID 0 缓存，响应日志中新解析的服务端 GPID 在 session 聚合时被丢弃。

合并时仅在当前 GPID 为 0 时使用后续日志中的值补齐，已有非零值保持不变。扩展 #11883 的回归测试，覆盖从请求、响应到 `session_merge()` 后最终日志的完整链路。

**影响范围**

- 影响需要请求/响应 session 聚合的 L7 日志；
- 补齐后续报文获得的客户端或服务端 GPID；
- 不覆盖已有非零 GPID。

**验证方案**

- `rustfmt --edition 2021 --check agent/src/flow_generator/flow_map.rs agent/src/flow_generator/protocol_logs.rs`
- `cargo test --lib flow_generator::flow_map::tests::process_gpid_`
  - `process_gpid_updates_packet_source_peer`：通过
  - `process_gpid_is_available_to_first_l7_response_log`：通过，包含 session merge 断言

**涉及分支**

* v6.6

**检查项**

- [ ] 需要更新依赖
- [x] 是共性问题(代码中存在类似问题)
- [x] 编译通过
- [x] 单元测试通过
